### PR TITLE
fix(cds-studio): validate VS URLs at save; retire HAPI artifacts on delete

### DIFF
--- a/backend/api/cds_studio/visual_builder_router.py
+++ b/backend/api/cds_studio/visual_builder_router.py
@@ -32,6 +32,7 @@ from .visual_service_config import (
     VisualServiceConfigCreate,
     VisualServiceConfigUpdate,
     VisualServiceConfigResponse,
+    VisualValueSet,
     ServiceStatus,
     ServiceType,
     ServiceDeploymentRequest,
@@ -66,6 +67,48 @@ router = APIRouter(prefix="/api/cds-visual-builder", tags=["CDS Visual Builder"]
 async def get_code_generator() -> ServiceCodeGenerator:
     """Get service code generator instance"""
     return ServiceCodeGenerator()
+
+
+# Matches `valueset "Name": '<url>'` or `valueset "Name" : "<url>"` —
+# accepts single or double quotes around the URL since CQL allows both.
+_VALUESET_DECL_RE = re.compile(
+    r'valueset\s+"[^"]+"\s*:\s*[\'"]([^\'"]+)[\'"]'
+)
+
+
+async def _validate_cql_valueset_urls(cql_source: str, db: AsyncSession) -> None:
+    """Reject CQL whose `valueset` declarations point at canonical URLs we
+    don't have ValueSet rows for.
+
+    The Studio derives canonical URLs as kebab-case from the ValueSet name
+    (e.g. `Diabetes Mellitus` → `.../diabetes-mellitus`). LLM-generated CQL
+    routinely produces no-separator forms (`.../diabetesmellitus`) following
+    the prior prompt example. Without this check, the save succeeds, the
+    hook fires at runtime, and the CQL retrieve resolves to an empty set —
+    user-visible symptom is a silent `{"cards": []}` with no log line
+    indicating the URL didn't resolve. Fail loudly at save time instead.
+    """
+    declared = _VALUESET_DECL_RE.findall(cql_source or "")
+    if not declared:
+        return
+
+    result = await db.execute(
+        select(VisualValueSet.hapi_canonical_url).where(VisualValueSet.deleted_at.is_(None))
+    )
+    known = {row[0] for row in result.all()}
+
+    unresolved = [url for url in declared if url not in known]
+    if unresolved:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "CQL references ValueSet canonical URL(s) that don't match any "
+                f"composed ValueSet: {unresolved}. Canonical URLs are kebab-case "
+                "from the ValueSet name (e.g. 'Diabetes Mellitus' → "
+                "'http://wintehr.example.org/ValueSet/diabetes-mellitus'). "
+                "Compose the missing ValueSet first, or correct the URL in the CQL."
+            ),
+        )
 
 
 # Visual Service CRUD Endpoints
@@ -107,6 +150,7 @@ async def create_visual_service(
                         "applicability gate that decides when to fire."
                     ),
                 )
+            await _validate_cql_valueset_urls(config.cql_source, db)
             # No condition-tree validation, no Python codegen for CQL services.
             generated_code = None
             code_hash = None
@@ -474,6 +518,7 @@ async def update_visual_service(
                         "boolean expression."
                     ),
                 )
+            await _validate_cql_valueset_urls(update.cql_source, db)
             service.cql_source = update.cql_source
             needs_cql_rematerialize = True
 
