### PR TITLE
fix(cds-hooks): wire patient context through feedback so Accept actually creates resources

### DIFF
--- a/backend/api/cds_hooks/models.py
+++ b/backend/api/cds_hooks/models.py
@@ -361,8 +361,33 @@ class FeedbackItem(BaseModel):
 
 
 class FeedbackRequest(BaseModel):
-    """Feedback request - CDS Hooks 2.0"""
+    """Feedback request - CDS Hooks 2.0.
+
+    The CDS Hooks 2.0 spec defines only ``feedback: FeedbackItem[]``. We
+    extend the request with optional ``patientId`` / ``userId`` /
+    ``encounterId`` fields because the WintEHR-extension feedback path
+    can execute the suggestion's ``actions[].resource`` server-side
+    (creating MedicationRequest/ServiceRequest/Condition on the patient).
+    Without these fields the executor has no patient context, the auto-
+    injected ``subject`` reference becomes ``Patient/`` (empty), and HAPI
+    rejects the create with HAPI-0508.
+
+    The router already reads these via ``getattr(feedback, ..., None)``;
+    declaring them here just stops Pydantic from stripping them.
+    """
     feedback: List[FeedbackItem] = Field(..., description="Feedback items")
+    patientId: Optional[str] = Field(
+        None,
+        description="FHIR Patient ID for action execution (WintEHR extension).",
+    )
+    userId: Optional[str] = Field(
+        None,
+        description="FHIR Practitioner ID for action requester (WintEHR extension).",
+    )
+    encounterId: Optional[str] = Field(
+        None,
+        description="FHIR Encounter ID for action context (WintEHR extension).",
+    )
 
 
 # Hook Configuration Models (for internal use)

