### PR TITLE
fix(cds): project entries to resources before filtering for order-select hook

### DIFF
--- a/frontend/src/components/clinical/workspace/tabs/EnhancedOrdersTab.js
+++ b/frontend/src/components/clinical/workspace/tabs/EnhancedOrdersTab.js
@@ -515,10 +515,17 @@ const EnhancedOrdersTab = ({
   const [detailsDialogOpen, setDetailsDialogOpen] = useState(false);
 
   // CDS Hooks: order-select integration
-  // Convert selected order IDs Set to array of order objects for CDS hooks
+  // Convert selected order IDs Set to array of order objects for CDS hooks.
+  // `entries` here is an array of FHIR Bundle entries (`{resource: ...}`),
+  // not flat resources — `selectedOrders` tracks `resource.id`. The earlier
+  // `entries.filter(o => selectedOrders.has(o.id))` always returned []
+  // because Bundle entries don't have a top-level `id`, so the order-select
+  // hook never fired. Project to resources first.
   const selectedOrdersArray = useMemo(() => {
     if (selectedOrders.size === 0) return [];
-    return entries.filter(order => selectedOrders.has(order.id));
+    return entries
+      .map(entry => entry.resource || entry)
+      .filter(resource => resource && selectedOrders.has(resource.id));
   }, [selectedOrders, entries]);
 
   // Trigger order-select CDS hooks when orders are selected. The hook


### PR DESCRIPTION
## Summary

Followup to #76. The render path that PR added is correct, but smoke-testing on prod surfaced a separate bug *upstream* of it: `useOrderSelectHook` never actually fired despite the React selection state updating correctly.

## The bug

`useAdvancedOrderSearch` returns `entries` as FHIR Bundle entries (`{resource: <ServiceRequest|MedicationRequest>}` wrappers), not flat resources. `selectedOrders` (the Set state in `EnhancedOrdersTab`) tracks `resource.id`. The filter:

```js
entries.filter(order => selectedOrders.has(order.id))
```

was reading `entries[i].id` — but Bundle entries don't have a top-level `id`, only `entries[i].resource.id`. Result: filter always returned `[]`, so `selectedOrdersArray` was always empty, so `useOrderSelectHook`'s `useEffect` saw `selections.length === 0` and never invoked `executeHook`. The "1 selected" badge appeared correctly but no CDS hook fired.

This bug existed before #76 — that PR's render path just made the bug visible (cards never came back to render).

## Fix

Map each entry to `entry.resource || entry` first, then filter by `resource.id`. Defensive `|| entry` so it tolerates either Bundle entries or already-flattened resources.

## Verified on prod

End-to-end: created an `order-select` test service, navigated to the orders tab, clicked an order checkbox. Network log showed `POST /api/cds-services/order-select-smoke` (request #55), and the card rendered inside the Orders tab `<main>` element (not in any dialog) — exactly the behavior #76's render path was designed for.

## Test plan
- [x] `npx eslint` clean.
- [x] Production build succeeds.
- [x] Deployed on prod, end-to-end verified via Playwright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)