### PR TITLE
fix(cds): differentiate failure categories in suppression cooldown

### DIFF
--- a/frontend/src/services/__tests__/cdsHooksClient.test.js
+++ b/frontend/src/services/__tests__/cdsHooksClient.test.js
@@ -170,47 +170,81 @@ describe('CDSHooksClient', () => {
       expect(result).toEqual({ cards: [] });
     });
 
-    test('should suppress further calls after a 5xx response', async () => {
+    test('should suppress further calls after a 5xx, with 60s cooldown', async () => {
       const hookId = 'broken-service';
       const context = { patientId: 'patient-1' };
 
       mock.onPost(`/cds-services/${hookId}`).reply(503);
 
-      // First call fires and fails — that 503 hits the network.
       const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
       const first = await cdsHooksClient.executeHook(hookId, { hook: 'patient-view', context });
       expect(first).toEqual({ cards: [] });
       expect(mock.history.post).toHaveLength(1);
       expect(warnSpy).toHaveBeenCalledTimes(1);
 
-      // Second call short-circuits — no new HTTP call. Use a different
-      // context to bypass the request cache so we're definitely testing
-      // the suppression path, not the cache path.
+      // Second call short-circuits — no new HTTP call. Different context
+      // bypasses the request cache so we're definitely testing the
+      // suppression path, not the cache path.
       const second = await cdsHooksClient.executeHook(hookId, {
         hook: 'patient-view',
         context: { patientId: 'patient-2' },
       });
       expect(second).toEqual({ cards: [] });
       expect(mock.history.post).toHaveLength(1);
-      expect(warnSpy).toHaveBeenCalledTimes(1); // logged once, not on every call
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+
+      // Cooldown for 5xx is short — 60s. Verify the entry carries that
+      // cooldown rather than the 5-min one used for 404s.
+      const entry = cdsHooksClient.failedServices.get(hookId);
+      expect(entry.cooldownMs).toBe(cdsHooksClient.FAILED_COOLDOWN_5XX_MS);
+
       warnSpy.mockRestore();
     });
 
-    test('should not suppress on a 400 (transient client error)', async () => {
+    test('should suppress 404 with the long 5-min cooldown', async () => {
+      const hookId = 'gone-service';
+      const context = { patientId: 'patient-1' };
+
+      mock.onPost(`/cds-services/${hookId}`).reply(404);
+
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      await cdsHooksClient.executeHook(hookId, { hook: 'patient-view', context });
+      warnSpy.mockRestore();
+
+      // 404 means the service genuinely doesn't exist — long cooldown
+      // because retrying soon won't help.
+      const entry = cdsHooksClient.failedServices.get(hookId);
+      expect(entry.cooldownMs).toBe(cdsHooksClient.FAILED_COOLDOWN_404_MS);
+      expect(entry.cooldownMs).toBeGreaterThan(cdsHooksClient.FAILED_COOLDOWN_5XX_MS);
+    });
+
+    test('should NOT sticky-fail on a network error', async () => {
+      const hookId = 'flaky-network';
+      const context = { patientId: 'patient-1' };
+
+      mock.onPost(`/cds-services/${hookId}`).networkError();
+
+      await cdsHooksClient.executeHook(hookId, { hook: 'patient-view', context });
+
+      // Network blips (offline, DNS, transient) shouldn't lock out a
+      // working service — the next render's request gets to try fresh.
+      expect(cdsHooksClient.failedServices.has(hookId)).toBe(false);
+    });
+
+    test('should not suppress on a 400 (caller-side error)', async () => {
       const hookId = 'misconfigured-call';
       const context = { patientId: 'patient-1' };
 
       mock.onPost(`/cds-services/${hookId}`).reply(400);
 
       await cdsHooksClient.executeHook(hookId, { hook: 'patient-view', context });
-      // Different context to dodge the request cache
       await cdsHooksClient.executeHook(hookId, {
         hook: 'patient-view',
         context: { patientId: 'patient-2' },
       });
 
-      // Both calls go over the wire — 4xx is the caller's fault, not the
-      // service's, so we don't sticky-fail it.
+      // 4xx (other than 404) is the caller's fault, not the service's,
+      // so we don't sticky-fail it.
       expect(mock.history.post).toHaveLength(2);
       expect(cdsHooksClient.failedServices.has(hookId)).toBe(false);
     });

--- a/frontend/src/services/cdsHooksClient.js
+++ b/frontend/src/services/cdsHooksClient.js
@@ -33,15 +33,19 @@ class CDSHooksClient {
     this.requestCacheTimeout = 30 * 1000; // 30 seconds cache for individual requests
     this.lastFailureLogged = null;
 
-    // Services that have failed hard (5xx, 404, network error). Once a service
-    // is in this set we short-circuit subsequent executeHook calls for it and
-    // return empty cards without going over the wire. Otherwise a broken
-    // deployed service drops a failed XHR every render and clutters the
-    // network tab forever. The Map value is the ms timestamp of the failure
-    // so we can retry after `failedServiceCooldownMs` in case the service
-    // comes back.
+    // Suppress further calls to a service that just failed, so a broken
+    // service doesn't drop a failed XHR on every React render. The cooldown
+    // depends on the failure category — see executeHook():
+    //   - 404: stick for FAILED_COOLDOWN_404_MS — service genuinely doesn't
+    //     exist; pointless to keep trying.
+    //   - 5xx: stick for FAILED_COOLDOWN_5XX_MS — likely infrastructure
+    //     (nginx rate limit, backend hiccup); recover quickly.
+    //   - network error: do NOT stick. Transient client-side blips
+    //     (offline, DNS) shouldn't lock out a working service.
+    // Map value: { at: ms timestamp, cooldownMs: number }.
     this.failedServices = new Map();
-    this.failedServiceCooldownMs = 5 * 60 * 1000; // 5 minutes
+    this.FAILED_COOLDOWN_404_MS = 5 * 60 * 1000; // 5 minutes
+    this.FAILED_COOLDOWN_5XX_MS = 60 * 1000;     // 60 seconds
 
     // Promise deduplication for in-flight requests
     this.inFlightRequests = new Map();
@@ -110,11 +114,12 @@ class CDSHooksClient {
     const now = Date.now();
 
     // Short-circuit services that have already failed hard in this session.
-    // After the cooldown elapses we drop the entry and try once more — the
-    // service may have been redeployed.
-    const failedAt = this.failedServices.get(hookId);
-    if (failedAt !== undefined) {
-      if (now - failedAt < this.failedServiceCooldownMs) {
+    // After the per-entry cooldown elapses we drop the record and try
+    // again — the service may have been redeployed (404 → 200) or
+    // infrastructure pressure may have subsided (503 → 200).
+    const failure = this.failedServices.get(hookId);
+    if (failure !== undefined) {
+      if (now - failure.at < failure.cooldownMs) {
         return { cards: [] };
       }
       this.failedServices.delete(hookId);
@@ -165,22 +170,26 @@ class CDSHooksClient {
         
         return response.data;
       } catch (error) {
-        // Failed to execute CDS hook - error handled gracefully with fallback
-
-        // Mark the service as failed so we stop hammering it for the rest of
-        // the cooldown window. 5xx / 404 / network errors all qualify;
-        // we only suppress when the failure is structural rather than a
-        // transient network blip. The first occurrence logs once so a
-        // student running locally still notices something is wrong.
+        // Failed to execute CDS hook - error handled gracefully with fallback.
+        //
+        // Pick a cooldown by failure category:
+        //   404 → service is gone; long cooldown (no point retrying)
+        //   5xx → infrastructure (nginx rate limit, backend hiccup);
+        //         short cooldown so we recover quickly when it eases
+        //   network/other → transient client-side; do NOT sticky-fail,
+        //         the next render's request gets to try fresh
         const status = error.response?.status;
-        const shouldSuppress = !status || status >= 500 || status === 404;
-        if (shouldSuppress && !this.failedServices.has(hookId)) {
-          this.failedServices.set(hookId, Date.now());
+        let cooldownMs = null;
+        if (status === 404) {
+          cooldownMs = this.FAILED_COOLDOWN_404_MS;
+        } else if (status >= 500) {
+          cooldownMs = this.FAILED_COOLDOWN_5XX_MS;
+        }
+        if (cooldownMs !== null && !this.failedServices.has(hookId)) {
+          this.failedServices.set(hookId, { at: Date.now(), cooldownMs });
           console.warn(
             `[CDSHooksClient] Suppressing further calls to "${hookId}" for `
-            + `${this.failedServiceCooldownMs / 1000}s after `
-            + (status ? `HTTP ${status}` : 'network error')
-            + '. Check the service deployment if this persists.'
+            + `${cooldownMs / 1000}s after HTTP ${status}.`
           );
         }
 


### PR DESCRIPTION
## Why

PR #80 used a single 5-minute cooldown for any \`executeHook\` failure (5xx, 404, network). Diagnosing the prod 503s today (#82 fixes the actual cause — nginx rate-limit pressure) revealed that lumping them together is wrong: a transient rate-limit 503 isn't a structurally broken service, and a 5-minute lockout hides the user's *next* chart open after the pressure subsides.

The lockout is only justified for genuinely gone services (404s).

## New behavior

| Failure | Cooldown | Reasoning |
|---|---|---|
| 404 | 5 min | Service genuinely missing — pointless to retry soon |
| 5xx | 60 sec | Transient infra (nginx rate limit, backend hiccup) — recover quickly |
| network / other | none | Client-side blip — let next request try fresh |
| 4xx other than 404 | none | Caller-side error, not a service problem |

## Code shape

Storage shape changes from \`Map<id, ms>\` to \`Map<id, {at, cooldownMs}>\` so each entry carries its own cooldown. Read path checks the entry's own \`cooldownMs\` rather than a global constant.

## Test plan

- [x] Existing 5xx test updated to assert the 60s cooldown is recorded
- [x] New test: 404 → 5-min cooldown (and that it's strictly longer than 5xx's)
- [x] New test: network error → no entry recorded
- [x] Existing 400 test unchanged (still no sticky-fail)
- [x] Lint clean on both files

## Defense-in-depth

#82 should make 5xx-from-rate-limit nearly never happen in practice. This PR exists so that if 5xx *does* sneak through, the suppression window is sized for "infrastructure transient" rather than "service is dead."

🤖 Generated with [Claude Code](https://claude.com/claude-code)