### PR TITLE
feat(cds): /api/cds-debug/{service_id} read-only triage endpoint

### DIFF
--- a/backend/api/cds_hooks/cds_hooks_router.py
+++ b/backend/api/cds_hooks/cds_hooks_router.py
@@ -1029,6 +1029,292 @@ async def analyze_prefetch_patterns(
         raise HTTPException(status_code=500, detail="Failed to analyze prefetch patterns")
 
 
+# Debug / Diagnostic Endpoint
+@router.get("/cds-debug/{service_id}")
+async def diagnose_service(
+    service_id: str,
+    db: AsyncSession = Depends(get_db_session),
+):
+    """Read-only triage for a CDS service that isn't producing cards.
+
+    Walks the same path execute_service walks and reports what was found
+    at each stage. Always returns 200 — the response body is the report,
+    not the result of executing the service. Safe to call on prod since
+    no PHI is touched and no resource is mutated.
+
+    Stages reported:
+      - registry          v3.0 ServiceRegistry hit?
+      - hapi_plan_definition  Direct read by id, then extension search
+      - duplicates        Count of PlanDefinitions sharing this hook-service-id
+      - external_service  metadata row in external_services.services (when origin=external)
+      - visual_config     VisualServiceConfig row (when origin=visual-builder)
+      - cql_libraries     For cql-based: each library reference is resolved
+                          against HAPI to see if it still exists
+      - diagnosis         Human-readable summary
+    """
+    from services.hapi_fhir_client import HAPIFHIRClient
+    from sqlalchemy import select
+
+    report: Dict[str, Any] = {
+        "service_id": service_id,
+        "checks": {
+            "registry": {"found": False, "title": None},
+            "hapi_plan_definition": {
+                "found": False,
+                "id": None,
+                "method": None,  # "direct_read" | "extension_search"
+                "service_origin": None,
+                "hook_type": None,
+                "library_refs": [],
+            },
+            "duplicates": {"count": 0, "ids": []},
+            "external_service": None,
+            "visual_config": None,
+            "cql_libraries": None,
+        },
+        "diagnosis": None,
+    }
+    diagnosis_parts: List[str] = []
+
+    # 1. Registry lookup
+    registry = get_registry()
+    registered = registry.get(service_id)
+    if registered is not None:
+        report["checks"]["registry"]["found"] = True
+        report["checks"]["registry"]["title"] = getattr(registered, "title", None)
+
+    # 2. HAPI lookup (direct read first, then extension search) +
+    #    duplicate count.
+    hapi_client = HAPIFHIRClient()
+    plan_definition: Optional[Dict[str, Any]] = None
+
+    try:
+        plan_definition = await hapi_client.read("PlanDefinition", service_id)
+        report["checks"]["hapi_plan_definition"]["method"] = "direct_read"
+    except Exception:
+        # 404 / other read errors fall through to the search path.
+        pass
+
+    # Extension search runs unconditionally so we can also count duplicates.
+    try:
+        bundle = await hapi_client.search(
+            "PlanDefinition", {"status": "active", "_count": 200}
+        )
+        matches: List[Dict[str, Any]] = []
+        for entry in bundle.get("entry", []) or []:
+            resource = entry.get("resource") or {}
+            ext_id = _extract_extension_value(
+                resource,
+                "http://wintehr.local/fhir/StructureDefinition/hook-service-id",
+            )
+            if ext_id == service_id:
+                matches.append(resource)
+
+        if matches:
+            # Sort by lastUpdated descending so the freshest one wins for the
+            # primary report (matches what discover_services dedup picks).
+            matches.sort(
+                key=lambda r: (r.get("meta") or {}).get("lastUpdated") or "",
+                reverse=True,
+            )
+            if plan_definition is None:
+                plan_definition = matches[0]
+                report["checks"]["hapi_plan_definition"]["method"] = "extension_search"
+            report["checks"]["duplicates"]["count"] = len(matches)
+            report["checks"]["duplicates"]["ids"] = [r.get("id") for r in matches]
+    except Exception as exc:
+        diagnosis_parts.append(f"HAPI extension search failed: {exc}")
+
+    if plan_definition is not None:
+        report["checks"]["hapi_plan_definition"]["found"] = True
+        report["checks"]["hapi_plan_definition"]["id"] = plan_definition.get("id")
+        report["checks"]["hapi_plan_definition"]["service_origin"] = (
+            _extract_extension_value(
+                plan_definition,
+                "http://wintehr.local/fhir/StructureDefinition/service-origin",
+            )
+        )
+        report["checks"]["hapi_plan_definition"]["hook_type"] = (
+            _extract_extension_value(
+                plan_definition,
+                "http://wintehr.local/fhir/StructureDefinition/hook-type",
+            )
+        )
+        report["checks"]["hapi_plan_definition"]["library_refs"] = list(
+            plan_definition.get("library") or []
+        )
+
+    # 3. Origin-specific deeper checks. Mirror execute_service's routing.
+    origin = report["checks"]["hapi_plan_definition"]["service_origin"]
+
+    if origin == "external" and plan_definition is not None:
+        external_service_id = _extract_extension_value(
+            plan_definition,
+            "http://wintehr.local/fhir/StructureDefinition/external-service-id",
+        )
+        report["checks"]["external_service"] = {
+            "external_service_id": external_service_id,
+            "metadata_row_found": False,
+            "auto_disabled": None,
+            "consecutive_failures": None,
+            "last_error_message": None,
+        }
+        if external_service_id:
+            try:
+                row = (
+                    await db.execute(
+                        text(
+                            "SELECT auto_disabled, consecutive_failures, "
+                            "last_error_message "
+                            "FROM external_services.services "
+                            "WHERE id = :id LIMIT 1"
+                        ),
+                        {"id": external_service_id},
+                    )
+                ).mappings().first()
+                if row:
+                    report["checks"]["external_service"]["metadata_row_found"] = True
+                    report["checks"]["external_service"]["auto_disabled"] = row[
+                        "auto_disabled"
+                    ]
+                    report["checks"]["external_service"]["consecutive_failures"] = row[
+                        "consecutive_failures"
+                    ]
+                    report["checks"]["external_service"]["last_error_message"] = row[
+                        "last_error_message"
+                    ]
+                else:
+                    diagnosis_parts.append(
+                        "External service has no metadata row "
+                        "(external_services.services). Likely deleted."
+                    )
+            except Exception as exc:
+                diagnosis_parts.append(f"Could not read external service row: {exc}")
+        else:
+            diagnosis_parts.append(
+                "PlanDefinition is tagged service-origin=external but missing "
+                "the external-service-id extension."
+            )
+
+    elif origin == "visual-builder" and plan_definition is not None:
+        from api.cds_studio.visual_service_config import (
+            VisualServiceConfig,
+            is_cql_service_type,
+        )
+
+        visual_service_id = _extract_extension_value(
+            plan_definition,
+            "http://wintehr.local/fhir/StructureDefinition/visual-service-id",
+        )
+        vc_report: Dict[str, Any] = {
+            "visual_service_id": visual_service_id,
+            "config_row_found": False,
+            "service_type": None,
+            "is_cql": False,
+        }
+        if visual_service_id:
+            try:
+                config = (
+                    await db.execute(
+                        select(VisualServiceConfig).where(
+                            VisualServiceConfig.id == int(visual_service_id)
+                        )
+                    )
+                ).scalar_one_or_none()
+                if config is not None:
+                    vc_report["config_row_found"] = True
+                    vc_report["service_type"] = config.service_type
+                    vc_report["is_cql"] = is_cql_service_type(config.service_type)
+                else:
+                    diagnosis_parts.append(
+                        f"VisualServiceConfig row {visual_service_id} not found "
+                        "— execute_service would 500 with 'Visual service not configured'."
+                    )
+            except Exception as exc:
+                diagnosis_parts.append(
+                    f"Could not read VisualServiceConfig row: {exc}"
+                )
+        else:
+            diagnosis_parts.append(
+                "PlanDefinition is tagged service-origin=visual-builder but "
+                "missing the visual-service-id extension."
+            )
+        report["checks"]["visual_config"] = vc_report
+
+        # CQL-specific: check that each library reference resolves.
+        if vc_report["is_cql"]:
+            library_refs = report["checks"]["hapi_plan_definition"]["library_refs"]
+            cql_report: List[Dict[str, Any]] = []
+            if not library_refs:
+                diagnosis_parts.append(
+                    "CQL service but PlanDefinition.library[] is empty — "
+                    "$apply will return no actions."
+                )
+            for ref in library_refs:
+                # The reference is a canonical URL. The Library.id is the last
+                # path segment. Try to read it directly; fall back to a url
+                # search if the canonical doesn't match the id.
+                tail = ref.rsplit("/", 1)[-1] if isinstance(ref, str) else None
+                resolution: Dict[str, Any] = {
+                    "reference": ref,
+                    "exists_in_hapi": False,
+                    "resolved_id": None,
+                }
+                if tail:
+                    try:
+                        lib = await hapi_client.read("Library", tail)
+                        if lib:
+                            resolution["exists_in_hapi"] = True
+                            resolution["resolved_id"] = lib.get("id")
+                    except Exception:
+                        pass
+                if not resolution["exists_in_hapi"] and isinstance(ref, str):
+                    try:
+                        b = await hapi_client.search("Library", {"url": ref})
+                        for e in b.get("entry", []) or []:
+                            r = e.get("resource") or {}
+                            if r.get("resourceType") == "Library":
+                                resolution["exists_in_hapi"] = True
+                                resolution["resolved_id"] = r.get("id")
+                                break
+                    except Exception:
+                        pass
+                if not resolution["exists_in_hapi"]:
+                    diagnosis_parts.append(
+                        f"PlanDefinition references Library {ref!r} which does "
+                        "not exist in HAPI. $apply will fail; runtime returns "
+                        "empty cards via the catch-all."
+                    )
+                cql_report.append(resolution)
+            report["checks"]["cql_libraries"] = cql_report
+
+    elif plan_definition is None and not report["checks"]["registry"]["found"]:
+        diagnosis_parts.append(
+            "Service not found in either the registry or HAPI. "
+            "Discovery would return it as nonexistent; execute returns 404."
+        )
+
+    # 4. Pre-PR-79 duplicate stacking warning.
+    if report["checks"]["duplicates"]["count"] > 1:
+        diagnosis_parts.append(
+            f"{report['checks']['duplicates']['count']} PlanDefinitions share "
+            "this hook-service-id. Discovery dedupes on read (since "
+            "PR #79) but the orphans should be reclaimed via "
+            "expunge_orphan_visual_plan_definitions.py --apply."
+        )
+
+    if not diagnosis_parts:
+        diagnosis_parts.append(
+            "No structural problem detected. If the service is still not "
+            "producing cards, the issue is in the runtime path — check "
+            "backend logs for $apply errors or condition-tree evaluation "
+            "warnings during a real hook fire."
+        )
+
+    report["diagnosis"] = " ".join(diagnosis_parts)
+    return report
+
+
 # Service Management Endpoints (for CRUD operations)
 @router.get("/services", response_model=List[HookConfiguration])
 async def list_services(

--- a/backend/tests/api/cds_hooks/test_cds_hooks_router.py
+++ b/backend/tests/api/cds_hooks/test_cds_hooks_router.py
@@ -474,3 +474,83 @@ class TestExecutionLogging:
             call_kwargs = mock_log.call_args.kwargs
             assert "execution_time_ms" in call_kwargs
             assert call_kwargs["execution_time_ms"] >= 0
+
+
+class TestCDSDebugEndpoint:
+    """Tests for the /cds-debug/{service_id} read-only triage endpoint."""
+
+    @pytest.fixture
+    def app(self):
+        app = FastAPI()
+        app.include_router(router)
+        return app
+
+    @pytest.fixture
+    def client(self, app):
+        return TestClient(app)
+
+    def test_diagnose_service_not_found_anywhere(self, client):
+        """Empty registry + empty HAPI → diagnosis says service is missing."""
+        empty_bundle = {
+            "resourceType": "Bundle",
+            "type": "searchset",
+            "entry": [],
+        }
+        with patch('services.hapi_fhir_client.HAPIFHIRClient') as mock_hapi:
+            mock_client = AsyncMock()
+            mock_client.read.side_effect = Exception("not found")
+            mock_client.search.return_value = empty_bundle
+            mock_hapi.return_value = mock_client
+
+            response = client.get("/cds-debug/totally-fake-service")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["service_id"] == "totally-fake-service"
+        assert data["checks"]["registry"]["found"] is False
+        assert data["checks"]["hapi_plan_definition"]["found"] is False
+        assert "not found" in data["diagnosis"].lower()
+
+    def test_diagnose_service_reports_duplicates(self, client):
+        """Three PlanDefinitions sharing one hook-service-id → duplicates count + warning."""
+        def vb_pd(plan_def_id, last_updated):
+            return {
+                "resourceType": "PlanDefinition",
+                "id": plan_def_id,
+                "meta": {"lastUpdated": last_updated},
+                "extension": [
+                    {
+                        "url": "http://wintehr.local/fhir/StructureDefinition/service-origin",
+                        "valueString": "visual-builder",
+                    },
+                    {
+                        "url": "http://wintehr.local/fhir/StructureDefinition/hook-service-id",
+                        "valueString": "stacked-service",
+                    },
+                ],
+            }
+
+        bundle = {
+            "resourceType": "Bundle",
+            "type": "searchset",
+            "entry": [
+                {"resource": vb_pd("old-1", "2026-01-01T00:00:00Z")},
+                {"resource": vb_pd("old-2", "2026-02-01T00:00:00Z")},
+                {"resource": vb_pd("vb-stacked-service", "2026-05-01T00:00:00Z")},
+            ],
+        }
+
+        with patch('services.hapi_fhir_client.HAPIFHIRClient') as mock_hapi:
+            mock_client = AsyncMock()
+            mock_client.read.side_effect = Exception("not found")
+            mock_client.search.return_value = bundle
+            mock_hapi.return_value = mock_client
+
+            response = client.get("/cds-debug/stacked-service")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["checks"]["duplicates"]["count"] == 3
+        # The freshest one wins as the primary report.
+        assert data["checks"]["hapi_plan_definition"]["id"] == "vb-stacked-service"
+        assert "share" in data["diagnosis"]  # "N PlanDefinitions share this hook-service-id"


### PR DESCRIPTION
## Why

When a CDS service stops producing cards, the failure is hidden behind two layers of catch-alls (the frontend \`executeHook\` swallows errors; the backend \`execute_service\` catch returns empty cards on \`httpx.HTTPStatusError\`). Triaging "why is this service broken?" required SSH'ing to prod and reading logs — and even then, the path through registry → HAPI → config row → Library resolution is enough hops that the answer wasn't always obvious.

This endpoint reproduces the routing logic in \`execute_service\` and reports what each stage found, so the answer becomes a single \`curl\`.

## What it reports

- **registry** — was it found in the v3.0 \`ServiceRegistry\`? (built-in services live here)
- **hapi_plan_definition** — found via direct id read or extension search? what's the \`service-origin\` and \`hook-type\`? what \`library[]\` references does it carry?
- **duplicates** — count of PlanDefinitions sharing this \`hook-service-id\` (warns about pre-PR-79 stacking)
- **external_service** — for \`origin=external\`: does the row in \`external_services.services\` still exist? is it auto-disabled?
- **visual_config** — for \`origin=visual-builder\`: does the \`VisualServiceConfig\` row still exist? what's its \`service_type\`?
- **cql_libraries** — for \`cql-based\`: each \`library[]\` reference is read back from HAPI to confirm it still exists. The most common CQL breakage is a PD whose \`Library\` got expunged.
- **diagnosis** — concatenated human-readable summary

Always returns 200; the response body is the report, not the result of executing the service. No PHI, no mutation; safe on prod.

## Usage

\`\`\`bash
curl -s https://wintehr.eastus2.cloudapp.azure.com/api/cds-debug/PneumococcalVaccineReminder | jq .
\`\`\`

Sample shape:
\`\`\`json
{
  "service_id": "PneumococcalVaccineReminder",
  "checks": {
    "registry": { "found": false, "title": null },
    "hapi_plan_definition": {
      "found": true,
      "id": "vb-PneumococcalVaccineReminder",
      "method": "extension_search",
      "service_origin": "visual-builder",
      "hook_type": "patient-view",
      "library_refs": ["http://wintehr.org/Library/PneumococcalVaccineReminderV100"]
    },
    "duplicates": { "count": 1, "ids": ["vb-PneumococcalVaccineReminder"] },
    "visual_config": { "config_row_found": true, "service_type": "cql-based", "is_cql": true },
    "cql_libraries": [
      { "reference": "http://...PneumococcalVaccineReminderV100", "exists_in_hapi": false, "resolved_id": null }
    ]
  },
  "diagnosis": "PlanDefinition references Library 'http://...V100' which does not exist in HAPI. \$apply will fail; runtime returns empty cards via the catch-all."
}
\`\`\`

## Test plan

- [x] Two new unit tests under \`TestCDSDebugEndpoint\`:
  - service not found in registry or HAPI → \`diagnosis\` flags it as missing
  - three PlanDefinitions sharing one \`hook-service-id\` → \`duplicates.count == 3\`, freshest wins as primary report
- [ ] Manual: hit the endpoint on prod for the three known-broken services (\`patient-greeter\`, \`asduads\`, \`PneumococcalVaccineReminder\`); the report should pinpoint each failure mode.

## Notes for reviewer

- The endpoint is unauthenticated. The educational platform doesn't gate diagnostic endpoints in general (see \`api/system/health.py\`, \`api/system/debug_router.py\`). If we want to bring this in line with a tighter prod policy later, we can wrap with the same gate the rest of \`/api/system/*\` uses — separate change.
- The duplicate count uses the \`hook-service-id\` extension specifically, not the PD id. Built-in PDs loaded by \`load_cds_services_to_hapi.py\` use a different extension URL (\`.org\` instead of \`.local\`) and don't show up in the duplicate count. That's intentional — they're distinct from the visual-builder/external stacking we care about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)