### PR TITLE
feat(cds): make medication-prescribe alerts surface as CDSCards (and actually fire correctly)

### DIFF
--- a/frontend/src/components/clinical/workspace/dialogs/MedicationDialogEnhanced.js
+++ b/frontend/src/components/clinical/workspace/dialogs/MedicationDialogEnhanced.js
@@ -609,12 +609,18 @@ const MedicationDialogEnhanced = ({
         medicationDisplay: selectedMedication.display || selectedMedication.label || 'Unknown Medication'
       }));
       
-      // Evaluate CDS for drug interactions
+      // Evaluate CDS for drug interactions. Use the CDS Hooks 2.0
+      // medication-prescribe context shape: `patientId` + `userId` +
+      // `medications` (array). The previous shape (`patient` /
+      // `medication` / `context: 'prescribe'`) was non-spec — built-in
+      // services tolerated it, but visual-builder services that
+      // reference patient.age etc. couldn't read patientId from it and
+      // returned empty cards.
       try {
         const alerts = await executeCDSHooks('medication-prescribe', {
-          patient: patientId,
-          medication: selectedMedication,
-          context: 'prescribe'
+          patientId,
+          userId: user?.id || user?.username || 'unknown',
+          medications: [selectedMedication]
         });
         setCdsAlerts(alerts || []);
       } catch (error) {

--- a/frontend/src/components/clinical/workspace/dialogs/MedicationDialogEnhanced.js
+++ b/frontend/src/components/clinical/workspace/dialogs/MedicationDialogEnhanced.js
@@ -836,7 +836,7 @@ const MedicationDialogEnhanced = ({
       note: ''
     });
     setErrors({});
-    setCdsAlerts([]);
+    // cdsAlerts is now derived from context (getAlerts), no local state to clear.
     setShowAdvancedOptions(false);
     onClose();
   };

--- a/frontend/src/components/clinical/workspace/dialogs/MedicationDialogEnhanced.js
+++ b/frontend/src/components/clinical/workspace/dialogs/MedicationDialogEnhanced.js
@@ -92,7 +92,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import cdsClinicalDataService from '../../../../services/cdsClinicalDataService';
 import { fhirClient } from '../../../../core/fhir/services/fhirClient';
 import { useFHIRResource } from '../../../../contexts/FHIRResourceContext';
-import { useCDS } from '../../../../contexts/CDSContext';
+import { useCDS, CDS_HOOK_TYPES } from '../../../../contexts/CDSContext';
 import { useClinicalWorkflow } from '../../../../contexts/ClinicalWorkflowContext';
 import { useAuth } from '../../../../contexts/AuthContext';
 import CDSCard from '../../cds/CDSCard';
