### PR TITLE
feat(catalogs): local SQLite terminology index for fast catalog search

### DIFF
--- a/backend/scripts/active/build_terminology_index.py
+++ b/backend/scripts/active/build_terminology_index.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Build a local SQLite terminology index for catalog search.
+
+The clinical workspace dialogs (Add Condition, Add Medication, etc.) and the
+CDS Studio's ValueSet Composer query `/api/catalogs/*` for autocomplete.
+Those endpoints are layered:
+
+  1. Dynamic results extracted from actual Synthea patient data
+  2. Terminology fallback via the wintehr-* ValueSets in HAPI
+
+Layer 2 is broken: HAPI's in-memory $expand fails with HAPI-0831 ("produced
+too many codes") on the big CodeSystems (RxNorm 121K, LOINC 175K, ICD-10
+98K). The HSearch infrastructure that would index those is currently
+disabled for heap reasons. So search degrades to layer 1 only — typing
+"diabetes" returns one ICD-10 code (E11.9) instead of the full list.
+
+This script bypasses HAPI entirely for layer 2: it reads the same JSON
+CodeSystem files that `scripts/load_terminology.py` uploads to HAPI and
+builds a local SQLite index with FTS5 search over the display text.
+The backend's `LocalTerminologyIndex` queries this index instead.
+
+Domain mapping mirrors `scripts/load_terminology.py:VALUESETS` exactly so
+the local index stays aligned with the wintehr-* ValueSets that already
+live in HAPI:
+
+    medications              ← rxnorm.json  (no filter)
+    medication_ingredients   ← rxnorm.json  (TTY=IN filter)
+    conditions_icd10         ← icd10cm.json
+    conditions_snomed        ← snomed.json  (only if present; SNOMED is
+                                opt-in via UMLS Affiliate license)
+    lab_tests                ← loinc.json
+    procedures_snomed        ← snomed.json  (same caveat)
+    procedures_hcpcs         ← hcpcs.json
+    vaccines                 ← cvx.json
+    units                    ← ucum.json    (bundled in scripts/)
+    drug_classes             ← atc.json
+
+The build is idempotent: drops the existing tables and rebuilds. SQLite
+file lives at the path passed via --output (deploy.sh writes
+/app/data/terminology.db).
+
+Usage (typically via deploy.sh; see ops):
+
+    python3 backend/scripts/active/build_terminology_index.py \
+        --json-dir /tmp/fhir_vocabularies/terminology \
+        --ucum-json /tmp/ucum.json \
+        --output /app/data/terminology.db
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sqlite3
+import sys
+import time
+from pathlib import Path
+from typing import Iterable, List, Optional, Tuple
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger(__name__)
+
+# Domain → (filename in --json-dir, optional TTY filter).
+# `tty_filter` is the set of property.TTY values to include; None means
+# "include all concepts." Filenames without a `.json` ext are special
+# (`ucum` is supplied via --ucum-json since it lives outside the
+# UMLS-extracted vocabulary dir).
+JSON_DOMAINS: List[Tuple[str, str, Optional[set]]] = [
+    ("medications",            "rxnorm.json",  None),
+    ("medication_ingredients", "rxnorm.json",  {"IN"}),
+    ("conditions_icd10",       "icd10cm.json", None),
+    ("conditions_snomed",      "snomed.json",  None),
+    ("lab_tests",              "loinc.json",   None),
+    ("procedures_snomed",      "snomed.json",  None),
+    ("procedures_hcpcs",       "hcpcs.json",   None),
+    ("vaccines",               "cvx.json",     None),
+    ("drug_classes",           "atc.json",     None),
+]
+
+UCUM_DOMAIN = "units"
+
+
+def _iter_concepts(
+    code_system: dict,
+    tty_filter: Optional[set],
+) -> Iterable[Tuple[str, str, str]]:
+    """Yield (system, code, display) tuples from a CodeSystem JSON."""
+    system = code_system.get("url") or ""
+    for concept in code_system.get("concept") or []:
+        if not isinstance(concept, dict):
+            continue
+        code = concept.get("code")
+        display = concept.get("display") or ""
+        if not code or not display:
+            continue
+        if tty_filter is not None:
+            tty = (concept.get("property") or {}).get("TTY")
+            if tty not in tty_filter:
+                continue
+        yield system, code, display
+
+
+def _create_schema(conn: sqlite3.Connection) -> None:
+    """Drop and rebuild the schema. Idempotent across invocations."""
+    cur = conn.cursor()
+    cur.executescript(
+        """
+        DROP TABLE IF EXISTS concepts_fts;
+        DROP TABLE IF EXISTS concepts;
+
+        CREATE TABLE concepts (
+            domain  TEXT NOT NULL,
+            system  TEXT NOT NULL,
+            code    TEXT NOT NULL,
+            display TEXT NOT NULL,
+            PRIMARY KEY (domain, system, code)
+        );
+
+        -- FTS5 with unicode61 + remove_diacritics so 'metformin' matches
+        -- 'Metformin'. content='concepts' makes FTS a contentless shadow
+        -- of the main table; rowid pairing is via the FTS-managed rowid.
+        CREATE VIRTUAL TABLE concepts_fts USING fts5(
+            display,
+            tokenize='unicode61'
+        );
+        """
+    )
+    conn.commit()
+
+
+def _load_codesystem_json(path: Path) -> Optional[dict]:
+    if not path.exists():
+        return None
+    with open(path, "r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _ingest_domain(
+    conn: sqlite3.Connection,
+    domain: str,
+    code_system: Optional[dict],
+    tty_filter: Optional[set],
+) -> int:
+    """Insert all concepts for one domain, including FTS rows. Returns count."""
+    if code_system is None:
+        return 0
+    cur = conn.cursor()
+    rows: List[Tuple[str, str, str, str]] = []
+    fts_rows: List[Tuple[str, int]] = []
+
+    # Insert in one batch so FTS rowids line up. We rely on autoincrement-style
+    # rowid alignment between `concepts` and `concepts_fts` — both tables
+    # start empty after _create_schema and are written in lockstep.
+    for system, code, display in _iter_concepts(code_system, tty_filter):
+        rows.append((domain, system, code, display))
+
+    if not rows:
+        return 0
+
+    cur.executemany(
+        "INSERT OR IGNORE INTO concepts (domain, system, code, display) "
+        "VALUES (?, ?, ?, ?)",
+        rows,
+    )
+    # Sync FTS table from main table so rowids line up. We pull only the
+    # rows we just inserted (filter by domain). Doing this after the
+    # main insert (rather than via INSERT triggers) keeps the build script
+    # straightforward and idempotent.
+    cur.execute(
+        "INSERT INTO concepts_fts (rowid, display) "
+        "SELECT rowid, display FROM concepts WHERE domain = ?",
+        (domain,),
+    )
+    conn.commit()
+    return len(rows)
+
+
+def build_index(
+    json_dir: Path,
+    ucum_path: Optional[Path],
+    output_db: Path,
+) -> int:
+    """Build the SQLite index. Returns total concept count."""
+    output_db.parent.mkdir(parents=True, exist_ok=True)
+    if output_db.exists():
+        output_db.unlink()
+
+    conn = sqlite3.connect(str(output_db))
+    # WAL gives concurrent readers + a single writer, the right shape for
+    # a backend that holds a long-lived read connection.
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.execute("PRAGMA synchronous = NORMAL")
+
+    try:
+        _create_schema(conn)
+
+        total = 0
+        loaded_files: dict = {}  # filename → parsed CodeSystem JSON, cached
+        for domain, filename, tty_filter in JSON_DOMAINS:
+            if filename not in loaded_files:
+                loaded_files[filename] = _load_codesystem_json(json_dir / filename)
+            cs = loaded_files[filename]
+            count = _ingest_domain(conn, domain, cs, tty_filter)
+            status = "ok" if cs is not None else "missing"
+            logger.info("  %-26s %-15s %8d concepts  (%s)", domain, filename, count, status)
+            total += count
+
+        # UCUM lives outside the UMLS-extracted vocabulary dir.
+        if ucum_path is not None:
+            ucum_cs = _load_codesystem_json(ucum_path)
+            count = _ingest_domain(conn, UCUM_DOMAIN, ucum_cs, None)
+            status = "ok" if ucum_cs is not None else "missing"
+            logger.info("  %-26s %-15s %8d concepts  (%s)", UCUM_DOMAIN, ucum_path.name, count, status)
+            total += count
+        else:
+            logger.info("  %-26s (no --ucum-json provided; skipping)", UCUM_DOMAIN)
+
+        # Helper indexes for the most common access patterns. The PRIMARY
+        # KEY already covers (domain, system, code) lookups; add a domain-
+        # only index for "list everything in this domain" pagination.
+        conn.execute("CREATE INDEX idx_concepts_domain ON concepts(domain)")
+        conn.commit()
+
+        # ANALYZE so the SQLite query planner picks reasonable plans for
+        # the prefix-match queries the backend issues.
+        conn.execute("ANALYZE")
+    finally:
+        conn.close()
+
+    return total
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--json-dir",
+        required=True,
+        type=Path,
+        help="Directory containing rxnorm.json, icd10cm.json, etc.",
+    )
+    parser.add_argument(
+        "--ucum-json",
+        type=Path,
+        default=None,
+        help="Path to scripts/ucum.json (units catalog, not in UMLS extract).",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        type=Path,
+        help="Where to write the SQLite database file.",
+    )
+    args = parser.parse_args()
+
+    if not args.json_dir.is_dir():
+        logger.error("--json-dir does not exist: %s", args.json_dir)
+        return 2
+
+    started = time.monotonic()
+    logger.info("Building terminology index → %s", args.output)
+    total = build_index(args.json_dir, args.ucum_json, args.output)
+    elapsed = time.monotonic() - started
+    size_mb = args.output.stat().st_size / (1024 * 1024)
+    logger.info(
+        "Done. %d concepts, %.1f MB, %.1fs",
+        total, size_mb, elapsed,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/services/local_terminology_index.py
+++ b/backend/services/local_terminology_index.py
@@ -1,0 +1,161 @@
+"""Local terminology index — fast catalog search backed by SQLite + FTS5.
+
+Bypasses HAPI's `$expand` (broken without HSearch on this deploy: the
+in-memory expansion path can't handle the 100K-300K-concept CodeSystems
+we have loaded). The build script `scripts/active/build_terminology_index.py`
+populates the SQLite database from the same JSON CodeSystems that get
+uploaded to HAPI; this service queries it for catalog search.
+
+Public interface mirrors `services.terminology_service.TerminologyService`
+(`search_catalog`, `search_multi`) so `UnifiedCatalogService` doesn't have
+to know which backend it's talking to.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+import sqlite3
+from pathlib import Path
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _build_fts_query(filter_text: str) -> str:
+    """Convert user input to a safe FTS5 MATCH expression with prefix matching.
+
+    FTS5's query syntax is finicky — bare punctuation can produce parse errors,
+    and unquoted user text can hit reserved tokens (AND, OR, NOT, NEAR). The
+    safest pattern is to extract word tokens, double-quote each, and append
+    `*` for prefix matching so a partial term like "diab" matches "diabetes".
+    """
+    # \w in Python regex is unicode-aware; matches across Latin-extended chars
+    # too (e.g. 'naïve' in a clinical display string).
+    tokens = re.findall(r"\w+", filter_text, flags=re.UNICODE)
+    if not tokens:
+        return ""
+    # Each token becomes "tok"* — prefix match against an exact token.
+    # Combining with implicit AND (the default) means all tokens must match.
+    return " ".join(f'"{tok}"*' for tok in tokens)
+
+
+class LocalTerminologyIndex:
+    """SQLite-backed terminology lookup for catalog search.
+
+    Same interface as `TerminologyService`: `search_catalog` and
+    `search_multi` return `[{system, code, display}, ...]`.
+
+    Connection model: a single read-only SQLite connection held for the
+    lifetime of the process. SQLite reads in WAL mode are concurrent-safe;
+    the build script is the only writer and runs at deploy time, not at
+    request time, so there's no contention.
+    """
+
+    def __init__(self, db_path: str):
+        self._db_path = db_path
+        self._conn: Optional[sqlite3.Connection] = None
+
+    def _connect(self) -> Optional[sqlite3.Connection]:
+        if self._conn is not None:
+            return self._conn
+        path = Path(self._db_path)
+        if not path.exists():
+            # Caller should have checked existence already, but be defensive
+            # — losing the index between startup and first query (e.g. on
+            # rebuild) shouldn't crash search.
+            logger.warning("Terminology index missing at %s; returning empty", self._db_path)
+            return None
+        # mode=ro + immutable=1 makes this read-only; the build script's
+        # rebuild reopens fresh anyway.
+        uri = f"file:{self._db_path}?mode=ro"
+        try:
+            self._conn = sqlite3.connect(uri, uri=True, check_same_thread=False)
+        except sqlite3.Error as exc:
+            logger.error("Failed to open terminology index at %s: %s", self._db_path, exc)
+            return None
+        return self._conn
+
+    def close(self) -> None:
+        if self._conn is not None:
+            self._conn.close()
+            self._conn = None
+
+    async def search_catalog(
+        self,
+        catalog_type: str,
+        filter_text: Optional[str] = None,
+        count: int = 50,
+    ) -> List[Dict[str, str]]:
+        """Search a single domain. Returns up to `count` matches."""
+        return await asyncio.to_thread(
+            self._search_sync, catalog_type, filter_text, count
+        )
+
+    async def search_multi(
+        self,
+        catalog_types: List[str],
+        filter_text: Optional[str] = None,
+        count: int = 50,
+    ) -> Dict[str, List[Dict[str, str]]]:
+        """Search multiple domains concurrently."""
+        results = await asyncio.gather(
+            *[self.search_catalog(ct, filter_text, count) for ct in catalog_types],
+            return_exceptions=True,
+        )
+        out: Dict[str, List[Dict[str, str]]] = {}
+        for ct, result in zip(catalog_types, results):
+            if isinstance(result, Exception):
+                logger.warning("Local terminology search failed for %s: %s", ct, result)
+                out[ct] = []
+            else:
+                out[ct] = result
+        return out
+
+    def _search_sync(
+        self,
+        domain: str,
+        filter_text: Optional[str],
+        count: int,
+    ) -> List[Dict[str, str]]:
+        conn = self._connect()
+        if conn is None:
+            return []
+        try:
+            if filter_text and filter_text.strip():
+                fts_query = _build_fts_query(filter_text)
+                if not fts_query:
+                    # All tokens were stripped — fall through to unfiltered
+                    # so the caller gets some results rather than empty.
+                    return self._fetch_unfiltered(conn, domain, count)
+                rows = conn.execute(
+                    """
+                    SELECT c.system, c.code, c.display
+                    FROM concepts_fts f
+                    JOIN concepts c ON c.rowid = f.rowid
+                    WHERE c.domain = ?
+                      AND concepts_fts MATCH ?
+                    LIMIT ?
+                    """,
+                    (domain, fts_query, count),
+                ).fetchall()
+            else:
+                return self._fetch_unfiltered(conn, domain, count)
+        except sqlite3.Error as exc:
+            logger.warning("Local terminology query failed for %s: %s", domain, exc)
+            return []
+
+        return [{"system": s, "code": c, "display": d} for s, c, d in rows]
+
+    @staticmethod
+    def _fetch_unfiltered(
+        conn: sqlite3.Connection,
+        domain: str,
+        count: int,
+    ) -> List[Dict[str, str]]:
+        rows = conn.execute(
+            "SELECT system, code, display FROM concepts WHERE domain = ? LIMIT ?",
+            (domain, count),
+        ).fetchall()
+        return [{"system": s, "code": c, "display": d} for s, c, d in rows]

--- a/backend/services/terminology_service.py
+++ b/backend/services/terminology_service.py
@@ -1,21 +1,38 @@
 """
-Terminology Service — FHIR ValueSet $expand wrapper for catalog search.
+Terminology Service — vocabulary search backend for catalog endpoints.
 
-Provides vocabulary search across HAPI FHIR-loaded ValueSets (SNOMED, RxNorm,
-LOINC, ICD-10-CM, CVX, HCPCS, etc.) with in-memory caching.
+Two implementations live here:
 
-Used by UnifiedCatalogService to provide comprehensive vocabulary coverage
-beyond what exists in patient data.
+  - `LocalTerminologyIndex` (preferred): SQLite + FTS5 index built from the
+    JSON CodeSystems we extract from UMLS. Fast prefix-match search, no
+    HAPI dependency.
+  - `_HapiTerminologyService`: legacy `$expand` wrapper around HAPI's
+    ValueSet expansion. Currently broken because HSearch is disabled —
+    `$expand` against the wintehr-* ValueSets aborts with HAPI-0831
+    ("produced too many codes"). Kept as a fallback so deploys without
+    the index file built (dev environments, fresh restores) don't crash;
+    they just degrade to dynamic-only catalog search.
+
+`get_terminology_service()` picks the local index when
+`/app/data/terminology.db` (or `$TERMINOLOGY_DB_PATH`) exists, falling
+back to the HAPI implementation otherwise. `UnifiedCatalogService`
+doesn't see the difference — both expose `search_catalog` and
+`search_multi`.
 """
 
 import asyncio
 import logging
+import os
 from datetime import datetime, timedelta
+from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
 from services.hapi_fhir_client import HAPIFHIRClient
+from services.local_terminology_index import LocalTerminologyIndex
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_TERMINOLOGY_DB_PATH = "/app/data/terminology.db"
 
 # ValueSet IDs loaded by scripts/load_terminology.py
 CATALOG_VALUESETS = {
@@ -34,8 +51,16 @@ CATALOG_VALUESETS = {
 CACHE_TTL_SECONDS = 600  # 10 minutes
 
 
-class TerminologyService:
-    """Wraps HAPI FHIR $expand for vocabulary search with caching."""
+class _HapiTerminologyService:
+    """Wraps HAPI FHIR $expand for vocabulary search with caching.
+
+    Fallback path. Currently degraded — `$expand` against the wintehr-*
+    ValueSets returns HAPI-0831 / HAPI-0888 errors because HSearch is
+    disabled. The catalog endpoints catch the empty result and fall back
+    to dynamic-from-Synthea data, which is the "1 result for diabetes"
+    behavior students see today. Use `LocalTerminologyIndex` instead
+    when the SQLite index has been built (deploy.sh handles that).
+    """
 
     def __init__(self):
         self.hapi_client = HAPIFHIRClient()
@@ -123,11 +148,38 @@ class TerminologyService:
         return out
 
 
-_terminology_service: Optional[TerminologyService] = None
+# Public type alias for the dependency-injection annotations in routers.
+# Both backends expose the same `search_catalog` / `search_multi` interface;
+# the type alias just keeps existing `Depends(get_terminology_service)`
+# annotations valid without callers needing to know which is active.
+TerminologyService = LocalTerminologyIndex  # alias for type annotations
 
 
-def get_terminology_service() -> TerminologyService:
+_terminology_service = None
+
+
+def get_terminology_service():
+    """Return the preferred terminology backend.
+
+    Picks LocalTerminologyIndex if `/app/data/terminology.db` (or the
+    override at `$TERMINOLOGY_DB_PATH`) is present. Otherwise falls
+    back to the HAPI-based implementation. The choice is sticky for
+    the lifetime of the process — restart the backend after building
+    the index to switch over.
+    """
     global _terminology_service
-    if _terminology_service is None:
-        _terminology_service = TerminologyService()
+    if _terminology_service is not None:
+        return _terminology_service
+
+    db_path = os.getenv("TERMINOLOGY_DB_PATH", DEFAULT_TERMINOLOGY_DB_PATH)
+    if Path(db_path).exists():
+        logger.info("Using LocalTerminologyIndex (db=%s)", db_path)
+        _terminology_service = LocalTerminologyIndex(db_path)
+    else:
+        logger.warning(
+            "Terminology index missing at %s; falling back to HAPI $expand "
+            "(degraded — catalog search will return only dynamic-from-patient-data results)",
+            db_path,
+        )
+        _terminology_service = _HapiTerminologyService()
     return _terminology_service

--- a/backend/tests/services/test_local_terminology_index.py
+++ b/backend/tests/services/test_local_terminology_index.py
@@ -1,0 +1,213 @@
+"""Tests for the local terminology index — build script + LocalTerminologyIndex.
+
+Round-trips fixture JSON through `build_terminology_index.py` into a
+tmpdir SQLite file, then exercises the search behaviors that catalog
+endpoints depend on. These tests don't touch HAPI or the database — the
+index is intentionally HAPI-independent.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+# `backend/` is the repo's PYTHONPATH root in production (uvicorn runs
+# from there); test-time we have to add it explicitly because pytest's
+# rootdir is the repo root.
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(BACKEND_ROOT))
+sys.path.insert(0, str(BACKEND_ROOT / "scripts" / "active"))
+
+import build_terminology_index  # noqa: E402
+from services.local_terminology_index import (  # noqa: E402
+    LocalTerminologyIndex,
+    _build_fts_query,
+)
+
+
+@pytest.fixture
+def fixture_json_dir(tmp_path: Path) -> Path:
+    """Write small CodeSystem JSON fixtures the build script can read."""
+    rxnorm = {
+        "url": "http://www.nlm.nih.gov/research/umls/rxnorm",
+        "name": "RxNorm",
+        "concept": [
+            {"code": "860975", "display": "Metformin hydrochloride 500 MG Tablet", "property": {"TTY": "SCD"}},
+            {"code": "6809",   "display": "metformin",                              "property": {"TTY": "IN"}},
+            {"code": "1551291","display": "lisinopril 10 MG Oral Tablet",           "property": {"TTY": "SCD"}},
+            {"code": "29046",  "display": "lisinopril",                             "property": {"TTY": "IN"}},
+        ],
+    }
+    icd = {
+        "url": "http://hl7.org/fhir/sid/icd-10-cm",
+        "name": "ICD-10-CM",
+        "concept": [
+            {"code": "E11.9",  "display": "Type 2 diabetes mellitus without complications"},
+            {"code": "E11.65", "display": "Type 2 diabetes mellitus with hyperglycemia"},
+            {"code": "I10",    "display": "Essential (primary) hypertension"},
+        ],
+    }
+    (tmp_path / "rxnorm.json").write_text(json.dumps(rxnorm))
+    (tmp_path / "icd10cm.json").write_text(json.dumps(icd))
+    return tmp_path
+
+
+@pytest.fixture
+def built_db(tmp_path: Path, fixture_json_dir: Path) -> Path:
+    """Run the build script against the fixture JSON; return the DB path."""
+    output = tmp_path / "terminology.db"
+    total = build_terminology_index.build_index(
+        json_dir=fixture_json_dir,
+        ucum_path=None,
+        output_db=output,
+    )
+    # 4 medications + 2 ingredients (TTY=IN filter) + 3 ICD-10 conditions
+    assert total == 9
+    return output
+
+
+# -- _build_fts_query -------------------------------------------------------
+
+def test_fts_query_simple_word():
+    assert _build_fts_query("metformin") == '"metformin"*'
+
+
+def test_fts_query_multiple_tokens_anded():
+    # FTS5 default operator is AND; both tokens must match.
+    assert _build_fts_query("type 2 diabetes") == '"type"* "2"* "diabetes"*'
+
+
+def test_fts_query_strips_punctuation():
+    # Apostrophes/parens shouldn't reach FTS5 — they break the parser.
+    assert _build_fts_query("Patient's (chronic)") == '"Patient"* "s"* "chronic"*'
+
+
+def test_fts_query_empty_input():
+    assert _build_fts_query("") == ""
+    assert _build_fts_query("   ") == ""
+    assert _build_fts_query("()") == ""
+
+
+# -- build_index ------------------------------------------------------------
+
+def test_build_index_creates_expected_schema(built_db: Path):
+    conn = sqlite3.connect(str(built_db))
+    tables = {row[0] for row in conn.execute(
+        "SELECT name FROM sqlite_master WHERE type IN ('table','index') AND name NOT LIKE 'sqlite_%'"
+    )}
+    conn.close()
+    assert "concepts" in tables
+    assert "concepts_fts" in tables
+    assert "idx_concepts_domain" in tables
+
+
+def test_build_index_tty_filter_for_ingredients(built_db: Path):
+    """medication_ingredients only contains TTY=IN concepts."""
+    conn = sqlite3.connect(str(built_db))
+    rows = conn.execute(
+        "SELECT code, display FROM concepts WHERE domain = 'medication_ingredients' ORDER BY code"
+    ).fetchall()
+    conn.close()
+    assert rows == [
+        ("29046", "lisinopril"),
+        ("6809",  "metformin"),
+    ]
+
+
+def test_build_index_idempotent(tmp_path: Path, fixture_json_dir: Path):
+    """Running the build twice produces the same row count, no duplication."""
+    output = tmp_path / "terminology.db"
+    build_terminology_index.build_index(fixture_json_dir, None, output)
+    first = sqlite3.connect(str(output)).execute("SELECT COUNT(*) FROM concepts").fetchone()[0]
+    build_terminology_index.build_index(fixture_json_dir, None, output)
+    second = sqlite3.connect(str(output)).execute("SELECT COUNT(*) FROM concepts").fetchone()[0]
+    assert first == second == 9
+
+
+def test_build_index_handles_missing_files(tmp_path: Path):
+    """If a domain's source JSON is absent, that domain is empty (not an error)."""
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()
+    output = tmp_path / "terminology.db"
+    total = build_terminology_index.build_index(empty_dir, None, output)
+    assert total == 0
+    conn = sqlite3.connect(str(output))
+    # Schema still exists so search returns [] cleanly rather than crashing.
+    rows = conn.execute("SELECT COUNT(*) FROM concepts").fetchone()
+    assert rows == (0,)
+
+
+# -- LocalTerminologyIndex search ------------------------------------------
+
+@pytest.mark.asyncio
+async def test_search_catalog_prefix_match(built_db: Path):
+    """Typing 'metf' returns both metformin medication entries."""
+    idx = LocalTerminologyIndex(str(built_db))
+    try:
+        results = await idx.search_catalog("medications", "metf", count=10)
+    finally:
+        idx.close()
+    codes = {r["code"] for r in results}
+    assert codes == {"860975", "6809"}
+
+
+@pytest.mark.asyncio
+async def test_search_catalog_multi_token_anded(built_db: Path):
+    """'type 2' returns both Type 2 diabetes rows but not hypertension."""
+    idx = LocalTerminologyIndex(str(built_db))
+    try:
+        results = await idx.search_catalog("conditions_icd10", "type 2 diabetes", count=10)
+    finally:
+        idx.close()
+    codes = {r["code"] for r in results}
+    assert codes == {"E11.9", "E11.65"}
+
+
+@pytest.mark.asyncio
+async def test_search_catalog_no_filter_returns_all(built_db: Path):
+    """No filter returns every concept in the domain (up to count)."""
+    idx = LocalTerminologyIndex(str(built_db))
+    try:
+        results = await idx.search_catalog("conditions_icd10", None, count=100)
+    finally:
+        idx.close()
+    assert len(results) == 3
+
+
+@pytest.mark.asyncio
+async def test_search_catalog_unknown_domain_empty(built_db: Path):
+    idx = LocalTerminologyIndex(str(built_db))
+    try:
+        results = await idx.search_catalog("not_a_real_domain", "anything", count=10)
+    finally:
+        idx.close()
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_search_catalog_missing_db_returns_empty(tmp_path: Path):
+    """Missing index file shouldn't crash — return [] so callers degrade gracefully."""
+    idx = LocalTerminologyIndex(str(tmp_path / "does-not-exist.db"))
+    results = await idx.search_catalog("medications", "anything", count=10)
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_search_multi_runs_concurrently(built_db: Path):
+    """search_multi returns one entry per requested domain."""
+    idx = LocalTerminologyIndex(str(built_db))
+    try:
+        results = await idx.search_multi(
+            ["medications", "conditions_icd10"], "lisinopril", count=10
+        )
+    finally:
+        idx.close()
+    assert set(results.keys()) == {"medications", "conditions_icd10"}
+    # 'lisinopril' matches both lisinopril rows in medications and nothing
+    # in conditions.
+    assert {r["code"] for r in results["medications"]} == {"1551291", "29046"}
+    assert results["conditions_icd10"] == []

