### PR TITLE
feat(cds-studio): allow spaces in ValueSet names

### DIFF
--- a/backend/api/cds_studio/value_set_composer.py
+++ b/backend/api/cds_studio/value_set_composer.py
@@ -60,8 +60,15 @@ WINTEHR_FHIR_BASE = os.getenv("WINTEHR_FHIR_BASE", "http://wintehr.example.org")
 # Mirrors FHIR id constraints with a stricter character set so we don't accidentally
 # clash with system terminology ids loaded by load_terminology.py.
 _VS_ID_RE = re.compile(r"^[a-z][a-z0-9-]{2,63}$")
-# FHIR Name should be a valid CQL identifier — letters/digits/underscores, starts with letter.
-_FHIR_NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]*$")
+# Name accepts a human-readable label. CQL `valueset "X": '...'` declarations
+# take quoted identifiers (any string in double quotes), so spaces are valid;
+# FHIR `ValueSet.name` is data type `string`, not `id`, so spaces are spec-legal
+# there too. The earlier no-spaces rule was overly strict — it forced the
+# declaration name to PascalCase while LLM-generated retrieves naturally use
+# spaced names like `[Condition: "Diabetes Mellitus"]`, producing a mismatch
+# the student then had to debug. We still require a leading letter and
+# disallow weirdness like newlines/control chars; everything else is allowed.
+_FHIR_NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_ \-]{0,499}$")
 
 
 # ---------------------------------------------------------------------------
@@ -83,7 +90,9 @@ class ValueSetCreateRequest(BaseModel):
     )
     name: str = Field(
         ..., max_length=500,
-        description="FHIR Name (computer-friendly, valid CQL identifier)",
+        description="Display name. Used as ValueSet.name and as the quoted "
+        "identifier in CQL declarations (e.g. `valueset \"Diabetes Mellitus\": ...`). "
+        "Spaces and hyphens are allowed; must start with a letter.",
     )
     title: Optional[str] = Field(None, max_length=500, description="Human-readable title")
     description: Optional[str] = Field(None, description="What this ValueSet captures")
@@ -94,9 +103,19 @@ class ValueSetCreateRequest(BaseModel):
     @field_validator("name")
     @classmethod
     def _validate_name(cls, v: str) -> str:
+        # Normalize whitespace before regex check: strip leading/trailing
+        # space, collapse internal runs to a single space. Without this
+        # the looser regex would let a student create "Diabetes " (trailing
+        # space) — invisible in most UIs but a byte mismatch against
+        # `[Condition: "Diabetes"]` retrieves. Better to silently
+        # canonicalize than to ship the footgun.
+        v = re.sub(r"\s+", " ", (v or "").strip())
+        if not v:
+            raise ValueError("name is required")
         if not _FHIR_NAME_RE.match(v):
             raise ValueError(
-                "name must be a valid identifier (letters/digits/underscores, starts with letter)"
+                "name must start with a letter and contain only letters, "
+                "digits, spaces, hyphens, or underscores"
             )
         return v
 

--- a/docs/CQL_AUTHORING_PROMPT.md
+++ b/docs/CQL_AUTHORING_PROMPT.md
@@ -329,3 +329,17 @@ four fixes are now baked in above:
 If a future student/LLM produces CQL that fails for a new reason, add a
 section here documenting the failure mode and update the prompt above so it
 doesn't recur.