@@ -352,7 +352,14 @@ const MedicationDialogEnhanced = ({
   const theme = useTheme();
   const { user } = useAuth();
   const { currentPatient } = useFHIRResource();
-  const { executeCDSHooks } = useCDS();
+  const { executeCDSHooks, getAlerts } = useCDS();
+  // Pull medication-prescribe alerts directly from the CDS context.
+  // executeCDSHooks doesn't return its result (it has internal duplicate
+  // detection that early-returns), so the previous local-state pattern
+  // —`setCdsAlerts(await executeCDSHooks(…))` — was always recording
+  // []. getAlerts reads from the same context.alerts state that
+  // executeCDSHooks writes to.
+  const cdsAlerts = getAlerts(CDS_HOOK_TYPES.MEDICATION_PRESCRIBE) || [];
   const { publish } = useClinicalWorkflow();
   
   // State
@@ -361,7 +368,6 @@ const MedicationDialogEnhanced = ({
   const [loading, setLoading] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedMedication, setSelectedMedication] = useState(null);
-  const [cdsAlerts, setCdsAlerts] = useState([]);
   const [showAdvancedOptions, setShowAdvancedOptions] = useState(false);
   
   // Use consistent dialog helpers
@@ -614,18 +620,19 @@ const MedicationDialogEnhanced = ({
       // `medications` (array). The previous shape (`patient` /
       // `medication` / `context: 'prescribe'`) was non-spec — built-in
       // services tolerated it, but visual-builder services that
-      // reference patient.age etc. couldn't read patientId from it and
-      // returned empty cards.
+      // reference patient.age etc. couldn't read patientId from it
+      // and returned empty cards.
+      //
+      // Result lives in the CDSContext alerts map; we read it via
+      // getAlerts(MEDICATION_PRESCRIBE) above, no local state needed.
       try {
-        const alerts = await executeCDSHooks('medication-prescribe', {
+        await executeCDSHooks('medication-prescribe', {
           patientId,
           userId: user?.id || user?.username || 'unknown',
           medications: [selectedMedication]
         });
-        setCdsAlerts(alerts || []);
       } catch (error) {
         console.error('CDS evaluation error:', error);
-        setCdsAlerts([]);
       }
     }
     

--- a/frontend/src/components/clinical/workspace/dialogs/MedicationDialogEnhanced.js
+++ b/frontend/src/components/clinical/workspace/dialogs/MedicationDialogEnhanced.js
@@ -95,6 +95,7 @@ import { useFHIRResource } from '../../../../contexts/FHIRResourceContext';
 import { useCDS } from '../../../../contexts/CDSContext';
 import { useClinicalWorkflow } from '../../../../contexts/ClinicalWorkflowContext';
 import { useAuth } from '../../../../contexts/AuthContext';
+import CDSCard from '../../cds/CDSCard';
 import { CLINICAL_EVENTS } from '../../../../constants/clinicalEvents';
 import { useDialogSave, useDialogValidation, VALIDATION_RULES } from './utils/dialogHelpers';
 
@@ -1005,24 +1006,32 @@ const MedicationDialogEnhanced = ({
         return (
           <Fade in timeout={300}>
             <Box>
-              {/* CDS Alerts */}
+              {/* CDS Alerts — render as full CDSCards so suggestions
+                  surface their action buttons and Accept executes the
+                  proposed FHIR resource on the patient. Cards come from
+                  the medication-prescribe firing in handleNext above
+                  (`executeCDSHooks('medication-prescribe', …)`); each
+                  one already has uuid + serviceId attached by
+                  CDSContext. patientId/userId are forwarded so the
+                  feedback POST carries enough context for the runtime
+                  executor (cds_hooks_router::_execute_accepted_suggestion_actions). */}
               {cdsAlerts && cdsAlerts.length > 0 && (
                 <Box sx={{ mb: 3 }}>
-                  {cdsAlerts.map((alert, index) => (
-                    <Alert
-                      key={index}
-                      severity={alert.indicator}
-                      icon={<SmartIcon />}
-                      sx={{ mb: 1 }}
-                    >
-                      <Typography variant="body2">{alert.summary}</Typography>
-                      {alert.detail && (
-                        <Typography variant="caption" display="block" sx={{ mt: 0.5 }}>
-                          {alert.detail}
-                        </Typography>
-                      )}
-                    </Alert>
-                  ))}
+                  <Stack spacing={1}>
+                    {cdsAlerts.map((card) => (
+                      <CDSCard
+                        key={card.uuid}
+                        card={card}
+                        serviceId={card.serviceId}
+                        hookInstance={card.hookInstance}
+                        patientId={patientId}
+                        userId={user?.id || user?.username}
+                        compact={true}
+                        onAcceptSuggestion={() => {}}
+                        onDismiss={() => {}}
+                      />
+                    ))}
+                  </Stack>
                 </Box>
               )}
 


### PR DESCRIPTION
## Summary

Issue 2 from the post-merge issue list — medication-prescribe alerts rendering as plain Alerts instead of CDSCards. While fixing it, two pre-existing wiring bugs surfaced that were silently keeping medication-prescribe alerts from appearing at all for visual-builder services. Three commits in this PR, each its own fix:

| Commit | What |
|---|---|
| `a0b0290` | Replace `<Alert>` with `<CDSCard>` in step 2 of `MedicationDialogEnhanced`. Pass `patientId`/`userId` so Accept can execute actions. Same pattern as `OrderSigningDialog` (#73 reference impl) and `EnhancedOrdersTab` (#76+#77). |
| `da817d2` | Use CDS Hooks 2.0 spec context shape (`patientId`, `userId`, `medications: [...]`) instead of the previous non-spec `{patient, medication, context: 'prescribe'}`. Built-in services tolerated the old shape, but visual-builder codegen reads `context.patientId` and was returning empty cards. |
| `b73f22d` + `5bff46b` | Read `cdsAlerts` from `getAlerts(MEDICATION_PRESCRIBE)` instead of local state. `executeCDSHooks` doesn't return its result — internal duplicate-detection early-returns and the success path falls off the end — so the previous `setCdsAlerts(await executeCDSHooks(…))` always recorded `[]` even when the hook returned cards. |

## Verified on prod

End-to-end with a freshly-deployed `medication-prescribe` test service:
- Open chart → click Medications Add → pick a medication → click Next
- Network: `POST /api/cds-services/med-prescribe-smoke` returns the smoke card
- DOM: `Med-prescribe smoke alert` h6 renders above `Dosage Information` heading inside the dialog at step 2
- `Confirms CDSCard rendering in MedicationDialogEnhanced step 2.` detail text also visible

## Why this all needed three commits, not one

The path was broken in three independent places. Fixing only the rendering would have shown the same "no card visible" UX because the upstream wiring was eating the data. Each fix is small (~10-25 lines) but the layered nature of the bug needed all three to surface a card.

## Effort vs. estimate

Estimated 30-45 min in the issue plan. Actual: closer to 1.5h because of the two pre-existing bugs that needed fixing under the rendering change. Worth it — the shape and state-read fixes will help any future medication-prescribe consumer too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)