### PR TITLE
fix(cds): dedupe visual-builder discovery, upsert PlanDefinitions in place

### DIFF
--- a/backend/api/cds_hooks/cds_hooks_router.py
+++ b/backend/api/cds_hooks/cds_hooks_router.py
@@ -294,24 +294,55 @@ async def discover_services(
             # Query HAPI FHIR for all PlanDefinitions
             bundle = await hapi_client.search("PlanDefinition", search_params)
 
-            hapi_count = 0
+            # Defensive dedup by hook-service-id, keeping the most recently
+            # updated PlanDefinition. The deploy path now upserts to a stable
+            # id (vb-{service_id}) so future redeploys replace in place, but
+            # HAPI may still contain orphan PlanDefinitions from before that
+            # fix — without this, the same service shows up Nx in the discovery
+            # response and Nx in the CDS alert column on the patient chart.
+            # FHIR meta.lastUpdated is ISO 8601, so lexicographic compare works.
+            latest_by_service_id: Dict[str, Dict[str, Any]] = {}
+            duplicates_dropped = 0
             for entry in bundle.get("entry", []):
                 plan_def = entry.get("resource", {})
 
-                # Extract service-origin extension
                 origin = _extract_extension_value(
                     plan_def,
                     "http://wintehr.local/fhir/StructureDefinition/service-origin"
                 )
+                if origin not in ("external", "visual-builder"):
+                    continue
 
-                # Include external and visual-builder services from HAPI
-                # (built-in services are already in the registry above)
-                if origin in ("external", "visual-builder"):
-                    service = _plan_definition_to_cds_service(plan_def)
-                    if service:
-                        services.append(service)
-                        hapi_count += 1
+                service_id = _extract_extension_value(
+                    plan_def,
+                    "http://wintehr.local/fhir/StructureDefinition/hook-service-id",
+                    plan_def.get("id")
+                )
+                if not service_id:
+                    continue
 
+                last_updated = (plan_def.get("meta") or {}).get("lastUpdated") or ""
+                existing = latest_by_service_id.get(service_id)
+                if existing is None or last_updated > (existing.get("meta") or {}).get("lastUpdated", ""):
+                    if existing is not None:
+                        duplicates_dropped += 1
+                    latest_by_service_id[service_id] = plan_def
+                else:
+                    duplicates_dropped += 1
+
+            hapi_count = 0
+            for plan_def in latest_by_service_id.values():
+                service = _plan_definition_to_cds_service(plan_def)
+                if service:
+                    services.append(service)
+                    hapi_count += 1
+
+            if duplicates_dropped:
+                logger.warning(
+                    "Discovery dedup dropped %d duplicate PlanDefinition(s); "
+                    "consider running expunge_orphan_visual_plan_definitions.py",
+                    duplicates_dropped,
+                )
             logger.info(f"Discovered {hapi_count} external/visual-builder services from HAPI FHIR")
 
         except httpx.HTTPStatusError as e:

--- a/backend/api/cds_studio/visual_builder_router.py
+++ b/backend/api/cds_studio/visual_builder_router.py
@@ -861,11 +861,22 @@ async def deploy_visual_service(
             # PlanDefinition in HAPI for discovery. The runtime VisualServiceProvider
             # interprets the JSON config directly, so this PlanDefinition is just
             # a registry entry.
+            #
+            # Use PUT to a stable id derived from service_id so each deploy
+            # replaces in place rather than creating a new PlanDefinition.
+            # The previous `create` path stacked one PlanDefinition per
+            # deploy in HAPI, and discovery returned all of them — that's
+            # why services appeared 3× on the patient chart after a few
+            # redeploys. FHIR resource ids accept [A-Za-z0-9-.]{1,64}; a
+            # `vb-` prefix keeps these distinct from PlanDefinitions
+            # registered through other paths.
             from services.hapi_fhir_client import HAPIFHIRClient
             hapi_client = HAPIFHIRClient()
 
+            plan_def_id = f"vb-{service.service_id}"
             plan_definition = {
                 "resourceType": "PlanDefinition",
+                "id": plan_def_id,
                 "status": "active",
                 "title": service.name,
                 "description": service.description,
@@ -879,10 +890,16 @@ async def deploy_visual_service(
             }
 
             try:
-                created_plan = await hapi_client.create("PlanDefinition", plan_definition)
-                logger.info(f"Created PlanDefinition {created_plan.get('id')} for visual service {service.service_id}")
+                # HAPI's PUT to a known id is upsert: creates if absent,
+                # replaces if present. Same pattern as the CQL deploy path
+                # uses for its stable-identifier Library names.
+                upserted = await hapi_client.update("PlanDefinition", plan_def_id, plan_definition)
+                logger.info(
+                    "Upserted PlanDefinition %s for visual service %s",
+                    upserted.get('id', plan_def_id), service.service_id,
+                )
             except Exception as e:
-                logger.error(f"Failed to create PlanDefinition: {e}")
+                logger.error(f"Failed to upsert PlanDefinition: {e}")
                 # Continue deployment even if HAPI FHIR creation fails
 
         # Update deployment status

--- a/backend/scripts/active/expunge_orphan_visual_plan_definitions.py
+++ b/backend/scripts/active/expunge_orphan_visual_plan_definitions.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Expunge orphan visual-builder PlanDefinitions from HAPI.
+
+Before the deploy path was switched to upsert against a stable id
+(``vb-{service_id}``), each `Deploy` of a visual-builder service in the
+CDS Studio created a brand-new PlanDefinition in HAPI. Discovery returns
+all of them, so the same service shows up Nx in ``/api/cds-services`` and
+Nx as a card on the patient chart.
+
+This script reclaims those orphans:
+
+1. Query HAPI for every PlanDefinition with the ``service-origin``
+   extension set to ``visual-builder``.
+2. Group by the ``hook-service-id`` extension.
+3. For any group with more than one entry, keep the most recently
+   updated PlanDefinition and expunge the rest.
+
+The discovery endpoint already dedupes by hook-service-id at read time,
+so the cards stay correct without this script — but running it removes
+the wasted storage and stops the warning log.
+
+Usage:
+
+    # Dry run (default): list what would be expunged
+    python3 backend/scripts/active/expunge_orphan_visual_plan_definitions.py
+
+    # Actually expunge
+    python3 backend/scripts/active/expunge_orphan_visual_plan_definitions.py --apply
+
+    # Custom HAPI URL (defaults to HAPI_FHIR_URL env var or http://hapi-fhir:8080/fhir)
+    python3 backend/scripts/active/expunge_orphan_visual_plan_definitions.py \\
+        --hapi-url http://localhost:8888/fhir
+
+The script is safe to re-run; expunge is idempotent.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from collections import defaultdict
+from typing import Dict, Iterable, List, Optional
+
+import httpx
+
+DEFAULT_HAPI_URL = os.getenv("HAPI_FHIR_URL", "http://hapi-fhir:8080/fhir")
+SERVICE_ORIGIN_URL = "http://wintehr.local/fhir/StructureDefinition/service-origin"
+HOOK_SERVICE_ID_URL = "http://wintehr.local/fhir/StructureDefinition/hook-service-id"
+
+
+def _extension_value(resource: dict, url: str) -> Optional[str]:
+    for ext in resource.get("extension", []) or []:
+        if ext.get("url") == url:
+            return ext.get("valueString") or ext.get("valueCode")
+    return None
+
+
+def _iter_visual_plan_definitions(client: httpx.Client, hapi_url: str) -> Iterable[dict]:
+    """Yield every PlanDefinition that originated from the visual builder."""
+    url = f"{hapi_url}/PlanDefinition"
+    params = {"_count": "200", "_sort": "_lastUpdated"}
+    while url:
+        response = client.get(url, params=params)
+        response.raise_for_status()
+        bundle = response.json()
+        for entry in bundle.get("entry", []) or []:
+            resource = entry.get("resource") or {}
+            if resource.get("resourceType") != "PlanDefinition":
+                continue
+            if _extension_value(resource, SERVICE_ORIGIN_URL) != "visual-builder":
+                continue
+            yield resource
+        next_url = next(
+            (link.get("url") for link in bundle.get("link", []) if link.get("relation") == "next"),
+            None,
+        )
+        url = next_url
+        params = None
+
+
+def _expunge(client: httpx.Client, hapi_url: str, plan_def_id: str) -> None:
+    """DELETE then $expunge to fully reclaim the resource."""
+    delete_response = client.delete(f"{hapi_url}/PlanDefinition/{plan_def_id}")
+    if delete_response.status_code not in (200, 204, 404):
+        delete_response.raise_for_status()
+    response = client.post(
+        f"{hapi_url}/PlanDefinition/{plan_def_id}/$expunge",
+        json={
+            "resourceType": "Parameters",
+            "parameter": [
+                {"name": "limit", "valueInteger": 100},
+                {"name": "expungePreviousVersions", "valueBoolean": True},
+                {"name": "expungeDeletedResources", "valueBoolean": True},
+            ],
+        },
+        headers={"Content-Type": "application/fhir+json"},
+    )
+    response.raise_for_status()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--hapi-url", default=DEFAULT_HAPI_URL, help="HAPI FHIR base URL")
+    parser.add_argument("--apply", action="store_true", help="Actually expunge (default: dry run)")
+    args = parser.parse_args()
+
+    print(f"HAPI: {args.hapi_url}")
+    print(f"Mode: {'APPLY (will expunge)' if args.apply else 'DRY RUN (no changes)'}")
+    print()
+
+    groups: Dict[str, List[dict]] = defaultdict(list)
+    with httpx.Client(timeout=60.0) as client:
+        for plan_def in _iter_visual_plan_definitions(client, args.hapi_url):
+            service_id = _extension_value(plan_def, HOOK_SERVICE_ID_URL) or plan_def.get("id")
+            if not service_id:
+                continue
+            groups[service_id].append(plan_def)
+
+        expunged = 0
+        failed = 0
+        for service_id, plan_defs in sorted(groups.items()):
+            if len(plan_defs) <= 1:
+                continue
+            # Keep the most recently updated; expunge the rest.
+            plan_defs.sort(
+                key=lambda r: (r.get("meta") or {}).get("lastUpdated") or "",
+                reverse=True,
+            )
+            keeper = plan_defs[0]
+            orphans = plan_defs[1:]
+            print(f"service_id={service_id}  total={len(plan_defs)}  keeping={keeper.get('id')}")
+            for orphan in orphans:
+                orphan_id = orphan.get("id")
+                last_updated = (orphan.get("meta") or {}).get("lastUpdated") or "(unknown)"
+                print(f"  PlanDefinition/{orphan_id:32s}  last_updated={last_updated}", end="")
+                if args.apply:
+                    try:
+                        _expunge(client, args.hapi_url, orphan_id)
+                        print("  [EXPUNGED]")
+                        expunged += 1
+                    except Exception as exc:
+                        print(f"  [FAILED: {exc}]")
+                        failed += 1
+                else:
+                    print("  [would expunge]")
+                    expunged += 1
+
+    print()
+    print(f"Total {'expunged' if args.apply else 'eligible'}: {expunged}")
+    if failed:
+        print(f"Failed: {failed}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/api/cds_hooks/test_cds_hooks_router.py
+++ b/backend/tests/api/cds_hooks/test_cds_hooks_router.py
@@ -159,6 +159,62 @@ class TestCDSHooksDiscovery:
             data = response.json()
             assert data["services"] == []
 
+    def test_discover_services_dedupes_visual_builder_duplicates(self, client):
+        """Discovery dedupes by hook-service-id, keeping the latest by lastUpdated.
+
+        Before the deploy path was switched to upsert against a stable id, each
+        Deploy of a visual-builder service stacked a new PlanDefinition in HAPI.
+        Discovery now defensively dedupes so the same service doesn't appear
+        Nx in the response (and Nx as cards on the patient chart).
+        """
+        def _vb_plan_def(plan_def_id: str, last_updated: str, title: str):
+            return {
+                "resourceType": "PlanDefinition",
+                "id": plan_def_id,
+                "status": "active",
+                "title": title,
+                "meta": {"lastUpdated": last_updated},
+                "extension": [
+                    {
+                        "url": "http://wintehr.local/fhir/StructureDefinition/service-origin",
+                        "valueString": "visual-builder",
+                    },
+                    {
+                        "url": "http://wintehr.local/fhir/StructureDefinition/hook-type",
+                        "valueCode": "patient-view",
+                    },
+                    {
+                        "url": "http://wintehr.local/fhir/StructureDefinition/hook-service-id",
+                        "valueString": "duplicated-service",
+                    },
+                ],
+            }
+
+        mock_bundle = {
+            "resourceType": "Bundle",
+            "type": "searchset",
+            "entry": [
+                {"resource": _vb_plan_def("old-1", "2026-01-01T00:00:00Z", "old title")},
+                {"resource": _vb_plan_def("old-2", "2026-02-01T00:00:00Z", "older middle")},
+                {"resource": _vb_plan_def("vb-duplicated-service", "2026-05-01T00:00:00Z", "current title")},
+            ],
+        }
+
+        with patch('services.hapi_fhir_client.HAPIFHIRClient') as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client.search.return_value = mock_bundle
+            mock_client_class.return_value = mock_client
+
+            response = client.get("/cds-services?service_origin=external")
+
+            assert response.status_code == 200
+            data = response.json()
+            # Three PlanDefinitions for the same service_id collapse to one entry,
+            # and that entry is the most recently updated.
+            assert len(data["services"]) == 1
+            assert data["services"][0]["id"] == "duplicated-service"
+            assert data["services"][0]["title"] == "current title"
+
 
 class TestCDSHooksExecution:
     """Test suite for CDS service execution endpoint"""


### PR DESCRIPTION
## Why

Visual-builder services were showing up 3x in `/api/cds-services` and 3x as cards on the patient chart. Two compounding issues:

1. The deploy path POST-created a new `PlanDefinition` on every Deploy click, never expunging the old one — HAPI happily stacks them.
2. Discovery returned all of them.

Net effect for a student who clicked Deploy three times: one alert, three identical cards.

## What changed

**1. Deploy path is upsert (`backend/api/cds_studio/visual_builder_router.py`)**

Switched from `hapi_client.create("PlanDefinition", ...)` to `hapi_client.update("PlanDefinition", "vb-{service_id}", ...)`. HAPI's PUT-to-known-id is upsert — creates if absent, replaces if present. Future redeploys now overwrite in place. Same pattern the CQL deploy path uses for its stable Library names.

**2. Defensive dedup in discovery (`backend/api/cds_hooks/cds_hooks_router.py`)**

Group PlanDefinitions by the `hook-service-id` extension; keep the most recently updated. FHIR `meta.lastUpdated` is ISO 8601, so lexicographic compare works. If duplicates are dropped, log a warning so a regression of the upstream fix shows up immediately.

**3. Cleanup script (`backend/scripts/active/expunge_orphan_visual_plan_definitions.py`)**

One-shot reclamation for orphan PlanDefinitions already in HAPI from before this fix. Dry-run by default; `--apply` does DELETE + `$expunge`. Modeled on the existing `expunge_dev_libraries.py`.

## Test plan

- [x] New unit test `test_discover_services_dedupes_visual_builder_duplicates` asserts three PlanDefinitions with the same `hook-service-id` collapse to one entry, and the entry with the latest `meta.lastUpdated` wins.
- [ ] Deploy to prod (Azure), redeploy a visual-builder service three times, confirm only one PlanDefinition with id `vb-{service_id}` exists in HAPI and only one card renders on the chart.
- [ ] Run `expunge_orphan_visual_plan_definitions.py --apply` against prod once to clean the existing orphans; confirm the warning log goes silent on subsequent discovery requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)