### PR TITLE
fix(cds-studio): legacy delete now finds visual-builder PlanDefinitions

### DIFF
--- a/backend/api/cds_studio/service.py
+++ b/backend/api/cds_studio/service.py
@@ -949,21 +949,46 @@ class CDSStudioService:
             except Exception as e:
                 logger.error(f"Error updating local status for {service_id}: {e}")
 
-        # Update HAPI FHIR PlanDefinition if it exists
+        # Update HAPI FHIR PlanDefinition if it exists.
+        #
+        # Visual-builder services live at `PlanDefinition/vb-{service_id}` and
+        # have `name=None`, so the prior `?name={service_id}` search returned
+        # zero hits and the status update silently no-op'd — the symptom user
+        # see was "delete looks like it worked but the service stays in the
+        # listing." Try the canonical `vb-{service_id}` id directly; if that
+        # 404s (e.g. legacy services without the prefix, or external imports),
+        # fall back to walking PlanDefinitions matching the `hook-service-id`
+        # extension. Both paths are non-fatal — DB status was already flipped
+        # above, so a missed HAPI update at worst leaves a stale listing entry.
         try:
             fhir_status = fhir_status_map.get(status, "draft")
-            bundle = await self.hapi_client.search("PlanDefinition", {
-                "name": service_id,
-                "_count": "1"
-            })
-            entries = bundle.get("entry", [])
-            if entries:
-                plan_def = entries[0].get("resource", {})
+            plan_def = None
+            try:
+                plan_def = await self.hapi_client.read("PlanDefinition", f"vb-{service_id}")
+            except Exception:
+                plan_def = None
+
+            if plan_def is None:
+                bundle = await self.hapi_client.search("PlanDefinition", {
+                    "_count": "200",
+                    "status": "active,draft",
+                })
+                hook_service_id_url = "http://wintehr.local/fhir/StructureDefinition/hook-service-id"
+                for entry in bundle.get("entry", []) or []:
+                    candidate = entry.get("resource", {})
+                    for ext in candidate.get("extension", []) or []:
+                        if ext.get("url") == hook_service_id_url and ext.get("valueString") == service_id:
+                            plan_def = candidate
+                            break
+                    if plan_def is not None:
+                        break
+
+            if plan_def is not None:
                 plan_def["status"] = fhir_status
-                await self.hapi_client.update(
-                    "PlanDefinition", plan_def["id"], plan_def
-                )
-                logger.info(f"Updated PlanDefinition status for {service_id} to {fhir_status}")
+                await self.hapi_client.update("PlanDefinition", plan_def["id"], plan_def)
+                logger.info(f"Updated PlanDefinition/{plan_def['id']} status for {service_id} to {fhir_status}")
+            else:
+                logger.info(f"No PlanDefinition found for {service_id}; only DB status updated")
         except Exception as e:
             logger.error(f"Error updating FHIR PlanDefinition status for {service_id}: {e}")
 


### PR DESCRIPTION
## Why

The CDS Studio's delete button looks like it works (HTTP 200, success message), but the service stays in the listing and keeps firing.

## Root cause

The legacy DELETE handler at `/api/cds-studio/services/{id}` calls `update_service_status(service_id, INACTIVE)`, which:

1. UPDATEs the local `cds_visual_builder.service_configs` row to `status=INACTIVE` ✓
2. Searches HAPI for `PlanDefinition?name={service_id}` to flip its status to `retired`

But visual-builder PlanDefinitions are uploaded with `id = vb-{service_id}` and `name = None`. The `?name={service_id}` search returns zero hits, the status update silently no-ops, and HAPI still says `status=active`. Listing (`PlanDefinition?status=active,draft`) and discovery still return the service.

Reproduced live:
```
DELETE /api/cds-studio/services/dr-reminder-test2  →  HTTP 200 {"success":true,...}
GET    /api/cds-studio/services                    →  dr-reminder-test2 STILL THERE
GET    /api/cds-services                           →  dr-reminder-test2 STILL THERE
GET    /fhir/R4/PlanDefinition/dr-reminder-test2   →  404
GET    /fhir/R4/PlanDefinition?name=dr-reminder-test2 → total=0
```

The actual resource is `PlanDefinition/vb-dr-reminder-test2` (name=null, status=active).

## Fix

`update_service_status` now:
1. Tries `PlanDefinition/vb-{service_id}` directly (covers all visual-builder services)
2. On 404, walks active+draft PlanDefinitions and matches the `hook-service-id` extension (covers any service with a non-`vb-` id, e.g. legacy uploads)
3. If neither path finds a resource, logs and continues — DB status was already flipped, so the local store is correct.

PR #97's `/api/cds-visual-builder/services/{id}` DELETE is unaffected; it walks `plan_definition_canonical_url` directly.

## Test plan

- [x] AST parse clean
- [ ] Manual: DELETE a soft-target via UI → verify it disappears from `/api/cds-studio/services` and `/api/cds-services`, and `PlanDefinition/vb-{id}.status` flips to `retired` in HAPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)