### PR TITLE
feat(cds-studio): edit ValueSets inline in the Build Logic step

### DIFF
--- a/frontend/src/modules/cds-studio/components/builder/VisualBuilderWizard.jsx
+++ b/frontend/src/modules/cds-studio/components/builder/VisualBuilderWizard.jsx
@@ -138,6 +138,22 @@ const VisualBuilderWizard = ({ open, onClose, onSuccess, existingService = null 
   const isEditMode = Boolean(existingService);
   const isCQLService = serviceConfig.service_type === CQL_SERVICE_TYPE;
 
+  // After a ValueSet is created or edited inside the composer, refresh the
+  // referenced-VS list so the inline panel reflects the new code count.
+  // Only meaningful in edit mode (we have a deployed service to query); in
+  // create mode there's nothing for /full-edit-state to return yet.
+  const refreshReferencedValueSets = async () => {
+    if (!isEditMode || !serviceConfig.service_id) return;
+    try {
+      const { data } = await axios.get(
+        `/api/cds-visual-builder/services/${serviceConfig.service_id}/full-edit-state`
+      );
+      setReferencedValueSets(data.value_sets || []);
+    } catch (err) {
+      console.warn('Failed to refresh referenced ValueSets', err);
+    }
+  };
+
   // Edit-mode hydration: when the wizard opens with an existing service,
   // pull its full state (config + referenced ValueSets) in one round-trip
   // and seed the form. Skips draft-save (the row already exists in DB).
@@ -561,6 +577,8 @@ const VisualBuilderWizard = ({ open, onClose, onSuccess, existingService = null 
               if (!savedServiceId) return null;
               return cdsStudioApi.getServiceFHIRPreview(serviceConfig.service_id);
             }}
+            referencedValueSets={referencedValueSets}
+            onValueSetSaved={refreshReferencedValueSets}
           />
         </Box>
       );

--- a/frontend/src/modules/cds-studio/components/builders/CQLEditor.jsx
+++ b/frontend/src/modules/cds-studio/components/builders/CQLEditor.jsx
@@ -119,6 +119,14 @@ const CQLEditor = ({
   onOpenValueSetComposer,
   onLoadFHIRPreview,
   height = '380px',
+  // ValueSets the parent has resolved against the current CQL declarations.
+  // Each: { name, canonical_url, vs_id, title, description, codes }.
+  // Entries with vs_id=null are referenced-but-not-in-our-DB (e.g. system
+  // terminology); the Edit affordance is hidden for those.
+  referencedValueSets = [],
+  // Called after the user saves a ValueSet edit so the parent can refetch
+  // the referenced list (the code count in our local cache may have changed).
+  onValueSetSaved,
 }) => {
   const editorRef = useRef(null);
   const monacoRef = useRef(null);
@@ -132,6 +140,9 @@ const CQLEditor = ({
   const [previewLoading, setPreviewLoading] = useState(false);
   const [previewError, setPreviewError] = useState(null);
   const [composerOpen, setComposerOpen] = useState(false);
+  // When non-null, the composer opens in edit mode for this VS. Cleared
+  // on close so the next "Compose ValueSet" click starts fresh.
+  const [editingValueSet, setEditingValueSet] = useState(null);
 
   const handleEditorMount = useCallback((editor, monaco) => {
     editorRef.current = editor;
@@ -502,6 +513,57 @@ const CQLEditor = ({
             />
           </Box>
 
+          {referencedValueSets.length > 0 && (
+            <Box sx={{ mt: 2 }}>
+              <Typography variant="subtitle2" sx={{ mb: 1 }}>
+                ValueSets used by this CQL
+              </Typography>
+              <Stack spacing={0.5}>
+                {referencedValueSets.map((vs) => (
+                  <Box
+                    key={vs.canonical_url}
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      px: 1.5,
+                      py: 0.75,
+                      border: 1,
+                      borderColor: 'divider',
+                      borderRadius: 0,
+                      gap: 1,
+                    }}
+                  >
+                    <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
+                      &quot;{vs.name}&quot;
+                    </Typography>
+                    <Chip
+                      size="small"
+                      label={`${(vs.codes || []).length} codes`}
+                      variant="outlined"
+                    />
+                    <Box sx={{ flex: 1 }} />
+                    {vs.vs_id ? (
+                      <Button
+                        size="small"
+                        startIcon={<EditIcon />}
+                        onClick={() => {
+                          setEditingValueSet(vs);
+                          setComposerOpen(true);
+                        }}
+                      >
+                        Edit
+                      </Button>
+                    ) : (
+                      <Tooltip title="ValueSet not in local catalog (system terminology or external).">
+                        <Chip size="small" label="external" />
+                      </Tooltip>
+                    )}
+                  </Box>
+                ))}
+              </Stack>
+            </Box>
+          )}
+
           {issuePanel}
         </>
       )}
@@ -516,8 +578,23 @@ const CQLEditor = ({
 
       <ValueSetComposer
         open={composerOpen}
-        onClose={() => setComposerOpen(false)}
-        onSave={insertValueSetDeclaration}
+        onClose={() => {
+          setComposerOpen(false);
+          setEditingValueSet(null);
+        }}
+        editingValueSet={editingValueSet}
+        onSave={(payload) => {
+          // Create-mode: insert the new declaration into the CQL buffer.
+          // Edit-mode: leave the buffer alone (the declaration already
+          // exists). In both cases, let the parent know the catalog
+          // changed so it can refetch the referenced-VS list.
+          if (!editingValueSet) {
+            insertValueSetDeclaration(payload);
+          }
+          if (onValueSetSaved) {
+            onValueSetSaved(payload);
+          }
+        }}
       />
     </Box>
   );

--- a/frontend/src/modules/cds-studio/components/builders/ValueSetComposer.jsx
+++ b/frontend/src/modules/cds-studio/components/builders/ValueSetComposer.jsx
@@ -85,11 +85,23 @@ const FHIR_NAME_RE = /^[A-Za-z][A-Za-z0-9_]*$/;
  * @param {boolean} props.open
  * @param {() => void} props.onClose
  * @param {(payload: {name: string, hapi_canonical_url: string, vs_id: string}) => void}
- *   props.onSave — called after successful POST. Parent inserts the valueset
- *   declaration into the editor.
- * @param {string} [props.suggestedName] — pre-filled FHIR Name (CQL identifier)
+ *   props.onSave — called after successful save (POST for create, PUT for edit).
+ * @param {string} [props.suggestedName] — pre-filled FHIR Name (CQL identifier).
+ *   Only used in create mode; ignored when editing.
+ * @param {object} [props.editingValueSet] — when present, opens in edit mode:
+ *   `{ vs_id, name, title, description, codes: [{system, code, display}] }`.
+ *   Save calls PUT instead of POST. The `name` field is locked (canonical
+ *   identity in HAPI; rename would require re-uploading a new ValueSet
+ *   resource and rewriting CQL retrieves).
  */
-const ValueSetComposer = ({ open, onClose, onSave, suggestedName = '' }) => {
+const ValueSetComposer = ({
+  open,
+  onClose,
+  onSave,
+  suggestedName = '',
+  editingValueSet = null,
+}) => {
+  const isEditMode = Boolean(editingValueSet);
   // Form fields
   const [name, setName] = useState(suggestedName);
   const [title, setTitle] = useState('');
@@ -115,21 +127,38 @@ const ValueSetComposer = ({ open, onClose, onSave, suggestedName = '' }) => {
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState(null);
 
-  // Reset on open so re-opening starts fresh.
+  // Reset on open. In edit mode, hydrate from the supplied editingValueSet
+  // so the user sees the current name/title/description/codes; in create
+  // mode start fresh with the suggested name.
   useEffect(() => {
     if (!open) return;
-    setName(suggestedName);
-    setTitle('');
-    setDescription('');
+    if (editingValueSet) {
+      setName(editingValueSet.name || '');
+      setTitle(editingValueSet.title || '');
+      setDescription(editingValueSet.description || '');
+      setSelected(
+        Array.isArray(editingValueSet.codes)
+          ? editingValueSet.codes.map((c) => ({
+              system: c.system,
+              code: c.code,
+              display: c.display,
+            }))
+          : []
+      );
+    } else {
+      setName(suggestedName);
+      setTitle('');
+      setDescription('');
+      setSelected([]);
+    }
     setSearch('');
     setSearchResults([]);
     setManualSystem('');
     setManualCode('');
     setManualDisplay('');
     setManualError(null);
-    setSelected([]);
     setSaveError(null);
-  }, [open, suggestedName]);
+  }, [open, suggestedName, editingValueSet]);
 
   // Debounced catalog search.
   useEffect(() => {
@@ -229,11 +258,17 @@ const ValueSetComposer = ({ open, onClose, onSave, suggestedName = '' }) => {
           display: c.display,
         })),
       };
-      const created = await cdsStudioApi.createValueSet(payload);
+      // PUT in edit mode — the backend handler re-PUTs the FHIR ValueSet
+      // to HAPI when the code list changes and flushes the CR engine's
+      // expansion cache, so the next $apply for any service that
+      // references this VS sees the new codes.
+      const result = isEditMode
+        ? await cdsStudioApi.updateValueSet(editingValueSet.vs_id, payload)
+        : await cdsStudioApi.createValueSet(payload);
       onSave?.({
-        name: created.name,
-        hapi_canonical_url: created.hapi_canonical_url,
-        vs_id: created.vs_id,
+        name: result.name,
+        hapi_canonical_url: result.hapi_canonical_url,
+        vs_id: result.vs_id,
       });
       onClose?.();
     } catch (err) {
@@ -241,12 +276,12 @@ const ValueSetComposer = ({ open, onClose, onSave, suggestedName = '' }) => {
     } finally {
       setSaving(false);
     }
-  }, [canSave, name, title, description, selected, onSave, onClose]);
+  }, [canSave, name, title, description, selected, onSave, onClose, isEditMode, editingValueSet]);
 
   return (
     <Dialog open={open} onClose={saving ? undefined : onClose} maxWidth="md" fullWidth>
       <DialogTitle sx={{ display: 'flex', alignItems: 'center' }}>
-        Compose a ValueSet
+        {isEditMode ? `Edit ValueSet — ${editingValueSet.name}` : 'Compose a ValueSet'}
         <Box sx={{ flex: 1 }} />
         <IconButton onClick={onClose} disabled={saving} size="small">
           <CloseIcon fontSize="small" />
@@ -267,11 +302,14 @@ const ValueSetComposer = ({ open, onClose, onSave, suggestedName = '' }) => {
                 onChange={(e) => setName(e.target.value)}
                 placeholder="DiabetesConditions"
                 helperText={
-                  nameValid || !name
-                    ? 'Letters/digits/underscores; starts with letter (e.g. DiabetesConditions)'
-                    : 'Invalid identifier — no hyphens or spaces'
+                  isEditMode
+                    ? "Name is the canonical identity; rename isn't supported (would re-publish under a new URL)."
+                    : (nameValid || !name
+                      ? 'Letters/digits/underscores; starts with letter (e.g. DiabetesConditions)'
+                      : 'Invalid identifier — no hyphens or spaces')
                 }
                 error={!!name && !nameValid}
+                disabled={isEditMode}
                 required
                 sx={{ flex: 1 }}
               />


### PR DESCRIPTION
## Why

Stacks on #88. After PR 1 lands, students can edit a deployed service's CQL — but if the actual fix needs a ValueSet code change (the most common cause for a CQL service that "doesn't fire correctly"), there's no in-wizard path. Today they'd have to leave the wizard, find the ValueSet... actually they couldn't, because there's no standalone ValueSet management page. PR 2 closes the loop.

## What

- \`ValueSetComposer\` accepts a new \`editingValueSet\` prop. When non-null, opens in edit mode: hydrates from the supplied \`{vs_id, name, title, description, codes}\`, save uses PUT instead of POST, and the \`name\` field is locked (canonical identity in HAPI).
- \`CQLEditor\` accepts \`referencedValueSets\` and \`onValueSetSaved\`. Renders an inline list below the editor when there's at least one referenced VS. Each row: name (in CQL identifier form), code count chip, Edit button. VSs not in the local catalog (\`vs_id: null\`) render as "external" chips with no Edit affordance.
- \`VisualBuilderWizard\` adds \`refreshReferencedValueSets\` that re-runs \`GET /full-edit-state\` after any composer save, so the inline list's code count updates immediately.

## Full edit chain (after this PR)

1. Open a deployed service → Edit
2. Build Logic step shows CQL + the inline list of referenced ValueSets
3. Click Edit on a VS → composer opens prefilled → adjust codes → Save
4. Composer closes; inline list refreshes with new code count
5. Click "Save and Re-deploy" → service Library re-materializes; \`inline_value_set_retrieves\` runs against the updated VS codes; HAPI cache flushed

## Test plan

- [x] Lint clean on all 3 modified files
- [ ] Manual on prod: open \`dr-screening-reminder\` → see all 4 ValueSets listed under the CQL editor with code counts. Edit "Diabetic Retinopathy" → composer prefills with SNOMED \`4855003\` → add \`422034002\` → Save. List code count bumps to 2. Save and Re-deploy. Confirm \`/api/cds-debug/dr-screening-reminder | jq '.checks.cql_libraries'\` shows the bumped library, and a patient with \`Condition.code.coding[0].code=422034002\` no longer triggers the screening card.
- [ ] No regression on create flow — the existing "Compose ValueSet" button still creates new VSs and inserts the declaration.

## Notes

- This PR is **stacked on #88** (\`feat/cds-edit-existing-service\`). PR 2 will need PR 1 merged first; GitHub will auto-update PR 2's diff when that happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)