--- a/deploy.sh
+++ b/deploy.sh
@@ -677,6 +677,42 @@ else
 fi
 echo ""
 
+# Build the local terminology index for catalog search.
+# Background: HAPI's $expand against the loaded CodeSystems is broken
+# without HSearch (HAPI-0831 "produced too many codes"), so /api/catalogs/*
+# search degrades to dynamic-from-Synthea results only — typing "diabetes"
+# returns 1 result instead of the full ICD-10/SNOMED list. The local
+# SQLite index gives the catalog endpoints a fast search path that doesn't
+# depend on HAPI's expansion. The backend's terminology service factory
+# auto-detects the index file and uses it; no env var or feature flag.
+if [ -d "$HOME/fhir_vocabularies/terminology" ] && \
+   [ -n "$(ls -A $HOME/fhir_vocabularies/terminology/*.json 2>/dev/null)" ]; then
+    echo -e "${BLUE}🔍 Building local terminology index for catalog search...${NC}"
+
+    docker exec emr-backend mkdir -p /app/data
+
+    # The build script lives in the backend image; the JSON files were
+    # copied into /tmp/fhir_vocabularies during the load step above.
+    # ucum.json is bundled in the repo (not in UMLS) — copy it in.
+    docker cp scripts/ucum.json emr-backend:/tmp/ucum.json 2>/dev/null || true
+
+    if docker exec emr-backend python3 \
+        /app/scripts/active/build_terminology_index.py \
+        --json-dir /tmp/fhir_vocabularies/terminology \
+        --ucum-json /tmp/ucum.json \
+        --output /app/data/terminology.db; then
+        echo -e "${GREEN}✓ Local terminology index built — restart emr-backend to pick it up${NC}"
+        # The factory caches the chosen backend per-process, so an existing
+        # backend that booted before the index was built keeps using the
+        # HAPI fallback. Restart picks up the new index immediately.
+        docker restart emr-backend > /dev/null
+        echo "   emr-backend restarted; catalog search now uses the local index"
+    else
+        echo -e "${YELLOW}⚠️  Index build failed — catalog search will degrade to dynamic-only (HAPI \$expand fallback)${NC}"
+    fi
+    echo ""
+fi
+
 # Step 5: Configure Azure NSG (if Azure deployment and prod profile)
 AZURE_RESOURCE_GROUP="${WINTEHR_AZURE_RESOURCE_GROUP:-${AZURE_RESOURCE_GROUP:-}}"
 if [ -n "$AZURE_RESOURCE_GROUP" ] && [ "$PROFILE" = "prod" ]; then


