### PR TITLE
fix(cds): suppress further calls to broken services after 5xx/404

### DIFF
--- a/frontend/src/services/__tests__/cdsHooksClient.test.js
+++ b/frontend/src/services/__tests__/cdsHooksClient.test.js
@@ -20,6 +20,7 @@ describe('CDSHooksClient', () => {
     cdsHooksClient.servicesCacheTime = null;
     cdsHooksClient.requestCache.clear();
     cdsHooksClient.inFlightRequests.clear();
+    cdsHooksClient.failedServices.clear();
   });
 
   afterAll(() => {
@@ -158,7 +159,7 @@ describe('CDSHooksClient', () => {
 
     test('should handle hook execution errors', async () => {
       const hookId = 'test-service';
-      
+
       mock.onPost(`/cds-services/${hookId}`).reply(500);
 
       const result = await cdsHooksClient.executeHook(hookId, {
@@ -167,6 +168,51 @@ describe('CDSHooksClient', () => {
       });
 
       expect(result).toEqual({ cards: [] });
+    });
+
+    test('should suppress further calls after a 5xx response', async () => {
+      const hookId = 'broken-service';
+      const context = { patientId: 'patient-1' };
+
+      mock.onPost(`/cds-services/${hookId}`).reply(503);
+
+      // First call fires and fails — that 503 hits the network.
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const first = await cdsHooksClient.executeHook(hookId, { hook: 'patient-view', context });
+      expect(first).toEqual({ cards: [] });
+      expect(mock.history.post).toHaveLength(1);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+
+      // Second call short-circuits — no new HTTP call. Use a different
+      // context to bypass the request cache so we're definitely testing
+      // the suppression path, not the cache path.
+      const second = await cdsHooksClient.executeHook(hookId, {
+        hook: 'patient-view',
+        context: { patientId: 'patient-2' },
+      });
+      expect(second).toEqual({ cards: [] });
+      expect(mock.history.post).toHaveLength(1);
+      expect(warnSpy).toHaveBeenCalledTimes(1); // logged once, not on every call
+      warnSpy.mockRestore();
+    });
+
+    test('should not suppress on a 400 (transient client error)', async () => {
+      const hookId = 'misconfigured-call';
+      const context = { patientId: 'patient-1' };
+
+      mock.onPost(`/cds-services/${hookId}`).reply(400);
+
+      await cdsHooksClient.executeHook(hookId, { hook: 'patient-view', context });
+      // Different context to dodge the request cache
+      await cdsHooksClient.executeHook(hookId, {
+        hook: 'patient-view',
+        context: { patientId: 'patient-2' },
+      });
+
+      // Both calls go over the wire — 4xx is the caller's fault, not the
+      // service's, so we don't sticky-fail it.
+      expect(mock.history.post).toHaveLength(2);
+      expect(cdsHooksClient.failedServices.has(hookId)).toBe(false);
     });
   });
 

--- a/frontend/src/services/cdsHooksClient.js
+++ b/frontend/src/services/cdsHooksClient.js
@@ -32,7 +32,17 @@ class CDSHooksClient {
     this.requestCache = new Map();
     this.requestCacheTimeout = 30 * 1000; // 30 seconds cache for individual requests
     this.lastFailureLogged = null;
-    
+
+    // Services that have failed hard (5xx, 404, network error). Once a service
+    // is in this set we short-circuit subsequent executeHook calls for it and
+    // return empty cards without going over the wire. Otherwise a broken
+    // deployed service drops a failed XHR every render and clutters the
+    // network tab forever. The Map value is the ms timestamp of the failure
+    // so we can retry after `failedServiceCooldownMs` in case the service
+    // comes back.
+    this.failedServices = new Map();
+    this.failedServiceCooldownMs = 5 * 60 * 1000; // 5 minutes
+
     // Promise deduplication for in-flight requests
     this.inFlightRequests = new Map();
     
@@ -98,7 +108,18 @@ class CDSHooksClient {
     // Create cache key from hookId and context
     const cacheKey = `${hookId}-${JSON.stringify(context)}`;
     const now = Date.now();
-    
+
+    // Short-circuit services that have already failed hard in this session.
+    // After the cooldown elapses we drop the entry and try once more — the
+    // service may have been redeployed.
+    const failedAt = this.failedServices.get(hookId);
+    if (failedAt !== undefined) {
+      if (now - failedAt < this.failedServiceCooldownMs) {
+        return { cards: [] };
+      }
+      this.failedServices.delete(hookId);
+    }
+
     // Check cache
     const cached = this.requestCache.get(cacheKey);
     if (cached && (now - cached.time < this.requestCacheTimeout)) {
@@ -145,13 +166,30 @@ class CDSHooksClient {
         return response.data;
       } catch (error) {
         // Failed to execute CDS hook - error handled gracefully with fallback
-        
+
+        // Mark the service as failed so we stop hammering it for the rest of
+        // the cooldown window. 5xx / 404 / network errors all qualify;
+        // we only suppress when the failure is structural rather than a
+        // transient network blip. The first occurrence logs once so a
+        // student running locally still notices something is wrong.
+        const status = error.response?.status;
+        const shouldSuppress = !status || status >= 500 || status === 404;
+        if (shouldSuppress && !this.failedServices.has(hookId)) {
+          this.failedServices.set(hookId, Date.now());
+          console.warn(
+            `[CDSHooksClient] Suppressing further calls to "${hookId}" for `
+            + `${this.failedServiceCooldownMs / 1000}s after `
+            + (status ? `HTTP ${status}` : 'network error')
+            + '. Check the service deployment if this persists.'
+          );
+        }
+
         // Check if we have cached data for this request
         const cached = this.requestCache.get(cacheKey);
         if (cached) {
           return cached.data;
         }
-        
+
         return { cards: [] };
       } finally {
         // Clean up the in-flight request


### PR DESCRIPTION
## Why

Three deployed visual-builder services (\`patient-greeter\`, \`asduads\`, \`PneumococcalVaccineReminder\`) are 503-ing on prod every patient open, and the failed XHRs pile up in the network tab on every render. The cards themselves were already suppressed via the existing \`catch\` in \`executeHook\`, but the wire calls kept firing.

## What changed

\`cdsHooksClient.executeHook\` now tracks failed services in an in-memory \`Map\` with a 5-minute cooldown. After a hard failure, subsequent calls short-circuit before reaching the network and return \`{ cards: [] }\`. The first failure logs ONCE so a student running locally still gets a signal, then we go quiet until the cooldown elapses.

What counts as a hard failure: \`5xx\`, \`404\`, or network error. \`4xx\` (excluding 404) is treated as a transient/caller-side issue and does NOT sticky-fail — the next call goes over the wire normally.

## Out of scope (deliberate)

Identifying *why* each of the three services is currently 503-ing on prod and deciding fix-vs-delete per service. That triage needs prod log access and is separate from the client-side suppression. This change is the floor-it-doesn't-spam fix that helps regardless of which services are currently broken — and it generalizes to any future service that breaks.

## Test plan

- [x] Two new unit tests under \`Hook Execution\`:
  - asserts the second call short-circuits after a 503 and \`console.warn\` fires only once
  - asserts a 400 doesn't sticky-fail and the next call still goes over the wire
- [ ] Manual: open a patient on prod, confirm the network tab shows ONE failed call per broken service (not one per render). Wait 5 min, refresh, confirm the request fires again.

## Notes for reviewer

- The cooldown duration (5 min) is a guess — long enough that a redeploy that fixes the service is observable, short enough that you don't have to refresh-and-wait forever after fixing it.
- The pre-existing test infra (axios + axios-mock-adapter import) was already broken under jest in this file — the tests are documented but not currently runnable in CI. Out of scope to fix here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)