### PR TITLE
fix(nginx): bump rate limits so a normal chart open doesn't trip them

### DIFF
--- a/nginx-prod.conf
+++ b/nginx-prod.conf
@@ -33,13 +33,17 @@ http {
                application/rss+xml font/truetype font/opentype
                application/vnd.ms-fontobject image/svg+xml;
 
-    # Rate limiting
-    limit_req_zone $binary_remote_addr zone=api_limit:10m rate=10r/s;
-    limit_req_zone $binary_remote_addr zone=general_limit:10m rate=100r/s;
-    # CDS hooks fire in parallel on patient-view / order-select / etc. — opening
-    # one patient chart can generate 10–20+ concurrent POSTs across registered
-    # services. Needs a much higher rate ceiling than normal API traffic.
-    limit_req_zone $binary_remote_addr zone=cds_limit:10m rate=50r/s;
+    # Rate limiting — sized for a classroom-shared NAT IP, not a public-facing
+    # service. The denominator is $binary_remote_addr, so all students behind
+    # one school/VPN egress share these budgets. A single chart open already
+    # fires 30+ requests in milliseconds across /api/, /fhir/, and CDS hooks;
+    # the previous values (10 r/s / burst 20 on /api/) tripped the limiter
+    # on legitimate traffic. These ceilings are loose enough that real
+    # interactions never hit them, but tight enough that a runaway frontend
+    # render loop trips after a few seconds rather than DoSing the backend.
+    limit_req_zone $binary_remote_addr zone=api_limit:10m rate=100r/s;
+    limit_req_zone $binary_remote_addr zone=general_limit:10m rate=200r/s;
+    limit_req_zone $binary_remote_addr zone=cds_limit:10m rate=100r/s;
 
     # WebSocket connection upgrade mapping
     map $http_upgrade $connection_upgrade {
@@ -143,14 +147,11 @@ http {
             proxy_buffering off;
         }
 
-        # CDS Hooks endpoints — more permissive rate limit because a single
-        # patient chart open fires a parallel POST to every registered service
-        # at once (patient-view / order-select / encounter-start hooks).
-        # The old api_limit (10r/s + 20 burst) rejected anything past the 7th
-        # concurrent CDS service with 503s, which only surfaced once users
-        # added visual-builder services on top of the built-in ones.
+        # CDS Hooks endpoints — kept on a dedicated zone so a CDS-fanout burst
+        # can't starve the rest of the API budget. A single patient chart open
+        # fires a parallel POST to every registered service.
         location /api/cds-services {
-            limit_req zone=cds_limit burst=50 nodelay;
+            limit_req zone=cds_limit burst=100 nodelay;
 
             proxy_pass http://backend;
             proxy_http_version 1.1;
@@ -164,7 +165,7 @@ http {
 
         # Backend API
         location /api/ {
-            limit_req zone=api_limit burst=20 nodelay;
+            limit_req zone=api_limit burst=200 nodelay;
 
             proxy_pass http://backend;
             proxy_http_version 1.1;
@@ -204,7 +205,7 @@ http {
 
         # DICOM Services
         location /dicom/ {
-            limit_req zone=api_limit burst=20 nodelay;
+            limit_req zone=api_limit burst=100 nodelay;
 
             proxy_pass http://backend/dicom/;
             proxy_http_version 1.1;
@@ -221,7 +222,7 @@ http {
         # FHIR Server - Route through FastAPI backend for SMART token validation
         # Backend proxy (api/fhir/proxy.py) forwards validated requests to HAPI FHIR
         location /fhir/R4/ {
-            limit_req zone=api_limit burst=30 nodelay;
+            limit_req zone=api_limit burst=200 nodelay;
 
             # Handle CORS preflight
             if ($request_method = 'OPTIONS') {
@@ -251,7 +252,7 @@ http {
 
         # FHIR Server - Standard /fhir/ path (also through FastAPI for SMART validation)
         location /fhir/ {
-            limit_req zone=api_limit burst=30 nodelay;
+            limit_req zone=api_limit burst=200 nodelay;
 
             # Handle CORS preflight
             if ($request_method = 'OPTIONS') {


### PR DESCRIPTION
## Why

A single chart open on a real Synthea patient fires 30+ requests in milliseconds across `/api/`, `/fhir/`, and CDS hooks. The previous `api_limit` budget (10 r/s + burst 20) was set up for sparse human traffic, not the SPA's actual fan-out.

**Verified on prod today:** opening an 83-yo patient (4e8d6963…) returned 503 on 3 of 8 patient-view CDS POSTs with `limiting requests, excess: 20.470 by zone "api_limit"`. That's the source of the long-mysterious "patient-greeter / asduads / PneumococcalVaccineReminder return 503" symptom — the services themselves work; nginx was throttling.

Multiple students behind a school NAT egress also share these per-IP zones, so the denominator is "per classroom" in practice, not "per user."

## Bumps

| Setting | Before | After |
|---|---|---|
| zone `api_limit` rate | 10 r/s | 100 r/s |
| zone `general_limit` rate | 100 r/s | 200 r/s |
| zone `cds_limit` rate | 50 r/s | 100 r/s |
| `/api/` burst | 20 | 200 |
| `/api/cds-services` burst | 50 | 100 |
| `/dicom/` burst | 20 | 100 |
| `/fhir/R4/` burst | 30 | 200 |
| `/fhir/` burst | 30 | 200 |

## Why keep `limit_req` at all

A runaway frontend render loop would still trip the limiter after a few seconds rather than DoSing the backend indefinitely. Loose-but-present is cheaper than removing it entirely and rebuilding it the next time someone wires an infinite useEffect.

## Test plan

- [x] `nginx -t` against the running container (syntax OK)
- [ ] Deploy + recreate nginx (PR #B will automate this); chart-open the same 83-yo patient on prod and confirm all 8 services return 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)