### PR DESCRIPTION
## Why

Catalog search dialogs (Add Condition, Add Medication, CDS Studio's ValueSet Composer) return ~1 result per query because HAPI's \`\$expand\` against the wintehr-* ValueSets is broken. The vocabularies are loaded as CodeSystems (RxNorm 121K, LOINC 175K, ICD-10 98K, HCPCS, CVX, ATC, UCUM) but the in-memory expansion path aborts:

\`\`\`
$expand wintehr-conditions-icd10 → HAPI-0831: produced too many codes (max 3) - aborted
$expand wintehr-medications       → HAPI-0831: aborted
$expand wintehr-lab-tests         → HAPI-0888: cannot expand ValueSet
$expand wintehr-conditions-snomed → 0 results (SNOMED missing)
\`\`\`

HAPI counts the underlying CodeSystem size BEFORE applying \`filter=\` and \`count=\`, so it bombs on anything large. The HAPI-side fix is HSearch (Hibernate Search + Lucene/ES indexing), but that crashed under heap pressure last time and isn't worth the infra churn for an educational platform.

This PR bypasses HAPI for catalog search by building a local SQLite index from the same JSON CodeSystems we already extract from UMLS.

## What

1. **\`backend/scripts/active/build_terminology_index.py\`** — reads \`~/fhir_vocabularies/terminology/*.json\` and \`scripts/ucum.json\`. Writes a SQLite DB with one row per (domain, system, code) tuple and an FTS5 virtual table for prefix-match search. Domain mapping mirrors \`scripts/load_terminology.py:VALUESETS\` exactly (10 domains incl. \`medication_ingredients\` with the TTY=IN filter). Idempotent.
2. **\`backend/services/local_terminology_index.py\`** — \`LocalTerminologyIndex\` exposes the same \`search_catalog\` / \`search_multi\` interface as the existing service. FTS5 prefix matching with safe input handling (\`_build_fts_query\` extracts word tokens, double-quotes each, appends \`*\` — apostrophes/parens/reserved keywords can't break the parser).
3. **\`backend/services/terminology_service.py\`** — factory now picks \`LocalTerminologyIndex\` when \`/app/data/terminology.db\` (or \`\$TERMINOLOGY_DB_PATH\`) exists, falls back to renamed \`_HapiTerminologyService\` otherwise. \`UnifiedCatalogService\` doesn't change. \`TerminologyService\` kept as a type alias for backward-compatible imports.
4. **\`deploy.sh\`** — after the existing terminology-load block, builds the index inside \`emr-backend\` and restarts the backend so the factory picks it up. No-op when JSON files aren't present.
5. **Tests** — 14 unit tests covering the build (schema, idempotency, TTY filter, missing files) and search (prefix, multi-token, no-filter, unknown domain, missing DB graceful degradation). All pass.

## Domain mapping

| Domain | Source JSON | Filter |
|---|---|---|
| medications | \`rxnorm.json\` | none |
| medication_ingredients | \`rxnorm.json\` | \`property.TTY = 'IN'\` |
| conditions_icd10 | \`icd10cm.json\` | none |
| conditions_snomed | \`snomed.json\` (when present) | none |
| lab_tests | \`loinc.json\` | none |
| procedures_snomed | \`snomed.json\` (when present) | none |
| procedures_hcpcs | \`hcpcs.json\` | none |
| vaccines | \`cvx.json\` | none |
| units | \`scripts/ucum.json\` | none |
| drug_classes | \`atc.json\` | none |

SNOMED domains stay empty until someone re-extracts with \`--include-snomed\`. Adding SNOMED later: drop \`snomed.json\` into \`~/fhir_vocabularies/terminology/\`, redeploy → one rebuild + restart fills both SNOMED domains with zero other changes.

## Verification

- [x] 14/14 unit tests pass
- [ ] After deploy on prod: \`/api/catalogs/conditions?search=diabetes&limit=10\` returns ~10 results (was 1). Same for \`metformin\` and \`glucose\`.
- [ ] Open Add Condition dialog in clinical workspace, type "diabetes" — autocomplete shows the full ICD-10 list.
- [ ] CDS Studio's ValueSet Composer search for "diabetes" surfaces broader results.
- [ ] No regression on \`dr-screening-reminder\` firing — the inline-rewrite path doesn't go through the terminology service.

## Rollback

\`rm /app/data/terminology.db\` and restart \`emr-backend\` → factory falls back to \`_HapiTerminologyService\` and behavior reverts to today's "1 result per query" mode. Zero data risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)