### PR TITLE
fix(deploy): restart nginx after backend restart in terminology-index step

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -704,12 +704,22 @@ if [ -d "$HOME/fhir_vocabularies/terminology" ] && \
         --json-dir /tmp/fhir_vocabularies/terminology \
         --ucum-json /tmp/ucum.json \
         --output /app/data/terminology.db; then
-        echo -e "${GREEN}✓ Local terminology index built — restart emr-backend to pick it up${NC}"
+        echo -e "${GREEN}✓ Local terminology index built — restarting emr-backend to pick it up${NC}"
         # The factory caches the chosen backend per-process, so an existing
         # backend that booted before the index was built keeps using the
         # HAPI fallback. Restart picks up the new index immediately.
         docker restart emr-backend > /dev/null
         echo "   emr-backend restarted; catalog search now uses the local index"
+        # nginx caches upstream DNS at worker start. After a backend restart
+        # it can hold the old container IP and serve 502 Bad Gateway until
+        # something nudges it. `docker restart emr-nginx` is heavy-handed
+        # but cheap (~1s, no observable downtime) and re-resolves both the
+        # backend AND hapi-fhir upstreams. Without this, the catalog index
+        # we just built is unreachable until the next deploy.
+        if docker inspect emr-nginx >/dev/null 2>&1; then
+            docker restart emr-nginx > /dev/null
+            echo "   emr-nginx restarted to refresh upstream DNS"
+        fi
     else
         echo -e "${YELLOW}⚠️  Index build failed — catalog search will degrade to dynamic-only (HAPI \$expand fallback)${NC}"
     fi


### PR DESCRIPTION
## Why

Today's deploy of #94 + #95 left nginx serving 502 Bad Gateway for ~10 minutes after the terminology-index block restarted \`emr-backend\`. nginx caches upstream DNS at worker start; when the backend gets a new IP on the docker bridge after restart, nginx keeps trying the old one:

\`\`\`
[error] connect() failed (113: Host is unreachable) while connecting to upstream,
upstream: "http://172.19.0.5:8000/..."
\`\`\`

\`nginx -s reload\` couldn't recover it either — it failed to load because \`emr-hapi-fhir\` was simultaneously OOM-killed, putting one of the upstream hostnames into "host not found" state. Only a manual \`docker restart emr-nginx\` cleared it.

## Fix

In the index-build block, after restarting \`emr-backend\`, also restart \`emr-nginx\`. Cheap (~1s, no observable downtime) and re-resolves both the backend and hapi-fhir upstreams. Without this, the catalog index we just built is unreachable through the proxy until something else nudges nginx.

Same class of bug as #83 — nginx state drifts from the rest of the stack and \`deploy.sh\` needs to explicitly resync it.

## Test plan

- [x] Manual recovery on prod completed (\`docker restart emr-nginx\`); catalog endpoints back to 200.
- [ ] Next clean deploy: backend restart + nginx restart sequence runs, no 502 window.

## Notes

- The HAPI OOM was a separate event (heap pressure on the lowered 3-4GB heap after \~13h uptime). Not addressed here; orthogonal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)