### PR TITLE
feat(cds-studio): edit existing visual-builder service in wizard

### DIFF
--- a/backend/api/cds_studio/visual_builder_router.py
+++ b/backend/api/cds_studio/visual_builder_router.py
@@ -19,6 +19,7 @@ from typing import List, Optional, Dict, Any
 from datetime import datetime
 from pydantic import BaseModel, Field
 import logging
+import re
 import uuid
 import json
 
@@ -292,6 +293,85 @@ async def get_visual_service(
     except Exception as e:
         logger.error(f"Error getting visual service: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))
+
+
+# Match `valueset "Some Name": 'http://canonical/url'` declarations in CQL.
+# Whitespace-tolerant; only captures the quoted name and the single-quoted URL.
+_VALUESET_DECLARATION_RE = re.compile(
+    r"""valueset \s+ "([^"]+)" \s* : \s* '([^']+)'""",
+    re.VERBOSE,
+)
+
+
+@router.get("/services/{service_id}/full-edit-state")
+async def get_full_edit_state(
+    service_id: str,
+    db: AsyncSession = Depends(get_db_session),
+    current_user: User = Depends(get_current_user_or_demo),
+):
+    """Return everything the wizard needs to re-load a deployed service.
+
+    Combines the service config and the ValueSets its CQL references in one
+    round-trip so the edit-mode wizard doesn't have to do N+1 calls. The
+    backend has the local mirror of authored ValueSets in
+    cds_visual_builder.value_sets keyed by canonical URL, so we resolve
+    each declared canonical URL against that table.
+
+    ValueSets referenced by canonical URL but not present in the local
+    mirror (e.g. system terminology, or URLs typed before the composer
+    was used) are returned as `{name, canonical_url, vs_id: null,
+    codes: []}` so the wizard can still list them. The Edit affordance
+    in the wizard should only be enabled when `vs_id` is non-null.
+    """
+    query = select(VisualServiceConfig).where(
+        VisualServiceConfig.service_id == service_id
+    )
+    result = await db.execute(query)
+    service = result.scalar_one_or_none()
+    if not service:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Visual service '{service_id}' not found",
+        )
+
+    referenced: List[Dict[str, Any]] = []
+    if service.cql_source:
+        from .visual_service_config import VisualValueSet
+        seen_urls: set = set()
+        for name, canonical_url in _VALUESET_DECLARATION_RE.findall(service.cql_source):
+            if canonical_url in seen_urls:
+                continue
+            seen_urls.add(canonical_url)
+            vs_query = select(VisualValueSet).where(
+                VisualValueSet.hapi_canonical_url == canonical_url,
+                VisualValueSet.deleted_at.is_(None),
+            )
+            vs_row = (await db.execute(vs_query)).scalar_one_or_none()
+            if vs_row is not None:
+                referenced.append({
+                    "name": name,
+                    "canonical_url": canonical_url,
+                    "vs_id": vs_row.vs_id,
+                    "title": vs_row.title,
+                    "description": vs_row.description,
+                    "codes": vs_row.codes or [],
+                })
+            else:
+                # Declared but not in our local mirror — surface it so the
+                # wizard lists it; Edit button stays disabled (vs_id null).
+                referenced.append({
+                    "name": name,
+                    "canonical_url": canonical_url,
+                    "vs_id": None,
+                    "title": None,
+                    "description": None,
+                    "codes": [],
+                })
+
+    return {
+        "service": VisualServiceConfigResponse.from_orm(service),
+        "value_sets": referenced,
+    }
 
 
 @router.put("/services/{service_id}", response_model=VisualServiceConfigResponse)

--- a/frontend/src/modules/cds-studio/components/builder/VisualBuilderWizard.jsx
+++ b/frontend/src/modules/cds-studio/components/builder/VisualBuilderWizard.jsx
@@ -16,7 +16,7 @@
  * review summary fits naturally above the deploy button.
  */
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   Dialog,
   DialogTitle,
@@ -76,8 +76,51 @@ const STEP_TEST_DEPLOY = 4;
 
 /**
  * Visual Builder Wizard Component
+ *
+ * @param {Object|null} existingService - When non-null, the wizard opens in
+ *   edit mode: it fetches the deployed config + referenced ValueSets and
+ *   seeds the form. The final-step button becomes "Save and Re-deploy" and
+ *   submits via PUT + redeploy instead of POST + deploy. The `service_id`
+ *   field is locked because the id is the stable identifier across HAPI,
+ *   the DB, and the discovery response.
  */
-const VisualBuilderWizard = ({ open, onClose, onSuccess }) => {
+const buildEmptyServiceConfig = (createdBy) => ({
+  service_id: '',
+  name: '',
+  description: '',
+  service_type: 'condition-based',
+  category: 'preventive-care',
+  hook_type: 'patient-view',
+  conditions: [
+    {
+      type: 'group',
+      operator: 'AND',
+      conditions: []
+    }
+  ],
+  // CQL services store their logic here instead of in `conditions`. The
+  // backend dispatcher reads `service_type` to decide which path runs.
+  cql_source: '',
+  card: {
+    summary: '',
+    detail: '',
+    indicator: 'info',
+    source: { label: '' },
+    suggestions: [],
+    links: []
+  },
+  // Backend Pydantic model (`DisplayConfiguration`) requires
+  // `presentationMode`. We send the spec-default `'inline'` so saves
+  // succeed; the wizard no longer surfaces display behavior because the
+  // EMR runtime reads `card.displayBehavior` / `card.overrideReasons`,
+  // not `service.display_config`. If someone wires per-service display
+  // behavior into the runtime later, re-add the panel.
+  display_config: { presentationMode: 'inline' },
+  prefetch: {},
+  created_by: createdBy || 'unknown'
+});
+
+const VisualBuilderWizard = ({ open, onClose, onSuccess, existingService = null }) => {
   const { user } = useAuth();
   const [activeStep, setActiveStep] = useState(0);
   const [loading, setLoading] = useState(false);
@@ -85,44 +128,64 @@ const VisualBuilderWizard = ({ open, onClose, onSuccess }) => {
   const [testResults, setTestResults] = useState(null);
 
   // Service configuration state
-  const [serviceConfig, setServiceConfig] = useState({
-    service_id: '',
-    name: '',
-    description: '',
-    service_type: 'condition-based',
-    category: 'preventive-care',
-    hook_type: 'patient-view',
-    conditions: [
-      {
-        type: 'group',
-        operator: 'AND',
-        conditions: []
-      }
-    ],
-    // CQL services store their logic here instead of in `conditions`. The
-    // backend dispatcher reads `service_type` to decide which path runs.
-    cql_source: '',
-    card: {
-      summary: '',
-      detail: '',
-      indicator: 'info',
-      source: { label: '' },
-      suggestions: [],
-      links: []
-    },
-    // Backend Pydantic model (`DisplayConfiguration`) requires
-    // `presentationMode`. We send the spec-default `'inline'` so saves
-    // succeed; the wizard no longer surfaces display behavior because the
-    // EMR runtime reads `card.displayBehavior` / `card.overrideReasons`,
-    // not `service.display_config`. If someone wires per-service display
-    // behavior into the runtime later, re-add the panel.
-    display_config: { presentationMode: 'inline' },
-    prefetch: {},
-    created_by: user?.username || 'unknown'
-  });
+  const [serviceConfig, setServiceConfig] = useState(() => buildEmptyServiceConfig(user?.username));
 
   const [savedServiceId, setSavedServiceId] = useState(null);
+  // ValueSets that the current CQL references — populated when editing an
+  // existing service so PR 2 (inline VS edit list) has data to render.
+  // For new services this stays empty.
+  const [referencedValueSets, setReferencedValueSets] = useState([]);
+  const isEditMode = Boolean(existingService);
   const isCQLService = serviceConfig.service_type === CQL_SERVICE_TYPE;
+
+  // Edit-mode hydration: when the wizard opens with an existing service,
+  // pull its full state (config + referenced ValueSets) in one round-trip
+  // and seed the form. Skips draft-save (the row already exists in DB).
+  useEffect(() => {
+    if (!open || !existingService) return;
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const { data } = await axios.get(
+          `/api/cds-visual-builder/services/${existingService.service_id}/full-edit-state`
+        );
+        if (cancelled) return;
+        const svc = data.service || {};
+        setServiceConfig({
+          service_id: svc.service_id || existingService.service_id,
+          name: svc.name || '',
+          description: svc.description || '',
+          service_type: svc.service_type || 'condition-based',
+          category: svc.category || 'preventive-care',
+          hook_type: svc.hook_type || 'patient-view',
+          conditions: svc.conditions || [{ type: 'group', operator: 'AND', conditions: [] }],
+          cql_source: svc.cql_source || '',
+          card: svc.card_config || {
+            summary: '',
+            detail: '',
+            indicator: 'info',
+            source: { label: '' },
+            suggestions: [],
+            links: []
+          },
+          display_config: svc.display_config || { presentationMode: 'inline' },
+          prefetch: svc.prefetch_config || {},
+          created_by: svc.created_by || user?.username || 'unknown'
+        });
+        setReferencedValueSets(data.value_sets || []);
+        setSavedServiceId(svc.id || existingService.id);
+        setActiveStep(0);
+      } catch (err) {
+        if (cancelled) return;
+        setError(err.response?.data?.detail || 'Failed to load service for editing');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [open, existingService, user?.username]);
 
   /**
    * Format error messages for display
@@ -251,17 +314,40 @@ const VisualBuilderWizard = ({ open, onClose, onSuccess }) => {
     setError(null);
 
     try {
-      // Save or update service first
       let serviceId = savedServiceId;
-      if (!serviceId) {
+      if (isEditMode) {
+        // Edit-mode: PUT the updated config (re-materializes Library +
+        // PlanDefinition for CQL services, regenerates Python for visual
+        // services), then deploy to bump the stable Library version and
+        // refresh inlined ValueSet codes. Single-button "Save and
+        // Re-deploy" — the user shouldn't have to remember a second step
+        // for the deployed Library to pick up changes.
+        await axios.put(
+          `/api/cds-visual-builder/services/${serviceConfig.service_id}`,
+          {
+            name: serviceConfig.name,
+            description: serviceConfig.description,
+            service_type: serviceConfig.service_type,
+            category: serviceConfig.category,
+            hook_type: serviceConfig.hook_type,
+            conditions: isCQLService ? undefined : serviceConfig.conditions,
+            cql_source: isCQLService ? serviceConfig.cql_source : undefined,
+            card_config: serviceConfig.card,
+            display_config: serviceConfig.display_config,
+            prefetch_config: serviceConfig.prefetch
+          }
+        );
+      } else if (!serviceId) {
         const savedService = await handleSaveDraft();
         serviceId = savedService.id;
       }
 
-      // Deploy the service (send empty object for ServiceDeploymentRequest)
+      // Deploy. For new services this is the first stable-version upload;
+      // for edits this bumps the version and re-runs `inline_value_set_retrieves`,
+      // refreshing any ValueSet code edits made in this session.
       await axios.post(
-        `/api/cds-visual-builder/services/${serviceId}/deploy`,
-        {}  // Required: ServiceDeploymentRequest body (deployed_by and notes are optional)
+        `/api/cds-visual-builder/services/${serviceConfig.service_id}/deploy`,
+        {}
       );
 
       onSuccess?.();
@@ -276,30 +362,13 @@ const VisualBuilderWizard = ({ open, onClose, onSuccess }) => {
   };
 
   const handleClose = () => {
-    // Reset wizard state
+    // Reset wizard state so a subsequent Create doesn't pre-populate from
+    // a stale edit, and a subsequent Edit doesn't see the previous service's
+    // CQL/valuesets while the GET /full-edit-state is in flight.
     setActiveStep(0);
-    setServiceConfig({
-      service_id: '',
-      name: '',
-      description: '',
-      service_type: 'condition-based',
-      category: 'preventive-care',
-      hook_type: 'patient-view',
-      conditions: [],
-      cql_source: '',
-      card: {
-        summary: '',
-        detail: '',
-        indicator: 'info',
-        source: { label: '' },
-        suggestions: [],
-        links: []
-      },
-      display_config: { presentationMode: 'inline' },
-      prefetch: {},
-      created_by: user?.username || 'unknown'
-    });
+    setServiceConfig(buildEmptyServiceConfig(user?.username));
     setSavedServiceId(null);
+    setReferencedValueSets([]);
     setTestResults(null);
     setError(null);
 
@@ -350,7 +419,10 @@ const VisualBuilderWizard = ({ open, onClose, onSuccess }) => {
             value={serviceConfig.service_id}
             onChange={(e) => setServiceConfig({ ...serviceConfig, service_id: e.target.value })}
             placeholder="my-preventive-care-service"
-            helperText="Unique identifier for this service (lowercase, hyphens allowed)"
+            helperText={isEditMode
+              ? 'Service ID is the stable identifier in HAPI and the database; rename is not supported.'
+              : 'Unique identifier for this service (lowercase, hyphens allowed)'}
+            disabled={isEditMode}
             required
           />
         </Grid>
@@ -656,7 +728,9 @@ const VisualBuilderWizard = ({ open, onClose, onSuccess }) => {
       }}
     >
       <DialogTitle>
-        Visual Service Builder
+        {isEditMode
+          ? `Edit Service — ${existingService?.service_id || serviceConfig.service_id}`
+          : 'Visual Service Builder'}
       </DialogTitle>
 
       <DialogContent dividers sx={{ p: 3 }}>
@@ -718,7 +792,9 @@ const VisualBuilderWizard = ({ open, onClose, onSuccess }) => {
             onClick={handleDeploy}
             disabled={loading}
           >
-            {loading ? <CircularProgress size={20} color="inherit" /> : 'Deploy Service'}
+            {loading
+              ? <CircularProgress size={20} color="inherit" />
+              : (isEditMode ? 'Save and Re-deploy' : 'Deploy Service')}
           </Button>
         )}
       </DialogActions>

--- a/frontend/src/modules/cds-studio/pages/CDSStudioPage.jsx
+++ b/frontend/src/modules/cds-studio/pages/CDSStudioPage.jsx
@@ -39,6 +39,9 @@ const CDSStudioPage = () => {
 
   // Builder dialog states
   const [visualBuilderOpen, setVisualBuilderOpen] = useState(false);
+  // When non-null, the wizard opens in edit mode and seeds from this service
+  // via GET /full-edit-state. Cleared on close.
+  const [editingService, setEditingService] = useState(null);
   const [templateBuilderOpen, setTemplateBuilderOpen] = useState(false);
   const [builtInDialogOpen, setBuiltInDialogOpen] = useState(false);
   const [externalDialogOpen, setExternalDialogOpen] = useState(false);
@@ -67,8 +70,14 @@ const CDSStudioPage = () => {
   };
 
   const handleNewVisualBuilder = () => {
+    setEditingService(null);
     setVisualBuilderOpen(true);
     handleCloseNewServiceMenu();
+  };
+
+  const handleEditService = (service) => {
+    setEditingService(service);
+    setVisualBuilderOpen(true);
   };
 
   const handleNewTemplateBuilder = () => {
@@ -194,6 +203,7 @@ const CDSStudioPage = () => {
 
           <ServicesTable
             onSelectService={handleSelectService}
+            onEditService={handleEditService}
             onRefresh={handleRefresh}
           />
         </Paper>
@@ -206,11 +216,17 @@ const CDSStudioPage = () => {
         onClose={handleCloseDetailPanel}
       />
 
-      {/* Visual Builder Wizard */}
+      {/* Visual Builder Wizard — handles both create and edit modes via the
+          existingService prop. Editing pulls full state via GET
+          /full-edit-state, the final-step button becomes "Save and Re-deploy". */}
       <VisualBuilderWizard
         open={visualBuilderOpen}
-        onClose={() => setVisualBuilderOpen(false)}
+        onClose={() => {
+          setVisualBuilderOpen(false);
+          setEditingService(null);
+        }}
         onSuccess={handleServiceCreated}
+        existingService={editingService}
       />
 
       {/* Template Service Builder */}

--- a/frontend/src/modules/cds-studio/pages/ServicesRegistry/ServicesTable.jsx
+++ b/frontend/src/modules/cds-studio/pages/ServicesRegistry/ServicesTable.jsx
@@ -34,7 +34,7 @@ import {
 } from '@mui/icons-material';
 import cdsStudioApi from '../../services/cdsStudioApi';
 
-const ServicesTable = ({ onSelectService, onRefresh }) => {
+const ServicesTable = ({ onSelectService, onEditService, onRefresh }) => {
   const [services, setServices] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -77,6 +77,13 @@ const ServicesTable = ({ onSelectService, onRefresh }) => {
   const handleViewDetails = () => {
     if (selectedService) {
       onSelectService(selectedService);
+    }
+    handleMenuClose();
+  };
+
+  const handleEdit = () => {
+    if (selectedService && onEditService) {
+      onEditService(selectedService);
     }
     handleMenuClose();
   };
@@ -316,6 +323,12 @@ const ServicesTable = ({ onSelectService, onRefresh }) => {
         onClose={handleMenuClose}
       >
         <MenuItem onClick={handleViewDetails}>View Details</MenuItem>
+        {/* Edit only applies to visual-builder-authored services. Built-in
+            services live in code (no DB row to edit), and external services
+            are HTTP endpoints owned elsewhere. */}
+        {selectedService?.origin === 'visual-builder' && onEditService && (
+          <MenuItem onClick={handleEdit}>Edit Service</MenuItem>
+        )}
         <MenuItem onClick={handleToggleStatus}>
           {selectedService?.status === 'active' ? 'Deactivate' : 'Activate'}
         </MenuItem>


### PR DESCRIPTION
## Why

After deploying a CQL service, students had no in-UI path to fix it — typo in CQL, wrong ValueSet codes, etc. The studio offered View Details / Activate / Delete, no Edit. While debugging \`dr-screening-reminder\` I had to drop to \`curl PUT /api/cds-visual-builder/services/{id}\` to fix four CQL bugs. This PR closes that gap.

## What

- Backend: new \`GET /services/{id}/full-edit-state\` returns the service config + the ValueSets its CQL references, in one round-trip. Parses \`valueset \"Name\": 'URL'\` declarations from cql_source and resolves each URL against \`cds_visual_builder.value_sets\`.
- Frontend: \`VisualBuilderWizard\` accepts a new \`existingService\` prop. On open it pulls full state, seeds the form, and the final-step button becomes **Save and Re-deploy** — one click PUTs the updated config, then runs deploy (which bumps the stable Library version, re-runs \`inline_value_set_retrieves\`, and flushes CR caches).
- \`ServicesTable\` action menu gets an Edit item, only visible for \`origin === 'visual-builder'\` services.
- \`CDSStudioPage\` wires \`editingService\` state and clears it on close so a subsequent Create doesn't pre-populate.

## Decisions baked in

| Question | Choice | Rationale |
|---|---|---|
| Save vs deploy in edit mode | One-button "Save and Re-deploy" | Saving alone leaves deployed Library stale (inlined ValueSet codes never refresh until deploy). Single button prevents footgun. |
| Service ID rename | Disabled | \`service_id\` is the stable identifier in HAPI, the DB primary key, and the discovery response. No backend support; not worth the complexity. |
| Origins eligible for Edit | \`visual-builder\` only | Built-in services live in code; external services are HTTP endpoints owned elsewhere. |

## Test plan

- [x] Backend compile-checked, frontend lint-clean (0 errors)
- [ ] Manual on prod: open \`dr-screening-reminder\` → Edit → wizard prefills CQL, name, all 4 ValueSets, card config. Change card summary text → Save and Re-deploy → verify \`/api/cds-debug/dr-screening-reminder | jq '.checks.hapi_plan_definition.library_refs'\` shows bumped \`V{n}\`. Hit \`\$apply\` for the candidate diabetic patient → card text reflects new summary.
- [ ] No regression on create flow.
- [ ] No regression on visual condition-tree services (PUT supports both paths via \`is_cql_service_type\`).

## Out of scope

- ValueSet edit affordance in the wizard (\`referencedValueSets\` state is populated but unused — PR 2 in this series).
- CQL CardSummary auto-populate in CardDesigner — PR 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)