@@ -581,7 +626,44 @@ async def delete_visual_service(
         service.deleted_at = datetime.utcnow()
         service.deleted_by = current_user.id
 
+        # Snapshot HAPI canonicals BEFORE the commit; we'll need them after.
+        plan_def_url = service.plan_definition_canonical_url
+        library_url = service.library_canonical_url
+
         await db.commit()
+
+        # Retire the corresponding HAPI artifacts so the discovery query
+        # (`PlanDefinition?status=active`) stops returning this service.
+        # Without this, soft-deleted services keep appearing in the
+        # `/api/cds-services` listing and continue to fire — the runtime
+        # never reads the local `deleted_at` column.
+        #
+        # Failures here are non-fatal: the DB soft-delete already happened,
+        # so re-running the DELETE picks up the orphan retirement on retry.
+        # An offline cleanup script can also reconcile.
+        if plan_def_url or library_url:
+            from services.hapi_fhir_client import HAPIFHIRClient
+
+            hapi = HAPIFHIRClient()
+            for resource_type, canonical_url in (
+                ("PlanDefinition", plan_def_url),
+                ("Library", library_url),
+            ):
+                if not canonical_url:
+                    continue
+                resource_id = canonical_url.rsplit("/", 1)[-1]
+                try:
+                    resource = await hapi.read(resource_type, resource_id)
+                    if resource.get("status") != "retired":
+                        resource["status"] = "retired"
+                        await hapi.update(resource_type, resource_id, resource)
+                except Exception as exc:
+                    logger.warning(
+                        "Failed to retire HAPI %s/%s for deleted service %s: %s. "
+                        "DB soft-delete completed; resource may still appear in "
+                        "discovery until retried or manually retired.",
+                        resource_type, resource_id, service_id, exc,
+                    )
 
         logger.info(f"Archived visual service: {service_id}")
 


### PR DESCRIPTION
## Why

Two latent issues surfaced by the 3-iteration CQL prompt eval round:

1. **Silent VS URL mismatch.** When CQL declares a `valueset` pointing at a canonical URL that doesn't exist in `cds_visual_builder.value_sets`, the save succeeds, the hook fires, the retrieve resolves to `[]`, and the response is `{"cards": []}` with no log entry. Indistinguishable from "rule correctly didn't fire" — exactly the failure mode all three eval subagents hit, because the prompt's prior example showed `.../diabetesmellitus` (no separators) but the platform's `derive_vs_id` kebab-cases multi-word names to `.../diabetes-mellitus`.

2. **Soft-deleted services still discovered & fire.** Visual-builder DELETE sets `deleted_at` + `status='ARCHIVED'` locally but never updates the corresponding HAPI `PlanDefinition` / `Library`, leaving them `status=active`. Discovery queries `PlanDefinition?status=active`, so deleted services keep appearing in `/api/cds-services` and continue firing.

## What changes

- New helper `_validate_cql_valueset_urls(cql_source, db)` parses every `valueset "Name": '<url>'` declaration via regex, queries `VisualValueSet.hapi_canonical_url` for non-deleted rows, and raises 400 with an actionable hint if any URL is unresolved. Called from both POST `/services` and PUT `/services/{id}` right after the existing `Applicability` check.
- DELETE `/services/{id}` snapshots `plan_definition_canonical_url` and `library_canonical_url` before commit, then after the DB soft-delete walks both and PUTs them to HAPI with `status='retired'`. Failures are logged non-fatally so the DB state is the source of truth.

## What this doesn't do

- Reconcile **already-orphaned** PlanDefinitions from past deletes. That's a separate one-off cleanup pass — query `cds_visual_builder.visual_services` for rows with `deleted_at IS NOT NULL`, retire any HAPI artifacts they reference, batch.
- Touch the discovery endpoint itself. The fix is upstream: the resources stop being `status=active` so the existing query naturally excludes them.

## Test plan

- [x] eslint/pylint clean (no new warnings)
- [x] AST parse verified
- [ ] Manual: POST a CQL service with a deliberately-wrong VS URL → expect 400 with the kebab-case hint, no row created.
- [ ] Manual: POST a CQL service with correct URLs → expect 201 as before.
- [ ] Manual: PUT a CQL service with a wrong VS URL → expect 400, row unchanged.
- [ ] Manual: DELETE a CQL service that has HAPI artifacts → expect 204, then verify `PlanDefinition.status=retired` and `Library.status=retired` in HAPI, and the service no longer appears in `/api/cds-services`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)