### PR TITLE
feat(cds): render order-select alerts in the orders tab

### DIFF
--- a/backend/api/cds_hooks/cds_hooks_router.py
+++ b/backend/api/cds_hooks/cds_hooks_router.py
@@ -1036,28 +1036,92 @@ async def list_services(
     enabled_only: bool = True,
     db: AsyncSession = Depends(get_db_session)
 ):
-    """List all CDS services"""
+    """List all CDS services.
+
+    Combines two sources:
+
+    1. Hooks stored in `cds_hooks.hook_configurations` (built-in / external
+       services managed via the legacy hook persistence layer).
+    2. Visual-builder services from `cds_hooks.visual_builder_services` —
+       these aren't in the legacy table, so without this merge they were
+       absent from the list and the EMR's `CDSHookManager` could never
+       look up their `displayBehavior`. That's why every wizard-built
+       service rendered as POPUP regardless of its `display_config`.
+
+    For the visual-builder rows we project `display_config.presentationMode`
+    onto `HookConfiguration.displayBehavior.defaultMode` so the existing
+    frontend mode-picker code path (CDSHookManager.js:222-234) just works.
+    """
     try:
         manager = await get_persistence_manager(db)
-        return await manager.list_hooks(hook_type=hook_type, enabled_only=enabled_only)
+        legacy_hooks = await manager.list_hooks(
+            hook_type=hook_type, enabled_only=enabled_only
+        )
     except DatabaseQueryError as e:
         logger.error(f"Database error listing hooks: {e.message}")
-        # Fallback to sample hooks
-        hooks = list(SAMPLE_HOOKS.values())
+        legacy_hooks = list(SAMPLE_HOOKS.values())
         if hook_type:
-            hooks = [h for h in hooks if h.hook.value == hook_type]
+            legacy_hooks = [h for h in legacy_hooks if h.hook.value == hook_type]
         if enabled_only:
-            hooks = [h for h in hooks if h.enabled]
-        return hooks
+            legacy_hooks = [h for h in legacy_hooks if h.enabled]
     except (ValueError, TypeError, KeyError, AttributeError) as e:
         logger.error(f"Data error listing hooks: {e}")
-        # Fallback to sample hooks
-        hooks = list(SAMPLE_HOOKS.values())
+        legacy_hooks = list(SAMPLE_HOOKS.values())
         if hook_type:
-            hooks = [h for h in hooks if h.hook.value == hook_type]
+            legacy_hooks = [h for h in legacy_hooks if h.hook.value == hook_type]
         if enabled_only:
-            hooks = [h for h in hooks if h.enabled]
-        return hooks
+            legacy_hooks = [h for h in legacy_hooks if h.enabled]
+
+    # Merge in visual-builder services with displayBehavior derived from
+    # their wizard-set `display_config`.
+    visual_hooks: List[HookConfiguration] = []
+    try:
+        from sqlalchemy import select as _select
+        from api.cds_studio.visual_service_config import VisualServiceConfig
+
+        vquery = _select(VisualServiceConfig)
+        if hook_type:
+            vquery = vquery.where(VisualServiceConfig.hook_type == hook_type)
+        if enabled_only:
+            vquery = vquery.where(VisualServiceConfig.status == "ACTIVE")
+
+        vresult = await db.execute(vquery)
+        for v in vresult.scalars().all():
+            display_cfg = v.display_config or {}
+            presentation = (display_cfg.get("presentationMode")
+                            if isinstance(display_cfg, dict) else None)
+            display_behavior = (
+                {"defaultMode": presentation} if presentation else None
+            )
+            try:
+                hook_enum = HookType(v.hook_type)
+            except ValueError:
+                # Unknown hook types are skipped — same as the legacy path.
+                continue
+            visual_hooks.append(HookConfiguration(
+                id=v.service_id,
+                hook=hook_enum,
+                title=v.name,
+                description=v.description or "",
+                enabled=(v.status == "ACTIVE"),
+                conditions=[],
+                actions=[],
+                prefetch=v.prefetch_config or None,
+                usageRequirements=None,
+                displayBehavior=display_behavior,
+                created_at=v.created_at,
+                updated_at=v.updated_at,
+            ))
+    except Exception as exc:  # noqa: BLE001 — non-fatal: legacy hooks still list
+        logger.warning(
+            "Failed to merge visual-builder services into hook list: %s", exc
+        )
+
+    # De-dupe in case both sources have a row for the same service_id.
+    # Visual-builder is the source of truth for display behavior.
+    seen = {h.id for h in visual_hooks}
+    merged = visual_hooks + [h for h in legacy_hooks if h.id not in seen]
+    return merged
 
 # Alias endpoint for CDS Builder compatibility
 @router.get("/cds-services/services", response_model=List[HookConfiguration])

