### PR TITLE
feat(cds): integrate per-service display modes into the clinical workspace

### DIFF
--- a/backend/api/cds_hooks/cds_hooks_router.py
+++ b/backend/api/cds_hooks/cds_hooks_router.py
@@ -1036,28 +1036,92 @@ async def list_services(
     enabled_only: bool = True,
     db: AsyncSession = Depends(get_db_session)
 ):
-    """List all CDS services"""
+    """List all CDS services.
+
+    Combines two sources:
+
+    1. Hooks stored in `cds_hooks.hook_configurations` (built-in / external
+       services managed via the legacy hook persistence layer).
+    2. Visual-builder services from `cds_hooks.visual_builder_services` —
+       these aren't in the legacy table, so without this merge they were
+       absent from the list and the EMR's `CDSHookManager` could never
+       look up their `displayBehavior`. That's why every wizard-built
+       service rendered as POPUP regardless of its `display_config`.
+
+    For the visual-builder rows we project `display_config.presentationMode`
+    onto `HookConfiguration.displayBehavior.defaultMode` so the existing
+    frontend mode-picker code path (CDSHookManager.js:222-234) just works.
+    """
     try:
         manager = await get_persistence_manager(db)
-        return await manager.list_hooks(hook_type=hook_type, enabled_only=enabled_only)
+        legacy_hooks = await manager.list_hooks(
+            hook_type=hook_type, enabled_only=enabled_only
+        )
     except DatabaseQueryError as e:
         logger.error(f"Database error listing hooks: {e.message}")
-        # Fallback to sample hooks
-        hooks = list(SAMPLE_HOOKS.values())
+        legacy_hooks = list(SAMPLE_HOOKS.values())
         if hook_type:
-            hooks = [h for h in hooks if h.hook.value == hook_type]
+            legacy_hooks = [h for h in legacy_hooks if h.hook.value == hook_type]
         if enabled_only:
-            hooks = [h for h in hooks if h.enabled]
-        return hooks
+            legacy_hooks = [h for h in legacy_hooks if h.enabled]
     except (ValueError, TypeError, KeyError, AttributeError) as e:
         logger.error(f"Data error listing hooks: {e}")
-        # Fallback to sample hooks
-        hooks = list(SAMPLE_HOOKS.values())
+        legacy_hooks = list(SAMPLE_HOOKS.values())
         if hook_type:
-            hooks = [h for h in hooks if h.hook.value == hook_type]
+            legacy_hooks = [h for h in legacy_hooks if h.hook.value == hook_type]
         if enabled_only:
-            hooks = [h for h in hooks if h.enabled]
-        return hooks
+            legacy_hooks = [h for h in legacy_hooks if h.enabled]
+
+    # Merge in visual-builder services with displayBehavior derived from
+    # their wizard-set `display_config`.
+    visual_hooks: List[HookConfiguration] = []
+    try:
+        from sqlalchemy import select as _select
+        from api.cds_studio.visual_service_config import VisualServiceConfig
+
+        vquery = _select(VisualServiceConfig)
+        if hook_type:
+            vquery = vquery.where(VisualServiceConfig.hook_type == hook_type)
+        if enabled_only:
+            vquery = vquery.where(VisualServiceConfig.status == "ACTIVE")
+
+        vresult = await db.execute(vquery)
+        for v in vresult.scalars().all():
+            display_cfg = v.display_config or {}
+            presentation = (display_cfg.get("presentationMode")
+                            if isinstance(display_cfg, dict) else None)
+            display_behavior = (
+                {"defaultMode": presentation} if presentation else None
+            )
+            try:
+                hook_enum = HookType(v.hook_type)
+            except ValueError:
+                # Unknown hook types are skipped — same as the legacy path.
+                continue
+            visual_hooks.append(HookConfiguration(
+                id=v.service_id,
+                hook=hook_enum,
+                title=v.name,
+                description=v.description or "",
+                enabled=(v.status == "ACTIVE"),
+                conditions=[],
+                actions=[],
+                prefetch=v.prefetch_config or None,
+                usageRequirements=None,
+                displayBehavior=display_behavior,
+                created_at=v.created_at,
+                updated_at=v.updated_at,
+            ))
+    except Exception as exc:  # noqa: BLE001 — non-fatal: legacy hooks still list
+        logger.warning(
+            "Failed to merge visual-builder services into hook list: %s", exc
+        )
+
+    # De-dupe in case both sources have a row for the same service_id.
+    # Visual-builder is the source of truth for display behavior.
+    seen = {h.id for h in visual_hooks}
+    merged = visual_hooks + [h for h in legacy_hooks if h.id not in seen]
+    return merged
 
 # Alias endpoint for CDS Builder compatibility
 @router.get("/cds-services/services", response_model=List[HookConfiguration])