--- a/frontend/src/components/clinical/cds/CDSCard.js
+++ b/frontend/src/components/clinical/cds/CDSCard.js
@@ -64,6 +64,15 @@ const CDSCard = ({
   card,
   serviceId,
   hookInstance,
+  // Patient context for the feedback POST. Required to execute a
+  // suggestion's actions[].resource server-side — without it the runtime
+  // executor has no patient and HAPI rejects the create. Previews
+  // (CardPreviewPanel, CardDesigner preview, ServiceTester) pass nothing,
+  // and this component skips the feedback round-trip when patientId is
+  // absent rather than firing a doomed call.
+  patientId = null,
+  userId = null,
+  encounterId = null,
   onAcceptSuggestion,
   onDismiss,
   compact = false
@@ -91,6 +100,22 @@ const CDSCard = ({
       setSubmittingFeedback(true);
       setAcceptedSuggestionId(suggestion.uuid || suggestion.label);
 
+      // Preview short-circuit: previews (in the studio) render this
+      // component to demo card UX and don't pass patientId. Without a
+      // patient the executor would try to create on `Patient/` (empty)
+      // and fail noisily. Acknowledge in the UI and bail out.
+      if (!patientId) {
+        setFeedbackSubmitted(true);
+        if (onAcceptSuggestion) {
+          try {
+            await onAcceptSuggestion(suggestion, { executed: [] });
+          } catch (cbErr) {
+            console.error('onAcceptSuggestion callback failed:', cbErr);
+          }
+        }
+        return;
+      }
+
       // Send feedback to CDS service. We include the suggestion's full
       // actions[] alongside its uuid (a backwards-compatible extension
       // beyond the spec's `{id}`-only shape). The backend's feedback
@@ -98,16 +123,25 @@ const CDSCard = ({
       // the FHIR resources the suggestion proposed — keyed for idempotency
       // by (hookInstance, suggestion.uuid). Without this, an Accept click
       // only records analytics; the proposed resource never lands.
+      //
+      // patientId/userId/encounterId/hookInstance carry the context the
+      // executor needs to fill in subject/requester/encounter and to
+      // dedupe by (hookInstance, suggestion.uuid). The backend
+      // FeedbackRequest model accepts these as a WintEHR extension.
       const feedbackResponse = await cdsHooksClient.sendFeedback(serviceId, {
         feedback: [{
           card: card.uuid,
+          hookInstance: hookInstance || undefined,
           outcome: 'accepted',
           outcomeTimestamp: new Date().toISOString(),
           acceptedSuggestions: [{
             id: suggestion.uuid,
             actions: suggestion.actions || []
           }]
-        }]
+        }],
+        patientId,
+        userId: userId || undefined,
+        encounterId: encounterId || undefined
       });
 
       // Notify the parent AFTER the FHIR write succeeded, passing any
@@ -132,7 +166,7 @@ const CDSCard = ({
     } finally {
       setSubmittingFeedback(false);
     }
-  }, [card.uuid, card.selectionBehavior, serviceId, onAcceptSuggestion, acceptedSuggestionId]);
+  }, [card.uuid, card.selectionBehavior, serviceId, hookInstance, patientId, userId, encounterId, onAcceptSuggestion, acceptedSuggestionId]);
 
   // Handle dismissing the card
   const handleDismiss = useCallback(async () => {
@@ -154,9 +188,13 @@ const CDSCard = ({
     try {
       setSubmittingFeedback(true);
 
-      // Send feedback to CDS service
+      // Send feedback to CDS service. Include hookInstance + patient
+      // context so the backend can correlate the override with the
+      // original hook fire (used for analytics; no resource is created
+      // on overridden outcomes).
       const feedbackItem = {
         card: card.uuid,
+        hookInstance: hookInstance || undefined,
         outcome: 'overridden',
         outcomeTimestamp: new Date().toISOString()
       };
@@ -168,9 +206,15 @@ const CDSCard = ({
         };
       }
 
-      await cdsHooksClient.sendFeedback(serviceId, {
-        feedback: [feedbackItem]
-      });
+      // Skip the network round-trip in previews (no patient context).
+      if (patientId) {
+        await cdsHooksClient.sendFeedback(serviceId, {
+          feedback: [feedbackItem],
+          patientId,
+          userId: userId || undefined,
+          encounterId: encounterId || undefined
+        });
+      }
 
       // Call parent handler
       if (onDismiss) {
@@ -184,7 +228,7 @@ const CDSCard = ({
     } finally {
       setSubmittingFeedback(false);
     }
-  }, [card, serviceId, onDismiss]);
+  }, [card, serviceId, hookInstance, patientId, userId, encounterId, onDismiss]);
 
   // Handle override dialog submission
   const handleOverrideSubmit = () => {

--- a/frontend/src/components/clinical/workspace/dialogs/OrderSigningDialog.js
+++ b/frontend/src/components/clinical/workspace/dialogs/OrderSigningDialog.js
@@ -187,6 +187,7 @@ const OrderSigningDialog = ({
                       card={card}
                       serviceId={card.serviceId}
                       hookInstance={card.hookInstance}
+                      patientId={effectivePatientId}
                       onAcceptSuggestion={(suggestion) => {
                         // Handle accepting suggestion (e.g., modify order)
                       }}


### PR DESCRIPTION
## Summary

The CDS Hooks Accept-creates-FHIR-resource flow was end-to-end broken on master. This PR completes the wiring so clicking Accept on a suggestion that has \`actions[].resource\` actually creates the resource on the patient. Three small changes:

1. **`backend/api/cds_hooks/models.py`** — Declare `patientId` / `userId` / `encounterId` as `Optional[str]` on `FeedbackRequest`. The router was already reading these via `getattr`; declaring them just stops Pydantic from stripping them.
2. **`frontend/src/components/clinical/cds/CDSCard.js`** — Accept `patientId` / `userId` / `encounterId` as props and include them (plus the existing `hookInstance` prop) on both the accept and override feedback POSTs. Added a preview short-circuit: when `patientId` is missing (studio previews pass nothing), skip the network round-trip — UI still updates and the parent callback fires.
3. **`frontend/src/components/clinical/workspace/dialogs/OrderSigningDialog.js`** — Pass `effectivePatientId` to `<CDSCard>`.

## Why it was broken

- Frontend never sent `patientId` or `hookInstance` in the feedback POST.
- `FeedbackRequest` didn't declare those fields, so a client that *did* send them would have them stripped on validation.
- `_execute_accepted_suggestion_actions` reads `feedback_item_data.get("patientId") or ""`, builds `Condition.subject = { reference: "Patient/" }`, and HAPI rejects with HAPI-0508.

## Verification on prod

```
PATIENT_ID=fa009f18-7c8f-27e3-8a1d-88c4ef376759
# before
GET /fhir/Condition?patient=Patient/$PATIENT_ID&_summary=count → total: 34
# POST /api/cds-services/.../feedback with patientId at FeedbackRequest level
→ {"executedActions":[{"success":true,"resourcesCreated":[{"id":"258405","resourceType":"Condition"}]}]}
# verify
GET /fhir/Condition/258405 → subject: { reference: "Patient/fa009f18-..." }, code: E11.9 ICD-10
GET /fhir/Condition?patient=Patient/$PATIENT_ID&_summary=count → total: 35
# cleanup
DELETE /fhir/Condition/258405 → OK; count back to 34
```

## Backwards compatibility

- Spec-only feedback POSTs (without patientId) still validate. The executor reads `""` and the action fails as before — no regression.
- CDSCard previews (studio) skip the feedback POST entirely now, instead of POSTing with no patient context. Previously they would POST with bad context; now they don't fire any network call. Behavior change is a no-op visible to users.

## Out of scope

The patient-view alert path through `CDSPresentation` + `cdsActionExecutor` uses a separate **client-side** executor that bypasses the backend entirely. It has its own `validateResource` that requires `subject` already set on the resource, which the wizard doesn't generate. That fix is independent and lives in `cdsActionExecutor.js` — separate PR.

## Pairs with #71

This pairs naturally with #71 (visual builder simplification, which fixed the wizard to *generate* the correct action shape). Together: the wizard generates real actions, and the runtime executes them. Either order of merging is fine.

## Test plan
- [x] Backend Pydantic round-trip (with + without patient context) — both validate.
- [x] ESLint clean on changed files (3 pre-existing warnings unrelated to this PR).
- [x] Deployed to https://wintehr.eastus2.cloudapp.azure.com/ on the fix branch.
- [x] End-to-end synthetic feedback POST creates a Condition on the right patient with the right ICD-10 code.
- [ ] Manual click-through Accept in the EMR (OrderSigningDialog) — not exercised; the path traces through the same code as the synthetic test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)