### PR TITLE
fix(cds): patient-view alerts now actually create FHIR resources on Accept

### DIFF
--- a/frontend/src/components/clinical/cds/CDSHookManager.js
+++ b/frontend/src/components/clinical/cds/CDSHookManager.js
@@ -391,6 +391,8 @@ const CDSHookManager = forwardRef(({
         onAlertAction={handleAlertAction}
         allowInteraction={true}
         patientId={patientId}
+        userId={userId}
+        encounterId={encounterId}
       />
     ));
   };

--- a/frontend/src/components/clinical/cds/CDSPresentation.js
+++ b/frontend/src/components/clinical/cds/CDSPresentation.js
@@ -116,7 +116,12 @@ const CDSPresentation = ({
   hideDelay = 5000,
   maxAlerts = 5,
   allowInteraction = true,
-  patientId = null
+  patientId = null,
+  // userId / encounterId are forwarded to cdsActionExecutor so it can
+  // auto-fill MedicationRequest.requester / *.encounter on accepted
+  // suggestions. Optional — patientId alone is enough for `subject`.
+  userId = null,
+  encounterId = null
 }) => {
   const [open, setOpen] = useState(true);
 
@@ -390,8 +395,18 @@ const CDSPresentation = ({
       }
     } else if (action === 'accept' && suggestion) {
       try {
-        // Execute the suggestion actions
-        const executionResult = await cdsActionExecutor.executeSuggestion(alert, suggestion);
+        // Execute the suggestion actions. Pass the hook context so the
+        // executor can auto-inject subject/requester/encounter on
+        // resources that need them — the wizard generates partial
+        // resources without a subject by design (mirroring how the
+        // backend executor would fill it in for the OrderSigningDialog
+        // path). Without this context, ServiceRequest/Condition/etc.
+        // would fail validation here for missing subject.
+        const executionResult = await cdsActionExecutor.executeSuggestion(
+          alert,
+          suggestion,
+          { patientId, userId, encounterId }
+        );
         
         if (executionResult.success) {
           // Show success notification if available

--- a/frontend/src/components/clinical/cds/CDSPresentation.js
+++ b/frontend/src/components/clinical/cds/CDSPresentation.js
@@ -383,7 +383,15 @@ const CDSPresentation = ({
         }
         return newSet;
       });
-      
+
+      // Persist via cdsAlertPersistence so the dismissal survives
+      // navigation. The component's initial state hydrates from this
+      // store (line 130-133), so without this call the alert would
+      // re-fire on every patient view despite being dismissed.
+      if (patientId) {
+        cdsAlertPersistence.dismissAlert(patientId, alertKey, 'clinical-judgment', false);
+      }
+
       // Send override feedback for dismissals
       if (alert.serviceId && alert.uuid) {
         await cdsFeedbackService.sendOverrideFeedback(
@@ -427,6 +435,12 @@ const CDSPresentation = ({
             }
             return newSet;
           });
+          // Persist via cdsAlertPersistence so the dismissal survives
+          // navigation. Otherwise the same alert re-fires on every
+          // patient view despite the user having accepted the suggestion.
+          if (patientId) {
+            cdsAlertPersistence.dismissAlert(patientId, alertKey, 'accepted', false);
+          }
         } else {
           // Show error notification if available
           if (window.showNotification) {
@@ -713,6 +727,174 @@ const CDSPresentation = ({
         <MenuItem onClick={() => snoozeMenuAlert && handleQuickSnooze(snoozeMenuAlert, 240)}>4 hours</MenuItem>
         <MenuItem onClick={() => snoozeMenuAlert && handleQuickSnooze(snoozeMenuAlert, 1440)}>24 hours</MenuItem>
       </Menu>
+      {/* Suggestion Detail Dialog — confirms a suggestion before executing
+          its actions[]. Must render here for POPUP mode; previously it was
+          only declared in the inline-mode return so clicking a suggestion
+          button in the popup did nothing. */}
+      {selectedAlert && (
+        <Dialog
+          open={!!selectedAlert}
+          onClose={() => setSelectedAlert(null)}
+          maxWidth="sm"
+          fullWidth
+          sx={{ zIndex: 1500 }}
+        >
+          <DialogTitle>{selectedAlert.suggestion.label}</DialogTitle>
+          <DialogContent>
+            <Typography variant="body1">
+              {selectedAlert.suggestion.description || 'No description available'}
+            </Typography>
+            {selectedAlert.suggestion.actions?.map((action, index) => (
+              <Typography
+                key={`action-${action.description?.substring(0, 20) || ''}-${index}`}
+                variant="body2"
+                color="text.secondary"
+                sx={{ mt: 1 }}
+              >
+                {action.description}
+              </Typography>
+            ))}
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => handleAlertAction(selectedAlert.alert, 'reject', selectedAlert.suggestion)}>
+              Reject
+            </Button>
+            <Button
+              variant="contained"
+              onClick={() => handleAlertAction(selectedAlert.alert, 'accept', selectedAlert.suggestion)}
+            >
+              Accept
+            </Button>
+          </DialogActions>
+        </Dialog>
+      )}
+      {/* Override Reason Dialog — same story; required when the alert
+          declares acknowledgmentRequired or reasonRequired so the user
+          can supply a reason without losing the rest of the popup. */}
+      {showOverrideDialog && currentOverride && (
+        <Dialog
+          open={showOverrideDialog}
+          onClose={() => setShowOverrideDialog(false)}
+          maxWidth="sm"
+          fullWidth
+          sx={{ zIndex: 1500 }}
+        >
+          <DialogTitle>
+            {currentOverride.requiresReason ? 'Override Clinical Alert' : 'Acknowledge Alert'}
+          </DialogTitle>
+          <DialogContent>
+            <Typography variant="body1" gutterBottom>
+              {currentOverride.requiresReason
+                ? `You are overriding a ${currentOverride.alert.indicator} alert. Please provide a reason:`
+                : `Please acknowledge this ${currentOverride.alert.indicator} alert before continuing.`}
+            </Typography>
+            <Alert severity={getSeverityColor(currentOverride.alert.indicator)} sx={{ my: 2 }}>
+              <Typography variant="subtitle2">{currentOverride.alert.summary}</Typography>
+              {currentOverride.alert.detail && (
+                <Typography variant="body2">{currentOverride.alert.detail}</Typography>
+              )}
+            </Alert>
+            {currentOverride.requiresReason && (
+              <>
+                <FormControl fullWidth sx={{ mt: 2 }}>
+                  <InputLabel>Override Reason</InputLabel>
+                  <Select
+                    value={overrideReasonCode}
+                    onChange={(e) => setOverrideReasonCode(e.target.value)}
+                    label="Override Reason"
+                  >
+                    {Object.entries(OVERRIDE_REASONS).map(([key, reason]) => (
+                      <MenuItem key={key} value={reason.code}>
+                        {reason.display}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+                <TextField
+                  fullWidth
+                  multiline
+                  rows={3}
+                  value={overrideUserComment}
+                  onChange={(e) => setOverrideUserComment(e.target.value)}
+                  placeholder="Additional comments (optional, required for 'Other' reason)..."
+                  label="Comments"
+                  variant="outlined"
+                  sx={{ mt: 2 }}
+                />
+              </>
+            )}
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => {
+              setShowOverrideDialog(false);
+              setCurrentOverride(null);
+              setOverrideReasonCode('');
+              setOverrideUserComment('');
+            }}>
+              Cancel
+            </Button>
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={async () => {
+                const alert = currentOverride.alert;
+                if (currentOverride.requiresReason) {
+                  if (!overrideReasonCode || (overrideReasonCode === 'other' && !overrideUserComment.trim())) {
+                    return;
+                  }
+                  if (alert.serviceId && alert.uuid) {
+                    await cdsFeedbackService.sendFeedback({
+                      serviceId: alert.serviceId,
+                      cardUuid: alert.uuid,
+                      outcome: 'overridden',
+                      overrideReason: OVERRIDE_REASONS[Object.keys(OVERRIDE_REASONS).find(key =>
+                        OVERRIDE_REASONS[key].code === overrideReasonCode
+                      )],
+                      userComment: overrideUserComment || undefined
+                    });
+                  }
+                } else if (alert.serviceId && alert.uuid) {
+                  await cdsFeedbackService.sendFeedback({
+                    serviceId: alert.serviceId,
+                    cardUuid: alert.uuid,
+                    outcome: 'acknowledged'
+                  });
+                }
+                // Mark as dismissed so the popup re-renders with the
+                // remaining cards. Persist via cdsAlertPersistence so the
+                // dismissal survives navigation.
+                const alertKey = `${alert.serviceId}-${alert.summary}`;
+                setDismissedAlerts(prev => {
+                  const newSet = new Set([...prev, alertKey]);
+                  if (patientId) {
+                    try {
+                      sessionStorage.setItem(
+                        `cds-dismissed-alerts-${patientId}`,
+                        JSON.stringify([...newSet])
+                      );
+                    } catch (e) { /* ignore storage errors */ }
+                  }
+                  return newSet;
+                });
+                if (patientId) {
+                  cdsAlertPersistence.dismissAlert(
+                    patientId,
+                    alertKey,
+                    currentOverride.requiresReason ? 'override' : 'acknowledged',
+                    false
+                  );
+                }
+                setShowOverrideDialog(false);
+                setCurrentOverride(null);
+                setOverrideReasonCode('');
+                setOverrideUserComment('');
+              }}
+            >
+              {currentOverride.requiresReason ? 'Override Alert' : 'Acknowledge'}
+            </Button>
+          </DialogActions>
+        </Dialog>
+      )}
       {/* Snooze dialog for POPUP mode — must be outside the main Dialog */}
       {showSnoozeDialog && alertToSnooze && (
         <Dialog open={showSnoozeDialog} onClose={() => setShowSnoozeDialog(false)} maxWidth="xs" fullWidth sx={{ zIndex: 1400 }}>

--- a/frontend/src/services/__tests__/cdsActionExecutor.test.js
+++ b/frontend/src/services/__tests__/cdsActionExecutor.test.js
@@ -1,0 +1,130 @@
+/**
+ * Tests for cdsActionExecutor's context-injection behavior. The
+ * end-to-end create/update path is exercised manually against HAPI; here
+ * we pin the shape the wizard produces (resource without subject) ↔ what
+ * the validator sees after _injectContext runs.
+ */
+
+import CDSActionExecutor from '../cdsActionExecutor';
+
+// fhirClient and cdsFeedbackService are imported as side effects of the
+// module under test — mock them so import doesn't try to read window.
+jest.mock('../../core/fhir/services/fhirClient', () => ({
+  fhirClient: { create: jest.fn(), update: jest.fn(), delete: jest.fn() }
+}));
+jest.mock('../cdsFeedbackService', () => ({
+  cdsFeedbackService: { sendAcceptanceFeedback: jest.fn() }
+}));
+jest.mock('../../config/logging', () => ({
+  cdsLogger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+}));
+
+describe('cdsActionExecutor._injectContext', () => {
+  let executor;
+
+  beforeEach(() => {
+    executor = new CDSActionExecutor();
+  });
+
+  it('returns the resource unchanged when no context is provided', () => {
+    const resource = {
+      resourceType: 'Condition',
+      code: { text: 'T2DM' }
+    };
+    const result = executor._injectContext(resource, {});
+    expect(result.subject).toBeUndefined();
+    expect(result).toEqual(resource);
+  });
+
+  it('injects subject for subject-required types when patientId is given', () => {
+    const cases = [
+      'MedicationRequest', 'ServiceRequest', 'Observation',
+      'Condition', 'AllergyIntolerance', 'CarePlan', 'Goal', 'Task'
+    ];
+    cases.forEach((resourceType) => {
+      const result = executor._injectContext(
+        { resourceType, status: 'draft' },
+        { patientId: 'p-1' }
+      );
+      expect(result.subject).toEqual({ reference: 'Patient/p-1' });
+    });
+  });
+
+  it('does not overwrite an existing subject', () => {
+    const result = executor._injectContext(
+      { resourceType: 'Condition', subject: { reference: 'Patient/preset' } },
+      { patientId: 'p-1' }
+    );
+    expect(result.subject).toEqual({ reference: 'Patient/preset' });
+  });
+
+  it('does not inject subject for types that do not require one', () => {
+    // Appointment uses `participant` instead of subject — should be left alone.
+    const result = executor._injectContext(
+      { resourceType: 'Appointment', status: 'proposed' },
+      { patientId: 'p-1' }
+    );
+    expect(result.subject).toBeUndefined();
+  });
+
+  it('injects requester only for ServiceRequest, MedicationRequest, Task', () => {
+    const requesterTypes = ['ServiceRequest', 'MedicationRequest', 'Task'];
+    requesterTypes.forEach((resourceType) => {
+      const result = executor._injectContext(
+        { resourceType },
+        { patientId: 'p-1', userId: 'u-1' }
+      );
+      expect(result.requester).toEqual({ reference: 'Practitioner/u-1' });
+    });
+
+    const conditionResult = executor._injectContext(
+      { resourceType: 'Condition' },
+      { patientId: 'p-1', userId: 'u-1' }
+    );
+    expect(conditionResult.requester).toBeUndefined();
+  });
+
+  it('injects encounter for any type when encounterId is given', () => {
+    const result = executor._injectContext(
+      { resourceType: 'Condition' },
+      { patientId: 'p-1', encounterId: 'e-1' }
+    );
+    expect(result.encounter).toEqual({ reference: 'Encounter/e-1' });
+  });
+
+  it('does not mutate the input resource', () => {
+    const input = { resourceType: 'Condition' };
+    const result = executor._injectContext(input, { patientId: 'p-1' });
+    expect(input.subject).toBeUndefined();
+    expect(result).not.toBe(input);
+  });
+
+  it('round-trips a wizard-shaped Condition into something the validator accepts', () => {
+    // This is the exact shape the visual wizard now generates for
+    // "Add Problem: Type 2 diabetes" (post PR #71). Pre-context, the
+    // validator throws at _injectContext; post-context, it should pass.
+    const wizardResource = {
+      resourceType: 'Condition',
+      clinicalStatus: { coding: [{ system: 'x', code: 'active' }] },
+      verificationStatus: { coding: [{ system: 'x', code: 'confirmed' }] },
+      code: {
+        coding: [{
+          system: 'http://hl7.org/fhir/sid/icd-10-cm',
+          code: 'E11.9',
+          display: 'T2DM'
+        }],
+        text: 'T2DM'
+      }
+    };
+    const enriched = executor._injectContext(
+      wizardResource,
+      { patientId: 'p-1' }
+    );
+    // Note: Condition isn't on the validator's switch (no subject check),
+    // but executor injects it anyway because Condition is in the
+    // SUBJECT_REQUIRED_TYPES set — matching backend behavior so the
+    // resource lands with a real subject reference.
+    expect(enriched.subject).toEqual({ reference: 'Patient/p-1' });
+    expect(enriched.code.coding[0].code).toBe('E11.9');
+  });
+});

--- a/frontend/src/services/cdsActionExecutor.js
+++ b/frontend/src/services/cdsActionExecutor.js
@@ -1,10 +1,34 @@
 /**
  * CDS Action Executor Service
- * Handles execution of CDS suggestion actions (create, update, delete FHIR resources)
+ *
+ * Handles execution of CDS suggestion actions (create, update, delete FHIR
+ * resources) on the **client side**. This is a parallel implementation to
+ * the backend executor at
+ * `backend/api/cds_hooks/actions/executor.py::_execute_create_action`.
+ * Both must agree on which fields get auto-injected from the hook context
+ * (subject, requester, encounter) so the wizard can produce the same
+ * `actions[].resource` shape and have it work through either path.
+ *
+ * Resource types that require a subject (MedicationRequest, ServiceRequest,
+ * Observation, Condition, AllergyIntolerance, CarePlan, Goal, Task) get
+ * `subject` auto-filled here when the caller passes a `patientId` in the
+ * execution context, exactly mirroring the backend's behavior.
  */
 import { fhirClient } from '../core/fhir/services/fhirClient';
 import { cdsLogger } from '../config/logging';
 import { cdsFeedbackService } from './cdsFeedbackService';
+
+// Resource types that the runtime auto-fills `subject` on when missing.
+// Source: backend/api/cds_hooks/actions/executor.py:_execute_create_action.
+const SUBJECT_REQUIRED_TYPES = new Set([
+  'MedicationRequest', 'ServiceRequest', 'Observation', 'Condition',
+  'AllergyIntolerance', 'CarePlan', 'Goal', 'Task'
+]);
+
+// Resource types that get `requester` auto-filled (subset of above).
+const REQUESTER_REQUIRED_TYPES = new Set([
+  'MedicationRequest', 'ServiceRequest', 'Task'
+]);
 
 class CDSActionExecutor {
   constructor() {
@@ -19,9 +43,18 @@ class CDSActionExecutor {
    * Execute a CDS suggestion
    * @param {Object} alert - CDS alert/card
    * @param {Object} suggestion - Suggestion to execute
+   * @param {Object} [context] - Hook context. Pass at least `patientId` so
+   *   subject/requester/encounter can be auto-injected before validation.
+   *   Without this, resources whose type requires a subject (Condition,
+   *   ServiceRequest, MedicationRequest, etc.) will fail validation —
+   *   the wizard generates them without a subject by design, expecting
+   *   the executor to fill it in from context.
+   * @param {string} [context.patientId] - FHIR Patient ID
+   * @param {string} [context.userId] - FHIR Practitioner ID (for requester)
+   * @param {string} [context.encounterId] - FHIR Encounter ID
    * @returns {Promise<Object>} Execution result
    */
-  async executeSuggestion(alert, suggestion) {
+  async executeSuggestion(alert, suggestion, context = {}) {
     try {
       cdsLogger.info('Executing CDS suggestion', {
         alertId: alert.uuid,
@@ -41,7 +74,7 @@ class CDSActionExecutor {
       // Process actions in the suggestion
       if (suggestion.actions && Array.isArray(suggestion.actions)) {
         for (const action of suggestion.actions) {
-          const actionResult = await this.executeAction(action);
+          const actionResult = await this.executeAction(action, context);
           
           if (actionResult.success) {
             results.executedActions.push(actionResult);
@@ -96,12 +129,14 @@ class CDSActionExecutor {
   /**
    * Execute a single action
    * @param {Object} action - Action to execute
+   * @param {Object} [context] - Hook context for subject/requester/encounter
+   *   injection. See `executeSuggestion` for the shape.
    * @returns {Promise<Object>} Action result
    */
-  async executeAction(action) {
+  async executeAction(action, context = {}) {
     try {
       const { type, description, resource } = action;
-      
+
       if (!type) {
         throw new Error('Action type is required');
       }
@@ -111,7 +146,7 @@ class CDSActionExecutor {
         throw new Error(`Unknown action type: ${type}`);
       }
 
-      const result = await handler(resource, description);
+      const result = await handler(resource, description, context);
       
       return {
         success: true,
@@ -136,30 +171,60 @@ class CDSActionExecutor {
   }
 
   /**
+   * Inject subject/requester/encounter from the hook context into a
+   * partial resource before validation, mirroring the backend executor
+   * (`_execute_create_action` in actions/executor.py). Returns a new
+   * resource — does not mutate the input.
+   */
+  _injectContext(resource, context = {}) {
+    if (!resource || !resource.resourceType) return resource;
+    const { patientId, userId, encounterId } = context;
+    const result = { ...resource };
+
+    if (patientId
+        && SUBJECT_REQUIRED_TYPES.has(result.resourceType)
+        && !result.subject) {
+      result.subject = { reference: `Patient/${patientId}` };
+    }
+    if (userId
+        && REQUESTER_REQUIRED_TYPES.has(result.resourceType)
+        && !result.requester) {
+      result.requester = { reference: `Practitioner/${userId}` };
+    }
+    if (encounterId && !result.encounter) {
+      result.encounter = { reference: `Encounter/${encounterId}` };
+    }
+    return result;
+  }
+
+  /**
    * Handle create action
    * @param {Object} resource - FHIR resource to create
    * @param {string} description - Action description
+   * @param {Object} [context] - Hook context for subject/requester/encounter
    * @returns {Promise<Object>} Creation result
    */
-  async handleCreateAction(resource, description) {
+  async handleCreateAction(resource, description, context = {}) {
     if (!resource || !resource.resourceType) {
       throw new Error('Invalid resource for create action');
     }
 
-    // Validate resource before creation
-    this.validateResource(resource);
+    const enriched = this._injectContext(resource, context);
+
+    // Validate resource (with injected context) before creation
+    this.validateResource(enriched);
 
     // Create the resource
-    const createdResource = await fhirClient.create(resource);
+    const createdResource = await fhirClient.create(enriched);
 
     cdsLogger.info('Created FHIR resource', {
-      resourceType: resource.resourceType,
+      resourceType: enriched.resourceType,
       id: createdResource.id,
       description
     });
 
     return {
-      resourceType: resource.resourceType,
+      resourceType: enriched.resourceType,
       resourceId: createdResource.id,
       resource: createdResource
     };
@@ -169,28 +234,33 @@ class CDSActionExecutor {
    * Handle update action
    * @param {Object} resource - FHIR resource to update
    * @param {string} description - Action description
+   * @param {Object} [context] - Hook context (typically not needed for
+   *   updates since the resource already has subject etc., but accepted
+   *   for symmetry with create)
    * @returns {Promise<Object>} Update result
    */
-  async handleUpdateAction(resource, description) {
+  async handleUpdateAction(resource, description, context = {}) {
     if (!resource || !resource.resourceType || !resource.id) {
       throw new Error('Invalid resource for update action - must include resourceType and id');
     }
 
-    // Validate resource before update
-    this.validateResource(resource);
+    const enriched = this._injectContext(resource, context);
+
+    // Validate resource (with injected context) before update
+    this.validateResource(enriched);
 
     // Update the resource
-    const updatedResource = await fhirClient.update(resource);
+    const updatedResource = await fhirClient.update(enriched);
 
     cdsLogger.info('Updated FHIR resource', {
-      resourceType: resource.resourceType,
-      id: resource.id,
+      resourceType: enriched.resourceType,
+      id: enriched.id,
       description
     });
 
     return {
-      resourceType: resource.resourceType,
-      resourceId: resource.id,
+      resourceType: enriched.resourceType,
+      resourceId: enriched.id,
       resource: updatedResource
     };
   }
@@ -330,9 +400,12 @@ class CDSActionExecutor {
   /**
    * Dry run a suggestion to preview what would happen
    * @param {Object} suggestion - Suggestion to dry run
+   * @param {Object} [context] - Hook context, same shape as
+   *   `executeSuggestion`. Forwarded to `_injectContext` so the dry-run
+   *   validation matches what the live execute path would see.
    * @returns {Object} Dry run result
    */
-  async dryRunSuggestion(suggestion) {
+  async dryRunSuggestion(suggestion, context = {}) {
     const result = {
       wouldCreate: [],
       wouldUpdate: [],
@@ -344,7 +417,8 @@ class CDSActionExecutor {
       for (const action of suggestion.actions) {
         try {
           if (action.resource) {
-            this.validateResource(action.resource);
+            const enriched = this._injectContext(action.resource, context);
+            this.validateResource(enriched);
           }
 
           switch (action.type) {

--- a/frontend/src/services/cdsActionExecutor.js
+++ b/frontend/src/services/cdsActionExecutor.js
@@ -214,8 +214,10 @@ class CDSActionExecutor {
     // Validate resource (with injected context) before creation
     this.validateResource(enriched);
 
-    // Create the resource
-    const createdResource = await fhirClient.create(enriched);
+    // Create the resource. fhirClient.create takes (resourceType, body)
+    // — the previous single-arg form sent the resource type as
+    // [object Object] in the URL and HAPI returned 400.
+    const createdResource = await fhirClient.create(enriched.resourceType, enriched);
 
     cdsLogger.info('Created FHIR resource', {
       resourceType: enriched.resourceType,
@@ -249,8 +251,9 @@ class CDSActionExecutor {
     // Validate resource (with injected context) before update
     this.validateResource(enriched);
 
-    // Update the resource
-    const updatedResource = await fhirClient.update(enriched);
+    // fhirClient.update takes (resourceType, id, body); same shape mismatch
+    // as create that we fix here for symmetry.
+    const updatedResource = await fhirClient.update(enriched.resourceType, enriched.id, enriched);
 
     cdsLogger.info('Updated FHIR resource', {
       resourceType: enriched.resourceType,


### PR DESCRIPTION
## Summary

Patient-view CDS alerts (the popup that fires when a clinician opens a patient chart) couldn't actually do anything on Accept. User reported clicking "Order Mammogram" did nothing, "Override" appeared to close the whole popup, and dismissed alerts kept re-firing on different pages. Three independent bugs in the same flow:

| Bug | File | Fix |
|---|---|---|
| Suggestion-detail and override dialogs only rendered in **inline** mode, not in **popup** mode (the actual chart UX) | `CDSPresentation.js` | Inline-copy both dialogs into the popup-mode return as siblings of the existing snooze dialog |
| Dismissals saved to sessionStorage but the component hydrated initial state from `cdsAlertPersistence` (different store) — so dismissed alerts re-fired on every navigation | `CDSPresentation.js` | Also call `cdsAlertPersistence.dismissAlert(...)` on dismiss / accept / override-confirm paths |
| `cdsActionExecutor.handleCreate/handleUpdate` called `fhirClient.create(resource)` — but the client signature is `create(resourceType, body)`. Result: `POST /fhir/R4/[object%20Object]` → 400. (Pre-existing; never hit because `validateResource` threw first on missing subject.) | `cdsActionExecutor.js` | Fix the call signatures |
| Wizard-generated suggestions have no `subject` on the resource (the runtime is supposed to inject it). Backend executor (PR #72) now does this for the OrderSigningDialog path; this PR adds the equivalent for the client-side patient-view path. | `cdsActionExecutor.js` | New `_injectContext(resource, {patientId, userId, encounterId})` mirroring backend behavior. Threaded through `executeSuggestion → executeAction → handleCreate/Update/dryRun`. `CDSPresentation` and `CDSHookManager` updated to forward `userId`/`encounterId` alongside the existing `patientId`. |

## Verification on prod (https://wintehr.eastus2.cloudapp.azure.com)

End-to-end test on patient `27eb5f08-b882-d55b-1801-781cc5be4727`:

```
# Open chart → "Mammography screening due" alert fires in popup
# Click "Order Mammogram" → suggestion-detail dialog opens (was missing before)
# Click "Accept"
# Verify:
GET /fhir/ServiceRequest?patient=Patient/27eb5f08-... 
  → total: 1
  → ServiceRequest/258408, code: Mammography, subject: Patient/27eb5f08-...
# Cleanup:
DELETE ServiceRequest/258408 → success
```

## Tests

New `frontend/src/services/__tests__/cdsActionExecutor.test.js` — 8 cases for `_injectContext` covering all the wizard's resource shapes (subject for the 8 required types, requester for the 3 that need it, encounter for any, no-overwrite, no-mutation, end-to-end round-trip of a wizard-shaped Condition). All pass.

## Commits

- `7d35b78` fix(cds): inject subject/requester/encounter in client-side action executor
- `e061c37` fix(cds): render suggestion-detail and override dialogs in popup mode
- `c98a8de` fix(cds): correct fhirClient.create/update call signatures in action executor

## Out of scope (deliberate)

- The same dialog-rendering pattern is wrong in modes other than popup (banner/toast/modal/drawer/compact/card/sidebar) — fix per-need to keep blast radius small. The user is on popup; that's what got fixed today.
- Pairs with #71 (wizard generates the right shape) and #72 (backend executor for OrderSigningDialog path). With this PR merged, both Accept paths work end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)