--- a/frontend/src/components/clinical/ClinicalWorkspaceEnhanced.js
+++ b/frontend/src/components/clinical/ClinicalWorkspaceEnhanced.js
@@ -322,21 +322,45 @@ const ClinicalWorkspaceEnhanced = ({
 
   return (
     <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
-      {/* CDS Alerts - Show as dialog once per patient, dismissed on close */}
-      {cdsAlerts && cdsAlerts.length > 0 && !cdsDialogDismissed && (
-        <CDSPresentation
-          alerts={cdsAlerts}
-          mode={PRESENTATION_MODES.POPUP}
-          patientId={patientId}
-          allowInteraction={true}
-          onAlertAction={(alertId, action, data) => {
-            if (action === 'dismiss' || action === 'close') {
-              setCdsDialogDismissed(true);
-            }
-          }}
-          onClose={() => setCdsDialogDismissed(true)}
-        />
-      )}
+      {/* CDS Alerts — group by each alert's configured presentation mode
+          and render one CDSPresentation per mode. Previously this was
+          hardcoded to POPUP, which silently ignored every service's
+          displayBehavior config and made the wizard's Display Mode picker
+          a no-op. Each alert's `displayBehavior.presentationMode` comes
+          from CDSContext (set when the alert is created from the hook
+          response, based on hookConfigurations). Falls back to POPUP for
+          alerts that didn't get a mode assigned. */}
+      {cdsAlerts && cdsAlerts.length > 0 && !cdsDialogDismissed && (() => {
+        const alertsByMode = {};
+        cdsAlerts.forEach(alert => {
+          const mode = alert.displayBehavior?.presentationMode || PRESENTATION_MODES.POPUP;
+          if (!alertsByMode[mode]) alertsByMode[mode] = [];
+          alertsByMode[mode].push(alert);
+        });
+        return Object.entries(alertsByMode).map(([mode, alerts]) => (
+          <CDSPresentation
+            key={mode}
+            alerts={alerts}
+            mode={mode}
+            patientId={patientId}
+            allowInteraction={true}
+            onAlertAction={(alertId, action, data) => {
+              if (action === 'dismiss' || action === 'close') {
+                // Close the popup-style host once user dismisses; other
+                // modes (sidebar/banner/toast) stay independent.
+                if (mode === PRESENTATION_MODES.POPUP || mode === PRESENTATION_MODES.MODAL) {
+                  setCdsDialogDismissed(true);
+                }
+              }
+            }}
+            onClose={() => {
+              if (mode === PRESENTATION_MODES.POPUP || mode === PRESENTATION_MODES.MODAL) {
+                setCdsDialogDismissed(true);
+              }
+            }}
+          />
+        ));
+      })()}
       
       {/* Tab Content - no extra spacing */}
       <Box 

--- a/frontend/src/components/clinical/cds/CDSHookManager.js
+++ b/frontend/src/components/clinical/cds/CDSHookManager.js
@@ -87,9 +87,17 @@ const CDSHookManager = forwardRef(({
   // Load hook configurations with display behavior
   const loadHookConfigurations = useCallback(async () => {
     try {
-      const hooks = await cdsHooksService.listCustomHooks();
+      // listCustomHooks (→ listCustomServices) returns `{success, data}`;
+      // earlier code did `hooks.forEach(...)` directly on that object,
+      // which silently fell into the catch and left configMap empty.
+      // Result: every service got the 'popup' fallback regardless of
+      // its configured displayBehavior. Unwrap the array here.
+      const response = await cdsHooksService.listCustomHooks();
+      const hooks = Array.isArray(response)
+        ? response
+        : (response?.data || []);
       const configMap = {};
-      
+
       hooks.forEach(hook => {
         configMap[hook.id] = hook;
       });

--- a/frontend/src/components/clinical/cds/CDSHookManager.js
+++ b/frontend/src/components/clinical/cds/CDSHookManager.js
@@ -218,12 +218,22 @@ const CDSHookManager = forwardRef(({
           const displayBehavior = hookConfig.displayBehavior;
           
           if (displayBehavior) {
-            // Map display behavior to presentation modes
+            // Map display behavior values to presentation modes. The
+            // wizard saves `display_config.presentationMode` using the
+            // PRESENTATION_MODES values directly (banner/toast/popup/etc.);
+            // the legacy hook config also accepts `'hard-stop'` as a
+            // synonym for modal. Cover both.
             const modeMapping = {
               'hard-stop': PRESENTATION_MODES.MODAL,
+              'modal': PRESENTATION_MODES.MODAL,
               'popup': PRESENTATION_MODES.POPUP,
               'sidebar': PRESENTATION_MODES.SIDEBAR,
-              'inline': PRESENTATION_MODES.INLINE
+              'inline': PRESENTATION_MODES.INLINE,
+              'banner': PRESENTATION_MODES.BANNER,
+              'toast': PRESENTATION_MODES.TOAST,
+              'card': PRESENTATION_MODES.CARD,
+              'compact': PRESENTATION_MODES.COMPACT,
+              'drawer': PRESENTATION_MODES.DRAWER
             };
             
             // Check for indicator-based overrides

--- a/frontend/src/contexts/CDSContext.js
+++ b/frontend/src/contexts/CDSContext.js
@@ -223,7 +223,10 @@ export const CDSProvider = ({ children }) => {
                 cdsLogger.debug(`CDSContext: Display behavior for ${service.id}`, displayBehavior);
                 
                 if (displayBehavior) {
-                  // Map display behavior to presentation modes
+                  // Map display behavior values to presentation modes.
+                  // Includes the modes the wizard now exposes (card,
+                  // compact, drawer) — missing entries fall back to POPUP
+                  // via the lookup default below.
                   const modeMapping = {
                     'hard-stop': PRESENTATION_MODES.MODAL,
                     'modal': PRESENTATION_MODES.MODAL,
@@ -231,7 +234,10 @@ export const CDSProvider = ({ children }) => {
                     'sidebar': PRESENTATION_MODES.SIDEBAR,
                     'inline': PRESENTATION_MODES.INLINE,
                     'banner': PRESENTATION_MODES.BANNER,
-                    'toast': PRESENTATION_MODES.TOAST
+                    'toast': PRESENTATION_MODES.TOAST,
+                    'card': PRESENTATION_MODES.CARD,
+                    'compact': PRESENTATION_MODES.COMPACT,
+                    'drawer': PRESENTATION_MODES.DRAWER
                   };
                   
                   // Check for indicator-based overrides

--- a/frontend/src/modules/cds-studio/components/builder/VisualBuilderWizard.jsx
+++ b/frontend/src/modules/cds-studio/components/builder/VisualBuilderWizard.jsx
@@ -431,6 +431,37 @@ const VisualBuilderWizard = ({ open, onClose, onSuccess }) => {
             </Select>
           </FormControl>
         </Grid>
+
+        <Grid item xs={12} md={6}>
+          <FormControl fullWidth>
+            <InputLabel>Display Mode</InputLabel>
+            <Select
+              value={serviceConfig.display_config?.presentationMode || 'popup'}
+              onChange={(e) => setServiceConfig({
+                ...serviceConfig,
+                display_config: {
+                  ...(serviceConfig.display_config || {}),
+                  presentationMode: e.target.value
+                }
+              })}
+              label="Display Mode"
+            >
+              {/* Values match PRESENTATION_MODES in CDSPresentation.js. The
+                  backend stores this on display_config; the listing
+                  endpoint maps it to displayBehavior.defaultMode and
+                  CDSHookManager picks the rendering mode from there. */}
+              <MenuItem value="popup">Popup — modal dialog (default)</MenuItem>
+              <MenuItem value="inline">Inline — within page flow</MenuItem>
+              <MenuItem value="modal">Modal — hard-stop, requires acknowledgment</MenuItem>
+              <MenuItem value="banner">Banner — sticky bar at top</MenuItem>
+              <MenuItem value="sidebar">Sidebar — fixed right-side panel</MenuItem>
+              <MenuItem value="drawer">Drawer — slide-out from right</MenuItem>
+              <MenuItem value="toast">Toast — corner notification</MenuItem>
+              <MenuItem value="card">Card — rich card display</MenuItem>
+              <MenuItem value="compact">Compact — icon with badge</MenuItem>
+            </Select>
+          </FormControl>
+        </Grid>
       </Grid>
     </Box>
   );


### PR DESCRIPTION
## Summary

Phase 1 of integrating the 9 CDS presentation modes into real workflows. Today every CDS alert renders as POPUP regardless of how a service is configured — that's not by design, it's because four separate gaps in the path between service config and runtime rendering all silently no-op'd. This PR fixes the path end-to-end and adds a Display Mode picker to the visual builder so authors can actually pick the mode their alert renders in.

## The four gaps

1. **Visual-builder services were missing from `/services` listing.** The endpoint only queried `cds_hooks.hook_configurations`, but visual-builder services live in `cds_visual_builder.service_configs`. CDSHookManager / CDSContext looked them up by id and got `undefined`, falling through to the `'popup'` ultimate fallback. ([commit](../commit/caddd03))

2. **`cdsHooksService.listCustomHooks` returns `{success, data}`**, but consumers did `hooks.forEach(...)` directly on the wrapper. That throws (objects don't have forEach), the catch swallowed it, and the service config map stayed empty. So even if visual-builder services *had* been in the listing, they wouldn't have been read into the map. ([commit](../commit/44d7714))

3. **`ClinicalWorkspaceEnhanced.js:329` hardcoded `mode={PRESENTATION_MODES.POPUP}`** when rendering CDS alerts on the patient chart. So even if alerts had a per-alert `displayBehavior.presentationMode` (which CDSContext does compute correctly when the map is populated), the workspace ignored it and rendered everything as popup. ([commit](../commit/724d794))

4. **The visual builder wizard had no Display Mode picker.** I removed `DisplayConfigPanel` in #71 because the runtime ignored it. Now that the runtime honors it, a simple Display Mode dropdown is back in Step 1. ([same commit as #1](../commit/caddd03))

## What changed

| File | Change |
|---|---|
| `backend/api/cds_hooks/cds_hooks_router.py` | `list_services` now also queries `VisualServiceConfig` and projects each row's `display_config.presentationMode` onto a `HookConfiguration.displayBehavior.defaultMode`. Visual-builder is the source of truth — legacy hooks for the same id are dropped on merge. |
| `frontend/src/components/clinical/cds/CDSHookManager.js` | Unwrap `listCustomHooks` response. `modeMapping` extended to all 9 modes. |
| `frontend/src/contexts/CDSContext.js` | `modeMapping` extended with card/compact/drawer (was missing them). |
| `frontend/src/components/clinical/ClinicalWorkspaceEnhanced.js` | Group alerts by `alert.displayBehavior.presentationMode` and render one `CDSPresentation` per mode. Was hardcoded to POPUP. |
| `frontend/src/modules/cds-studio/components/builder/VisualBuilderWizard.jsx` | New Display Mode dropdown in Step 1 with all 9 modes. |

## Verified on prod (https://wintehr.eastus2.cloudapp.azure.com)

Single patient (`27eb5f08-...`) with multiple active services. Switched the smoke-test service's `display_config.presentationMode` via API and reloaded the chart:

- `sidebar` → smoke service renders in a right-side fixed sidebar (350px wide, "CDS Alerts (3)" header), legacy services still in popup.
- `modal` → smoke service renders as a hard-stop modal ("Critical Alert - Action Required"), legacy services still in popup.

Both modes present on the same chart, simultaneously, without affecting each other.

## What this unlocks

After this PR lands, an author building a service in the wizard can pick from all 9 modes (popup/inline/modal/banner/sidebar/drawer/toast/card/compact) and the choice actually shows up at the patient bedside. **Phase 2** (separate PR) wires the non-patient-view hooks (`medication-prescribe`, `order-select`, `encounter-start`) into their respective EMR workflows so a service configured for one of those hooks fires when the clinician hits that workflow trigger.

## Backwards compatibility
- Services without `display_config.presentationMode` continue to fall back to POPUP exactly as before.
- The merge in `list_services` returns visual-builder rows first; legacy rows for the same id are dropped (visual-builder is canonical). No double-counting.
- ClinicalWorkspaceEnhanced grouping is invariant: with N alerts all in popup mode, you get one CDSPresentation rendering all N — same as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)