### PR TITLE
feat(cds-studio): auto-populate card preview from CQL CardSummary/CardDetail

### DIFF
--- a/frontend/src/modules/cds-studio/components/builder/VisualBuilderWizard.jsx
+++ b/frontend/src/modules/cds-studio/components/builder/VisualBuilderWizard.jsx
@@ -16,7 +16,7 @@
  * review summary fits naturally above the deploy button.
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import {
   Dialog,
   DialogTitle,
@@ -54,6 +54,7 @@ import ServiceTester from '../testing/ServiceTester';
 import { SERVICE_TYPES } from '../../types/serviceTypes';
 import cdsStudioApi from '../../services/cdsStudioApi';
 import { useAuth } from '../../../../contexts/AuthContext';
+import { extractCardDefinesFromCQL } from '../../utils/cqlDefineExtractor';
 import axios from 'axios';
 
 const CQL_SERVICE_TYPE = 'cql-based';
@@ -137,6 +138,14 @@ const VisualBuilderWizard = ({ open, onClose, onSuccess, existingService = null 
   const [referencedValueSets, setReferencedValueSets] = useState([]);
   const isEditMode = Boolean(existingService);
   const isCQLService = serviceConfig.service_type === CQL_SERVICE_TYPE;
+
+  // When CQL defines string-literal CardSummary / CardDetail, surface them
+  // as overrides so CardDesigner shows a read-only preview instead of an
+  // empty input. The CQL value wins at $apply time anyway.
+  const cqlCardOverrides = useMemo(
+    () => (isCQLService ? extractCardDefinesFromCQL(serviceConfig.cql_source) : {}),
+    [isCQLService, serviceConfig.cql_source]
+  );
 
   // After a ValueSet is created or edited inside the composer, refresh the
   // referenced-VS list so the inline panel reflects the new code count.
@@ -283,7 +292,11 @@ const VisualBuilderWizard = ({ open, onClose, onSuccess, existingService = null 
         break;
 
       case 2: // Card Design
-        if (!serviceConfig.card.summary) {
+        // When CQL defines CardSummary, the static summary is unreachable
+        // at runtime — the dynamicValue overrides it. Skip the required
+        // check in that case so the student isn't forced to type a
+        // duplicate string. Same for CardDetail.
+        if (!serviceConfig.card.summary && cqlCardOverrides.summary === undefined) {
           return { valid: false, error: 'Card summary is required' };
         }
         break;
@@ -616,6 +629,8 @@ const VisualBuilderWizard = ({ open, onClose, onSuccess, existingService = null 
           <CardDesigner
             card={serviceConfig.card}
             onChange={(card) => setServiceConfig({ ...serviceConfig, card })}
+            cqlOverrides={cqlCardOverrides}
+            onJumpToCQL={() => setActiveStep(1)}
           />
         </Grid>
 

--- a/frontend/src/modules/cds-studio/components/builders/CardDesigner.jsx
+++ b/frontend/src/modules/cds-studio/components/builders/CardDesigner.jsx
@@ -39,6 +39,46 @@ import CDSCard from '../../../../components/clinical/cds/CDSCard';
 import SuggestionActionBuilder from './SuggestionActionBuilder';
 
 /**
+ * Read-only preview shown in place of the static Summary/Detail input
+ * when the parent CQL has a matching `define CardSummary:` / `CardDetail:`
+ * literal. The CQL value wins at $apply time anyway, so the static field
+ * would be unreachable — surfacing the CQL value here is honest about
+ * what the runtime will display.
+ */
+const CqlOverridePreview = ({ label, value, onJumpToCQL, multiline = false }) => (
+  <Box
+    sx={{
+      border: 1,
+      borderColor: 'divider',
+      borderRadius: 0,
+      p: 1.5,
+      backgroundColor: 'action.hover',
+    }}
+  >
+    <Stack direction="row" alignItems="center" sx={{ mb: 0.5 }}>
+      <Typography variant="caption" color="text.secondary" sx={{ flex: 1 }}>
+        {label}
+      </Typography>
+      {onJumpToCQL && (
+        <Button size="small" startIcon={<EditIcon />} onClick={onJumpToCQL}>
+          Edit in CQL
+        </Button>
+      )}
+    </Stack>
+    <Typography
+      variant="body2"
+      sx={{
+        whiteSpace: multiline ? 'pre-wrap' : 'normal',
+        fontStyle: 'italic',
+        color: 'text.primary',
+      }}
+    >
+      {value || <span style={{ color: 'rgba(0,0,0,0.4)' }}>(empty string from CQL)</span>}
+    </Typography>
+  </Box>
+);
+
+/**
  * Card indicator options
  */
 const CARD_INDICATORS = {
@@ -217,7 +257,16 @@ const LinkBuilder = ({ links, onChange }) => {
 const CardDesigner = ({
   card,
   onChange,
-  error = null
+  error = null,
+  // When the parent CQL has `define CardSummary:` / `CardDetail:` string
+  // literals, surface them as `{ summary?, detail? }`. The matching
+  // static input is replaced with a read-only preview because the CQL
+  // value overrides the static action.title/description at $apply time
+  // anyway (cql_artifact_builder wires it as PlanDefinition.action.dynamicValue).
+  cqlOverrides = {},
+  // Optional callback to jump back to the Build Logic step. Used by the
+  // "Edit in CQL" affordance on the read-only preview.
+  onJumpToCQL,
 }) => {
   const [summary, setSummary] = useState(card?.summary || '');
   const [detail, setDetail] = useState(card?.detail || '');
@@ -355,28 +404,45 @@ const CardDesigner = ({
                 <Divider sx={{ mb: 2 }} />
 
                 <Stack spacing={2}>
-                  {/* Summary */}
-                  <TextField
-                    fullWidth
-                    label="Summary"
-                    value={summary}
-                    onChange={(e) => handleSummaryChange(e.target.value)}
-                    placeholder="Brief one-line summary of the alert"
-                    required
-                    helperText="Clear, concise summary (required)"
-                  />
+                  {/* Summary — read-only preview when CQL provides CardSummary */}
+                  {cqlOverrides.summary !== undefined ? (
+                    <CqlOverridePreview
+                      label="Summary (from CQL CardSummary)"
+                      value={cqlOverrides.summary}
+                      onJumpToCQL={onJumpToCQL}
+                    />
+                  ) : (
+                    <TextField
+                      fullWidth
+                      label="Summary"
+                      value={summary}
+                      onChange={(e) => handleSummaryChange(e.target.value)}
+                      placeholder="Brief one-line summary of the alert"
+                      required
+                      helperText="Clear, concise summary (required)"
+                    />
+                  )}
 
-                  {/* Detail */}
-                  <TextField
-                    fullWidth
-                    label="Detail"
-                    value={detail}
-                    onChange={(e) => handleDetailChange(e.target.value)}
-                    placeholder="Detailed explanation of the alert and recommended action"
-                    multiline
-                    rows={4}
-                    helperText="Provide clinical context and rationale"
-                  />
+                  {/* Detail — read-only preview when CQL provides CardDetail */}
+                  {cqlOverrides.detail !== undefined ? (
+                    <CqlOverridePreview
+                      label="Detail (from CQL CardDetail)"
+                      value={cqlOverrides.detail}
+                      onJumpToCQL={onJumpToCQL}
+                      multiline
+                    />
+                  ) : (
+                    <TextField
+                      fullWidth
+                      label="Detail"
+                      value={detail}
+                      onChange={(e) => handleDetailChange(e.target.value)}
+                      placeholder="Detailed explanation of the alert and recommended action"
+                      multiline
+                      rows={4}
+                      helperText="Provide clinical context and rationale"
+                    />
+                  )}
 
                   {/* Indicator */}
                   <FormControl fullWidth>

--- a/frontend/src/modules/cds-studio/utils/__tests__/cqlDefineExtractor.test.js
+++ b/frontend/src/modules/cds-studio/utils/__tests__/cqlDefineExtractor.test.js
@@ -1,0 +1,64 @@
+import { extractCardDefinesFromCQL } from '../cqlDefineExtractor';
+
+describe('extractCardDefinesFromCQL', () => {
+  test('extracts simple string-literal CardSummary and CardDetail', () => {
+    const cql = `
+      library Foo version '1.0.0'
+      using FHIR version '4.0.1'
+
+      define CardSummary:
+        'Diabetic retinopathy screening due'
+
+      define CardDetail:
+        'Patient is overdue for annual exam'
+    `;
+    expect(extractCardDefinesFromCQL(cql)).toEqual({
+      summary: 'Diabetic retinopathy screening due',
+      detail: 'Patient is overdue for annual exam',
+    });
+  });
+
+  test('returns empty object when neither define is present', () => {
+    const cql = `
+      library Foo version '1.0.0'
+      define Applicability: true
+    `;
+    expect(extractCardDefinesFromCQL(cql)).toEqual({});
+  });
+
+  test('returns only the defines that match', () => {
+    const cql = `define CardSummary: 'Just summary'`;
+    expect(extractCardDefinesFromCQL(cql)).toEqual({ summary: 'Just summary' });
+  });
+
+  test('handles escaped single quotes', () => {
+    const cql = `define CardSummary: 'Patient\\'s overdue'`;
+    expect(extractCardDefinesFromCQL(cql)).toEqual({ summary: "Patient's overdue" });
+  });
+
+  test('skips defines with non-string-literal expressions', () => {
+    // Concatenation, conditionals — runtime evaluates these, wizard shouldn't
+    // pretend to know the value.
+    const cql = `
+      define CardSummary:
+        'Patient last A1c was ' + ToString(LastA1cValue) + '%'
+      define CardDetail:
+        if HasSevereDiabetes then 'urgent' else 'routine'
+    `;
+    expect(extractCardDefinesFromCQL(cql)).toEqual({});
+  });
+
+  test('handles empty input gracefully', () => {
+    expect(extractCardDefinesFromCQL('')).toEqual({});
+    expect(extractCardDefinesFromCQL(null)).toEqual({});
+    expect(extractCardDefinesFromCQL(undefined)).toEqual({});
+  });
+
+  test('regex state is reset between invocations', () => {
+    // Global regex flags carry lastIndex across exec() calls. The extractor
+    // must reset it or the second call may miss matches.
+    const cql = `define CardSummary: 'X'`;
+    expect(extractCardDefinesFromCQL(cql)).toEqual({ summary: 'X' });
+    expect(extractCardDefinesFromCQL(cql)).toEqual({ summary: 'X' });
+  });
+});

--- a/frontend/src/modules/cds-studio/utils/cqlDefineExtractor.js
+++ b/frontend/src/modules/cds-studio/utils/cqlDefineExtractor.js
@@ -1,0 +1,44 @@
+/**
+ * Extract `define CardSummary: 'literal'` and `define CardDetail: 'literal'`
+ * from a CQL source. Returns `{ summary?: string, detail?: string }`.
+ *
+ * The platform's CQL artifact builder (cql_artifact_builder.py) wires
+ * CardSummary/CardDetail defines into PlanDefinition.action.dynamicValue
+ * so they override the static action.title/description at $apply time.
+ * That means a student who defines CardSummary in CQL doesn't also need
+ * to type a static summary into the Card Designer — the CQL value wins
+ * at runtime regardless. The wizard uses this extractor to recognize
+ * that case and show the CQL value as a read-only preview instead of
+ * an empty input.
+ *
+ * Only matches simple string-literal defines. Complex expressions
+ * (concatenation, `if/then/else`, `ToString(...)` calls) are evaluated
+ * at $apply time and aren't visible to the wizard preview — that's
+ * honest, since the rendered card text depends on patient data the
+ * preview doesn't have. Students see the dynamic value in the Test
+ * step.
+ */
+
+// `define\s+(CardSummary|CardDetail)\s*:\s*'<single-quoted body>'`
+// followed by optional whitespace and then either the next `define` keyword
+// or end-of-source. The trailing lookahead is what makes "just a string
+// literal" meaningfully different from "string-literal followed by
+// concatenation/conditional/etc": if there's any non-whitespace token
+// after the closing quote (a `+`, `if`, `(`, comment, etc.), the value
+// is a complex expression and the wizard preview can't faithfully render
+// it — so we don't match. The body permits escaped single quotes (`\'`).
+const STRING_LITERAL_DEFINE = /define\s+(CardSummary|CardDetail)\s*:\s*'((?:[^'\\]|\\.)*)'\s*(?=\bdefine\b|$)/g;
+
+export function extractCardDefinesFromCQL(cqlSource) {
+  if (!cqlSource) return {};
+  const out = {};
+  let match;
+  // Reset regex state — global regexes carry lastIndex across invocations.
+  STRING_LITERAL_DEFINE.lastIndex = 0;
+  // eslint-disable-next-line no-cond-assign
+  while ((match = STRING_LITERAL_DEFINE.exec(cqlSource)) !== null) {
+    const key = match[1] === 'CardSummary' ? 'summary' : 'detail';
+    out[key] = match[2].replace(/\\'/g, "'");
+  }
+  return out;
+}


### PR DESCRIPTION
## Why

If a student writes \`define CardSummary: 'Diabetic retinopathy screening due'\` in their CQL, the platform's artifact builder wires that as a \`PlanDefinition.action.dynamicValue\` so it overrides the static \`action.title\` at \`\$apply\` time. Today the wizard's Card Designer step still asks the student to type a static summary anyway — they're being asked to write the same string twice and the runtime silently picks one. The static value is unreachable.

This PR closes that gap: when the CQL has CardSummary or CardDetail as a string literal, the matching static input is replaced with a read-only preview showing the CQL value, plus an "Edit in CQL" link that jumps back to the Build Logic step.

## What

- New \`frontend/src/modules/cds-studio/utils/cqlDefineExtractor.js\` — regex-based extractor returning \`{ summary?, detail? }\` from CQL source. Only matches simple string literals; the trailing lookahead \`(?=\bdefine\b|\$)\` ensures complex expressions (concatenation, conditionals, \`ToString(...)\`) are NOT matched, since the wizard preview can't faithfully render them at static-time.
- \`CardDesigner\` accepts \`cqlOverrides\` and \`onJumpToCQL\` props. When \`cqlOverrides.summary\` is set, renders a \`CqlOverridePreview\` (italic body, "Edit in CQL" button) in place of the static TextField. Same for \`detail\`.
- \`VisualBuilderWizard\` runs the extractor over \`serviceConfig.cql_source\` (memoized), passes it to CardDesigner, and skips the "Card summary required" validation when CQL provides one.
- 7 unit tests cover all the edge cases.

## Decisions baked in

| Behavior | Choice |
|---|---|
| Static input when CQL has summary | Suppressed entirely (read-only preview only) |
| Complex CQL expressions | Not previewed (honest — would require partial CQL eval in browser) |
| Validation when CQL provides summary | Skipped — student isn't forced to type a duplicate |

## Test plan

- [x] \`npm test cqlDefineExtractor\` — 7/7 pass
- [x] Lint clean on all modified files
- [ ] Manual on prod: edit \`dr-screening-reminder\` (which has both \`CardSummary\` and \`CardDetail\` as strings interpolating runtime values) — Card Design step shows CQL value as read-only preview ONLY if it's a simple literal, else the static input. Try a service with a literal CardSummary → preview shows. Click "Edit in CQL" → jumps to step 1. Remove the define → preview disappears, static input reappears.

## Notes

- Stacked on #89 (which is stacked on #88). Merge #88 → #89 → this in order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)