### PR TITLE
fix(deploy): force-recreate nginx when its config is newer than the container

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -426,6 +426,32 @@ docker_compose up -d
 echo -e "${GREEN}✅ Services started${NC}"
 echo ""
 
+# Step 2a: Refresh nginx if its bind-mounted config is newer than the
+# running container. Background: nginx-prod.conf is bind-mounted as a
+# single file. When git pull or an editor rewrites the file via temp +
+# rename, the inode changes — but the running nginx container is pinned
+# to the original (now orphaned) inode and never sees the new content.
+# Even `nginx -s reload` reads the stale inode. The only way to pick up
+# the new config is to recreate the container so the bind mount
+# resolves the new inode. Without this guard, perfectly good nginx
+# config changes ship to master and silently sit unread on prod for
+# days.
+if [ -f "nginx-prod.conf" ] && docker inspect emr-nginx >/dev/null 2>&1; then
+    conf_mtime=$(stat -c %Y nginx-prod.conf 2>/dev/null || stat -f %m nginx-prod.conf)
+    started_at=$(docker inspect emr-nginx --format '{{.State.StartedAt}}')
+    started_epoch=$(
+        date -d "$started_at" +%s 2>/dev/null \
+        || python3 -c "import datetime,sys; print(int(datetime.datetime.fromisoformat(sys.argv[1].replace('Z','+00:00')).timestamp()))" "$started_at" 2>/dev/null \
+        || echo 0
+    )
+    if [ -n "$conf_mtime" ] && [ "$started_epoch" != "0" ] && [ "$conf_mtime" -gt "$started_epoch" ]; then
+        echo -e "${YELLOW}🔄 nginx-prod.conf is newer than the running nginx container; recreating to pick it up...${NC}"
+        docker_compose up -d --force-recreate nginx
+        echo -e "${GREEN}✅ nginx recreated${NC}"
+        echo ""
+    fi
+fi
+
 # Step 2.5: Sync PostgreSQL password with .env
 # This fixes an issue where PostgreSQL was initialized with a different password
 # than what's currently in .env (init scripts only run on first database creation)


### PR DESCRIPTION
## Why

\`nginx-prod.conf\` is bind-mounted as a single file. When \`git pull\` or an editor rewrites it via temp + rename (the standard atomic-write pattern), the on-disk inode changes — but the running nginx container is pinned to the original orphaned inode and never sees the new content. Even \`nginx -s reload\` from inside the container reads the stale view.

**Found this the hard way today:** the \`cds_limit\` zone fix in 1a2e7c0b4 (Apr 24) had been sitting unread on prod for 9 days because \`deploy.sh\`'s \`up -d\` decided nginx had "no change" and didn't recreate it. The fix was in the file but never executed. This PR closes that footgun.

## What it does

After the main \`up -d\`, compare \`nginx-prod.conf\`'s mtime against the nginx container's \`StartedAt\`. If the file is newer, force-recreate nginx so the bind mount resolves the new inode.

- No-op when the config hasn't changed (vast majority of deploys).
- ~2-second restart when it has, no observable downtime for other services.
- Cross-platform date parsing: GNU \`date -d\`, falling back to BSD-style \`stat -f\`, falling back to Python \`datetime.fromisoformat\`.

## Test plan

- [x] \`bash -n deploy.sh\` syntax check
- [x] Manual trace of mtime / started_epoch comparison logic
- [ ] Apply on prod, run \`./deploy.sh\` once with no nginx changes (should be no-op), once with a touched nginx-prod.conf (should recreate)

## Notes for reviewer

Alternative considered: switch to a directory bind mount so file rewrites are visible to the container. That would require restructuring \`/etc/nginx/conf.d/\` and is a larger change. The recreate guard is a few lines and solves the same problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)