+
+### 2026-05-04 — Composer now allows spaced ValueSet names
+
+Originally the ValueSet Composer enforced PascalCase identifiers (no
+spaces) for `ValueSet.name`, while LLM-generated retrieves naturally
+read as `[Condition: "Diabetes Mellitus"]`. That mismatch was the
+naming-consistency bug above (#2 in the prior section). With the
+composer relaxed (PR #93), the same string can be used end-to-end:
+the `Name` field accepts `"Diabetes Mellitus"`, the FHIR
+`ValueSet.name` is stored that way, and the inserted CQL declaration
+`valueset "Diabetes Mellitus": '...'` lines up with the retrieve.
+The "naming consistency" rule still applies — declaration name and
+retrieve name must match — but it's now a much smaller hazard
+because the natural form works everywhere.

--- a/frontend/src/modules/cds-studio/components/builders/ValueSetComposer.jsx
+++ b/frontend/src/modules/cds-studio/components/builders/ValueSetComposer.jsx
@@ -78,7 +78,13 @@ const KNOWN_SYSTEMS = [
   { uri: 'http://terminology.hl7.org/CodeSystem/v3-ActCode', label: 'HL7 ActCode' },
 ];
 
-const FHIR_NAME_RE = /^[A-Za-z][A-Za-z0-9_]*$/;
+// Name is the quoted identifier used in CQL `valueset "X": '...'` declarations
+// AND the FHIR `ValueSet.name` field. CQL accepts arbitrary quoted strings so
+// spaces are fine; FHIR `name` is data type `string` (not `id`), so spaces are
+// spec-legal there too. Earlier rule (PascalCase only) forced declarations to
+// disagree with LLM-generated retrieves like `[Condition: "Diabetes Mellitus"]`,
+// which students then had to debug. We just require a leading letter.
+const FHIR_NAME_RE = /^[A-Za-z][A-Za-z0-9_ -]{0,499}$/;
 
 /**
  * @param {object} props
@@ -297,16 +303,16 @@ const ValueSetComposer = ({
             </Typography>
             <Stack direction={{ xs: 'column', md: 'row' }} spacing={2}>
               <TextField
-                label="Name (CQL identifier)"
+                label="Name"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
-                placeholder="DiabetesConditions"
+                placeholder="Diabetes Mellitus"
                 helperText={
                   isEditMode
                     ? "Name is the canonical identity; rename isn't supported (would re-publish under a new URL)."
                     : (nameValid || !name
-                      ? 'Letters/digits/underscores; starts with letter (e.g. DiabetesConditions)'
-                      : 'Invalid identifier — no hyphens or spaces')
+                      ? 'Used in CQL as `valueset "Name": ...` and in retrieves. Spaces are fine.'
+                      : 'Must start with a letter; only letters, digits, spaces, hyphens, and underscores allowed.')
                 }
                 error={!!name && !nameValid}
                 disabled={isEditMode}


### PR DESCRIPTION
## Why

The composer's name regex was \`^[A-Za-z][A-Za-z0-9_]*\$\` — strict PascalCase, no spaces, no hyphens. Comment claimed it had to be a "valid CQL identifier," which is wrong:

- **CQL** \`valueset "X": '...'\` takes a *quoted identifier* — any string in double quotes. Spaces are valid.
- **FHIR** \`ValueSet.name\` is data type \`string\`, not \`id\`. Spaces are spec-legal.

The over-strict regex was the source of the dr-screening-reminder \`Could not resolve identifier "Diabetes Mellitus"\` bug: the LLM generated natural retrieves like \`[Condition: "Diabetes Mellitus"]\` but the composer forced \`valueset "DiabetesMellitus": '...'\` — CQL treats those as different identifiers and the library won't compile. Students had to manually reconcile the two halves with no spec backing.

## Fix

Relax to \`^[A-Za-z][A-Za-z0-9_ -]{0,499}\$\` on both ends (backend Pydantic validator + frontend regex). Must start with a letter; otherwise letters/digits/spaces/hyphens/underscores. The 500-char cap matches the existing \`max_length=500\` on the field. \`derive_vs_id\` already slugifies spaces to \`-\`, so the FHIR resource id stays clean (\`"Diabetes Mellitus"\` → \`vs_id="diabetes-mellitus"\`).

Updated:
- Backend Pydantic field description and validator error message
- Frontend placeholder ("Diabetes Mellitus") and helper text
- Comment in both files explaining why the regex is looser than \`id\`
- Prompt doc Changelog entry noting the looser rule

## Verification

- [x] Regex tested against positives (\`Diabetes Mellitus\`, \`Hemoglobin A1c\`, \`COVID-19\`, \`Type 2 diabetes\`, \`foo_bar\`, PascalCase) and negatives (\`1diabetes\`, empty, leading-space, embedded newline).
- [ ] After deploy: open the ValueSet Composer, type \`Diabetes Mellitus\` — accepts. Save. Confirm the CQL editor inserts \`valueset "Diabetes Mellitus": '...'\` and a retrieve \`[Condition: "Diabetes Mellitus"]\` matches.

## Notes

- The \`_VS_ID_RE\` (FHIR resource id) stays strict — that's the actual FHIR \`id\` data type and IS spec-constrained to \`[A-Za-z0-9-.]\`. Resource ids derive from name via \`derive_vs_id\` slugification.
- Existing ValueSets created under the old regex still work — this only loosens what's accepted on create/edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)