--- a/frontend/src/components/clinical/ClinicalWorkspaceEnhanced.js
+++ b/frontend/src/components/clinical/ClinicalWorkspaceEnhanced.js
@@ -322,21 +322,45 @@ const ClinicalWorkspaceEnhanced = ({
 
   return (
     <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
-      {/* CDS Alerts - Show as dialog once per patient, dismissed on close */}
-      {cdsAlerts && cdsAlerts.length > 0 && !cdsDialogDismissed && (
-        <CDSPresentation
-          alerts={cdsAlerts}
-          mode={PRESENTATION_MODES.POPUP}
-          patientId={patientId}
-          allowInteraction={true}
-          onAlertAction={(alertId, action, data) => {
-            if (action === 'dismiss' || action === 'close') {
-              setCdsDialogDismissed(true);
-            }
-          }}
-          onClose={() => setCdsDialogDismissed(true)}
-        />
-      )}
+      {/* CDS Alerts — group by each alert's configured presentation mode
+          and render one CDSPresentation per mode. Previously this was
+          hardcoded to POPUP, which silently ignored every service's
+          displayBehavior config and made the wizard's Display Mode picker
+          a no-op. Each alert's `displayBehavior.presentationMode` comes
+          from CDSContext (set when the alert is created from the hook
+          response, based on hookConfigurations). Falls back to POPUP for
+          alerts that didn't get a mode assigned. */}
+      {cdsAlerts && cdsAlerts.length > 0 && !cdsDialogDismissed && (() => {
+        const alertsByMode = {};
+        cdsAlerts.forEach(alert => {
+          const mode = alert.displayBehavior?.presentationMode || PRESENTATION_MODES.POPUP;
+          if (!alertsByMode[mode]) alertsByMode[mode] = [];
+          alertsByMode[mode].push(alert);
+        });
+        return Object.entries(alertsByMode).map(([mode, alerts]) => (
+          <CDSPresentation
+            key={mode}
+            alerts={alerts}
+            mode={mode}
+            patientId={patientId}
+            allowInteraction={true}
+            onAlertAction={(alertId, action, data) => {
+              if (action === 'dismiss' || action === 'close') {
+                // Close the popup-style host once user dismisses; other
+                // modes (sidebar/banner/toast) stay independent.
+                if (mode === PRESENTATION_MODES.POPUP || mode === PRESENTATION_MODES.MODAL) {
+                  setCdsDialogDismissed(true);
+                }
+              }
+            }}
+            onClose={() => {
+              if (mode === PRESENTATION_MODES.POPUP || mode === PRESENTATION_MODES.MODAL) {
+                setCdsDialogDismissed(true);
+              }
+            }}
+          />
+        ));
+      })()}
       
       {/* Tab Content - no extra spacing */}
       <Box 

--- a/frontend/src/components/clinical/cds/CDSHookManager.js
+++ b/frontend/src/components/clinical/cds/CDSHookManager.js
@@ -87,9 +87,17 @@ const CDSHookManager = forwardRef(({
   // Load hook configurations with display behavior
   const loadHookConfigurations = useCallback(async () => {
     try {
-      const hooks = await cdsHooksService.listCustomHooks();
+      // listCustomHooks (→ listCustomServices) returns `{success, data}`;
+      // earlier code did `hooks.forEach(...)` directly on that object,
+      // which silently fell into the catch and left configMap empty.
+      // Result: every service got the 'popup' fallback regardless of
+      // its configured displayBehavior. Unwrap the array here.
+      const response = await cdsHooksService.listCustomHooks();
+      const hooks = Array.isArray(response)
+        ? response
+        : (response?.data || []);
       const configMap = {};
-      
+
       hooks.forEach(hook => {
         configMap[hook.id] = hook;
       });

--- a/frontend/src/components/clinical/cds/CDSHookManager.js
+++ b/frontend/src/components/clinical/cds/CDSHookManager.js
@@ -218,12 +218,22 @@ const CDSHookManager = forwardRef(({
           const displayBehavior = hookConfig.displayBehavior;
           
           if (displayBehavior) {
-            // Map display behavior to presentation modes
+            // Map display behavior values to presentation modes. The
+            // wizard saves `display_config.presentationMode` using the
+            // PRESENTATION_MODES values directly (banner/toast/popup/etc.);
+            // the legacy hook config also accepts `'hard-stop'` as a
+            // synonym for modal. Cover both.
             const modeMapping = {
               'hard-stop': PRESENTATION_MODES.MODAL,
+              'modal': PRESENTATION_MODES.MODAL,
               'popup': PRESENTATION_MODES.POPUP,
               'sidebar': PRESENTATION_MODES.SIDEBAR,
-              'inline': PRESENTATION_MODES.INLINE
+              'inline': PRESENTATION_MODES.INLINE,
+              'banner': PRESENTATION_MODES.BANNER,
+              'toast': PRESENTATION_MODES.TOAST,
+              'card': PRESENTATION_MODES.CARD,
+              'compact': PRESENTATION_MODES.COMPACT,
+              'drawer': PRESENTATION_MODES.DRAWER
             };
             
             // Check for indicator-based overrides

--- a/frontend/src/components/clinical/workspace/tabs/EnhancedOrdersTab.js
+++ b/frontend/src/components/clinical/workspace/tabs/EnhancedOrdersTab.js
@@ -66,6 +66,7 @@ import { exportClinicalData, EXPORT_COLUMNS } from '../../../../core/export/expo
 import { getMedicationName } from '../../../../core/fhir/utils/medicationDisplayUtils';
 import { useCDS, CDS_HOOK_TYPES } from '../../../../contexts/CDSContext';
 import { useOrderSelectHook } from '../../../../hooks/useCDSHooks';
+import CDSCard from '../../cds/CDSCard';
 import { getStatusColor, getSeverityColor } from '../../../../themes/clinicalThemeUtils';
 import websocketService from '../../../../services/websocket';
 
@@ -520,12 +521,19 @@ const EnhancedOrdersTab = ({
     return entries.filter(order => selectedOrders.has(order.id));
   }, [selectedOrders, entries]);
 
-  // Trigger order-select CDS hooks when orders are selected
-  useOrderSelectHook(
+  // Trigger order-select CDS hooks when orders are selected. The hook
+  // returns the same shape as useCDSHooks() — `cards` is the CDS Hooks
+  // 2.0 response, populated when one or more services configured for
+  // `order-select` returned cards. Rendered below the header so the
+  // clinician sees the alert next to their selection.
+  const {
+    cards: orderSelectCards = [],
+    loading: orderSelectLoading
+  } = useOrderSelectHook(
     patientId || currentPatient?.id,
     user?.id || user?.username || 'unknown',
     selectedOrdersArray
-  );
+  ) || {};
 
   // FHIR resources for providers, locations, and organizations
   const [availableProviders, setAvailableProviders] = useState([]);
@@ -1074,6 +1082,45 @@ const EnhancedOrdersTab = ({
           </Stack>
         </Stack>
       </Box>
+
+      {/* CDS Hooks: order-select alerts. Fired by useOrderSelectHook
+          above whenever the clinician's selection changes. Render the
+          cards as a compact list so the user sees them next to the
+          selection. Cards land here for any service configured for the
+          `order-select` hook in the visual builder. */}
+      {(orderSelectLoading || orderSelectCards.length > 0) && (
+        <Box sx={{ mx: 1, mb: 1 }}>
+          <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1 }}>
+            <Typography variant="subtitle2" color="text.secondary">
+              Clinical Decision Support
+            </Typography>
+            {orderSelectLoading && <CircularProgress size={14} />}
+            {orderSelectCards.length > 0 && (
+              <Chip
+                label={`${orderSelectCards.length} alert${orderSelectCards.length > 1 ? 's' : ''}`}
+                size="small"
+                color="warning"
+                sx={{ borderRadius: 0, height: 20 }}
+              />
+            )}
+          </Stack>
+          <Stack spacing={1}>
+            {orderSelectCards.map((card) => (
+              <CDSCard
+                key={card.uuid}
+                card={card}
+                serviceId={card.serviceId}
+                hookInstance={card.hookInstance}
+                patientId={patientId || currentPatient?.id}
+                userId={user?.id || user?.username}
+                compact={true}
+                onAcceptSuggestion={() => {}}
+                onDismiss={() => {}}
+              />
+            ))}
+          </Stack>
+        </Box>
+      )}
 
       {/* Alerts */}
       {urgentOrdersCount > 0 && (

--- a/frontend/src/contexts/CDSContext.js
+++ b/frontend/src/contexts/CDSContext.js
@@ -223,7 +223,10 @@ export const CDSProvider = ({ children }) => {
                 cdsLogger.debug(`CDSContext: Display behavior for ${service.id}`, displayBehavior);
                 
                 if (displayBehavior) {
-                  // Map display behavior to presentation modes
+                  // Map display behavior values to presentation modes.
+                  // Includes the modes the wizard now exposes (card,
+                  // compact, drawer) — missing entries fall back to POPUP
+                  // via the lookup default below.
                   const modeMapping = {
                     'hard-stop': PRESENTATION_MODES.MODAL,
                     'modal': PRESENTATION_MODES.MODAL,
@@ -231,7 +234,10 @@ export const CDSProvider = ({ children }) => {
                     'sidebar': PRESENTATION_MODES.SIDEBAR,
                     'inline': PRESENTATION_MODES.INLINE,
                     'banner': PRESENTATION_MODES.BANNER,
-                    'toast': PRESENTATION_MODES.TOAST
+                    'toast': PRESENTATION_MODES.TOAST,
+                    'card': PRESENTATION_MODES.CARD,
+                    'compact': PRESENTATION_MODES.COMPACT,
+                    'drawer': PRESENTATION_MODES.DRAWER
                   };
                   
                   // Check for indicator-based overrides

--- a/frontend/src/modules/cds-studio/components/builder/VisualBuilderWizard.jsx
+++ b/frontend/src/modules/cds-studio/components/builder/VisualBuilderWizard.jsx
@@ -431,6 +431,37 @@ const VisualBuilderWizard = ({ open, onClose, onSuccess }) => {
             </Select>
           </FormControl>
         </Grid>
+
+        <Grid item xs={12} md={6}>
+          <FormControl fullWidth>
+            <InputLabel>Display Mode</InputLabel>
+            <Select
+              value={serviceConfig.display_config?.presentationMode || 'popup'}
+              onChange={(e) => setServiceConfig({
+                ...serviceConfig,
+                display_config: {
+                  ...(serviceConfig.display_config || {}),
+                  presentationMode: e.target.value
+                }
+              })}
+              label="Display Mode"
+            >
+              {/* Values match PRESENTATION_MODES in CDSPresentation.js. The
+                  backend stores this on display_config; the listing
+                  endpoint maps it to displayBehavior.defaultMode and
+                  CDSHookManager picks the rendering mode from there. */}
+              <MenuItem value="popup">Popup — modal dialog (default)</MenuItem>
+              <MenuItem value="inline">Inline — within page flow</MenuItem>
+              <MenuItem value="modal">Modal — hard-stop, requires acknowledgment</MenuItem>
+              <MenuItem value="banner">Banner — sticky bar at top</MenuItem>
+              <MenuItem value="sidebar">Sidebar — fixed right-side panel</MenuItem>
+              <MenuItem value="drawer">Drawer — slide-out from right</MenuItem>
+              <MenuItem value="toast">Toast — corner notification</MenuItem>
+              <MenuItem value="card">Card — rich card display</MenuItem>
+              <MenuItem value="compact">Compact — icon with badge</MenuItem>
+            </Select>
+          </FormControl>
+        </Grid>
       </Grid>
     </Box>
   );


### PR DESCRIPTION
## Summary

Phase 2 of integrating CDS Hooks into clinical workflows. The order-select firing call was already wired (`useOrderSelectHook` in `EnhancedOrdersTab` calls `executeHook('order-select', { selections })` whenever the user's selection changes), but the resulting cards were only used for a notification badge — nothing actually rendered them. This PR captures `cards` from the hook and renders them as a compact `CDSCard` list above the urgent-orders banner.

## What changed

`frontend/src/components/clinical/workspace/tabs/EnhancedOrdersTab.js`:
- Capture `cards` and `loading` from the existing `useOrderSelectHook(...)` call (was previously called for side effects only, return value discarded).
- Render the cards as a compact `CDSCard` list, mirroring the order-sign reference implementation in `OrderSigningDialog.js:158-203`.
- Imports: `CDSCard` (Stack/Typography/Chip/CircularProgress already imported).

## Hook coverage now

| Hook | Firing | Render | Notes |
|---|---|---|---|
| `patient-view` | ✅ | ✅ | `usePatientCDSAlerts` → `ClinicalWorkspaceEnhanced` (Phase 1 routes by mode) |
| `medication-prescribe` | ✅ | ⚠️ basic | `MedicationDialogEnhanced` fires; renders as plain Alerts. Could upgrade to CDSCard. |
| `order-select` | ✅ | ✅ | This PR. |
| `order-sign` | ✅ | ✅ | `OrderSigningDialog` — the original reference impl. |

## Hooks deliberately NOT wired

`encounter-start` and `encounter-discharge` are CDS Hooks 2.0 spec hooks, but WintEHR's `EncounterCreationDialog` and `EncounterSigningDialog` aren't real workflow trigger points clinicians use as start/discharge documentation in this educational app. Wiring CDS there would put plumbing in places nobody walks. Reconsider if those workflows actually get built out.

## Depends on PR #75 (Phase 1)

Phase 2 is off Phase 1's branch. When #75 merges, this PR's diff against master will narrow to just the order-select rendering change. Either order works for merge.

## Test plan
- [x] ESLint clean on changed file (20 pre-existing warnings unrelated).
- [x] Production build succeeds.
- [x] Deployed to prod on `feat/cds-workflow-hook-firing` branch.
- [ ] Manual smoke: open a patient chart, switch to Orders tab, select one or more existing orders, confirm any service configured for `order-select` produces a card here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)