### PR TITLE
fix(cds): patient summary page no longer shows previous patient's CDS cards

### DIFF
--- a/frontend/src/components/clinical/dashboard/PatientSummaryV4.js
+++ b/frontend/src/components/clinical/dashboard/PatientSummaryV4.js
@@ -38,7 +38,7 @@ import { useInitializationGuard } from '../../../hooks/ui/useStableReferences';
 import { getClinicalContext } from '../../../themes/clinicalThemeUtils';
 import { useClinicalWorkflow, CLINICAL_EVENTS } from '../../../contexts/ClinicalWorkflowContext';
 import CDSPresentation, { PRESENTATION_MODES } from '../cds/CDSPresentation';
-import { useCDS } from '../../../contexts/CDSContext';
+import { usePatientCDSAlerts } from '../../../contexts/CDSContext';
 import { useMedicationResolver } from '../../../core/fhir/hooks/useMedicationResolver';
 
 const PatientSummaryV4 = ({ patientId, department = 'general' }) => {
@@ -1069,19 +1069,24 @@ const PatientSummaryV4 = ({ patientId, department = 'general' }) => {
   );
 };
 
-// CDS Alerts Component - displays alerts inline as dismissible cards
+// CDS Alerts Component - displays alerts inline as dismissible cards.
+//
+// Uses `usePatientCDSAlerts(patientId)` rather than the bare
+// `useCDS().getAlerts('patient-view')` because the latter only reads cached
+// state. When a user navigates between patients (e.g. clinical workspace
+// for patient A → summary for patient B), the cache still holds patient
+// A's alerts and they'd render on patient B's summary until something else
+// triggered a re-fire. `usePatientCDSAlerts` detects the patient change,
+// clears alerts, and re-fires patient-view hooks for the new patient.
 const CDSAlerts = ({ patientId }) => {
-  const { getAlerts } = useCDS();
-  
-  // Get alerts for patient-view hook
-  const alerts = getAlerts('patient-view') || [];
-  
-  if (alerts.length === 0) {
+  const { alerts } = usePatientCDSAlerts(patientId);
+
+  if (!alerts || alerts.length === 0) {
     return null;
   }
-  
+
   return (
-    <CDSPresentation 
+    <CDSPresentation
       alerts={alerts}
       mode={PRESENTATION_MODES.INLINE}
       allowInteraction={true}


### PR DESCRIPTION
## Why

User-reported: navigating from Patient A's clinical workspace (where 5 CDS hooks fired) to Patient B's summary page shows Patient A's 5 cards on Patient B's chart, even though Patient B has 0 eligible services. Repro:

1. Open \`/patients/{A}/clinical\` → patient-view hooks fire, alerts populated
2. Navigate to \`/patients/{B}\` (summary page, before clinical workspace)
3. CDSAlerts on Patient B's summary reads \`getAlerts('patient-view')\` — which still holds Patient A's cached alerts
4. Stale alerts render on Patient B's chart

## Root cause

\`PatientSummaryV4.js:1074\` calls:

\`\`\`js
const { getAlerts } = useCDS();
const alerts = getAlerts('patient-view') || [];
\`\`\`

That only READS context state. Nothing triggers a re-fire when \`patientId\` changes, so the cache holds whatever was last set.

The clinical workspace gets this right via \`usePatientCDSAlerts(patientId)\` (ClinicalWorkspaceEnhanced.js:140), which:
- detects patient-id changes (\`prevPatientIdRef\` compare)
- calls \`executePatientViewHooks(patientId)\` once per patient
- that handler clears \`alerts\` (line 330: \`setAlerts({})\`) and re-fires hooks

## Fix

Swap the bare \`useCDS().getAlerts('patient-view')\` for \`usePatientCDSAlerts(patientId)\` in \`PatientSummaryV4\`'s CDSAlerts component. Same hook the clinical workspace already uses. Auto-fires on patient change.

## Test plan

- [x] Lint clean (0 new warnings)
- [ ] Manual on prod: open Patient A's clinical workspace → see cards. Click out to Patient B's summary page (\`/patients/{B}\`) — Patient A's cards should NOT appear; either no cards (if B has none eligible) or B's own cards.
- [ ] Specifically the user's scenario: 707acdb2-199e-54bf-300b-ab09953af7b7 (the patient with 0 eligible services) — should see 0 cards on summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)