### PR TITLE
fix(deploy): copy terminology JSON into container before index build

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -685,14 +685,17 @@ echo ""
 # SQLite index gives the catalog endpoints a fast search path that doesn't
 # depend on HAPI's expansion. The backend's terminology service factory
 # auto-detects the index file and uses it; no env var or feature flag.
+#
+# Copy the JSON into the container ourselves rather than relying on the
+# load-to-HAPI step above — when HAPI already has terminology loaded, that
+# step short-circuits and never populates /tmp/fhir_vocabularies, so the
+# build would fail with `--json-dir does not exist`.
 if [ -d "$HOME/fhir_vocabularies/terminology" ] && \
    [ -n "$(ls -A $HOME/fhir_vocabularies/terminology/*.json 2>/dev/null)" ]; then
     echo -e "${BLUE}🔍 Building local terminology index for catalog search...${NC}"
 
-    docker exec emr-backend mkdir -p /app/data
-
-    # The build script lives in the backend image; the JSON files were
-    # copied into /tmp/fhir_vocabularies during the load step above.
+    docker exec emr-backend mkdir -p /app/data /tmp/fhir_vocabularies
+    docker cp "$HOME/fhir_vocabularies/terminology" emr-backend:/tmp/fhir_vocabularies/
     # ucum.json is bundled in the repo (not in UMLS) — copy it in.
     docker cp scripts/ucum.json emr-backend:/tmp/ucum.json 2>/dev/null || true
 


### PR DESCRIPTION
## Why

The terminology-load step in deploy.sh that copies \`~/fhir_vocabularies/terminology\` into \`/tmp/fhir_vocabularies\` inside the backend container short-circuits when HAPI already has terminology loaded:

\`\`\`
📚 Checking terminology state...
✓ Terminology already loaded (RxNorm CodeSystem present in HAPI)
\`\`\`

The new index-build step from #91 assumed that copy had run, so it bombed on prod with:

\`\`\`
🔍 Building local terminology index for catalog search...
--json-dir does not exist: /tmp/fhir_vocabularies/terminology
⚠️  Index build failed
\`\`\`

I built the index manually on prod after the deploy and the catalog endpoints now return ~10 results (was 1) for diabetes/metformin/glucose. This PR makes future clean deploys do that automatically.

## Fix

Have the index-build step \`docker cp\` the JSON itself instead of relying on the load step. ~50MB extra copy, much faster than the index build itself.

## Test plan

- [x] Manually verified the build works against prod's data — 425,576 concepts indexed across 8 domains, 125MB SQLite, 11s.
- [ ] Next clean deploy on prod (or on a fresh dev environment): index builds automatically, no manual intervention needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)