### PR TITLE
fix(cds-studio): Pydantic v2 model_validate in full-edit-state endpoint

### DIFF
--- a/backend/api/cds_studio/visual_builder_router.py
+++ b/backend/api/cds_studio/visual_builder_router.py
@@ -369,7 +369,10 @@ async def get_full_edit_state(
                 })
 
     return {
-        "service": VisualServiceConfigResponse.from_orm(service),
+        # Pydantic v2 — `model_validate` replaces v1's `from_orm`. Pairs with
+        # `from_attributes=True` on VisualServiceConfigResponse.Config to read
+        # the SQLAlchemy ORM object's attributes.
+        "service": VisualServiceConfigResponse.model_validate(service),
         "value_sets": referenced,
     }
 

--- a/backend/api/cds_studio/visual_service_config.py
+++ b/backend/api/cds_studio/visual_service_config.py
@@ -350,7 +350,12 @@ class VisualServiceConfigResponse(BaseModel):
     # - analytics
 
     class Config:
-        orm_mode = True
+        # Pydantic v2 — `from_attributes=True` is the new spelling of v1's
+        # `orm_mode=True`. Required so `VisualServiceConfigResponse.model_validate(orm_obj)`
+        # reads attributes from the SQLAlchemy row instead of treating it
+        # as a dict. (FastAPI's response_model path tolerates the v1 key
+        # but explicit model_validate calls don't.)
+        from_attributes = True
 
 
 class ServiceDeploymentRequest(BaseModel):


### PR DESCRIPTION
## Why

Edit-mode in the visual builder wizard was failing with "Failed to load service for editing" because the \`/full-edit-state\` endpoint added in #88 called \`VisualServiceConfigResponse.from_orm(service)\`. \`from_orm\` is Pydantic v1; under v2.13 it raises \`PydanticUserError: You must set the config attribute \`from_attributes=True\` to use from_orm\`.

The other endpoints that return \`VisualServiceConfigResponse\` keep working because they just \`return service\` and FastAPI's response_model serializer handles the conversion (which silently tolerates the v1 \`orm_mode\` key). Only my explicit-call path hit the breakage.

## Fix

1. \`VisualServiceConfigResponse.from_orm(service)\` → \`.model_validate(service)\` (v2 spelling).
2. \`class Config: orm_mode = True\` → \`from_attributes = True\` (the v2 attribute that \`model_validate\` needs to read SQLAlchemy ORM attributes).

## Verification

Live-patched the container to confirm:

\`\`\`
GET /api/cds-visual-builder/services/dr-screening-reminder/full-edit-state
→ HTTP 200, service config + 4 referenced ValueSets
\`\`\`

This PR makes that fix permanent. No deploy strictly required (the live patch is already in place) but a rebuild from master would otherwise revert the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)