### PR TITLE
fix(nginx): remove duplicate CORS for /fhir paths

### DIFF
--- a/nginx-prod.conf
+++ b/nginx-prod.conf
@@ -220,22 +220,17 @@ http {
         }
 
         # FHIR Server - Route through FastAPI backend for SMART token validation
-        # Backend proxy (api/fhir/proxy.py) forwards validated requests to HAPI FHIR
+        # Backend proxy (api/fhir/proxy.py) forwards validated requests to HAPI FHIR.
+        #
+        # CORS is handled entirely by the backend's CORSSecurityMiddleware
+        # (api/middleware/security_middleware.py). nginx used to add its own
+        # `Access-Control-Allow-Origin: *` headers here as well, which produced
+        # responses with two or three values for the same header — browsers
+        # rejected them with "header contains multiple values" errors. Don't
+        # re-add CORS at the nginx layer; let the upstream do its job.
         location /fhir/R4/ {
             limit_req zone=api_limit burst=200 nodelay;
 
-            # Handle CORS preflight
-            if ($request_method = 'OPTIONS') {
-                add_header Access-Control-Allow-Origin * always;
-                add_header Access-Control-Allow-Methods "GET, POST, PUT, DELETE, OPTIONS" always;
-                add_header Access-Control-Allow-Headers "Authorization, Content-Type, Accept, Origin, Prefer, X-Requested-With, Cache-Control" always;
-                add_header Access-Control-Expose-Headers "Content-Location, Location" always;
-                add_header Access-Control-Max-Age 3600 always;
-                add_header Content-Length 0;
-                return 204;
-            }
-
-            # Route to FastAPI backend (SMART middleware validates tokens, then proxies to HAPI)
             proxy_pass http://backend;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
@@ -244,26 +239,12 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_read_timeout 300s;
             proxy_connect_timeout 75s;
-
-            # Set clean CORS headers
-            add_header Access-Control-Allow-Origin * always;
-            add_header Access-Control-Expose-Headers "Content-Location, Location" always;
         }
 
         # FHIR Server - Standard /fhir/ path (also through FastAPI for SMART validation)
+        # Same CORS rationale as /fhir/R4/ above.
         location /fhir/ {
             limit_req zone=api_limit burst=200 nodelay;
-
-            # Handle CORS preflight
-            if ($request_method = 'OPTIONS') {
-                add_header Access-Control-Allow-Origin * always;
-                add_header Access-Control-Allow-Methods "GET, POST, PUT, DELETE, OPTIONS" always;
-                add_header Access-Control-Allow-Headers "Authorization, Content-Type, Accept, Origin, Prefer, X-Requested-With, Cache-Control" always;
-                add_header Access-Control-Expose-Headers "Content-Location, Location" always;
-                add_header Access-Control-Max-Age 3600 always;
-                add_header Content-Length 0;
-                return 204;
-            }
 
             proxy_pass http://backend;
             proxy_http_version 1.1;
@@ -273,18 +254,6 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_read_timeout 300s;
             proxy_connect_timeout 75s;
-
-            # Set clean CORS headers
-            add_header Access-Control-Allow-Origin * always;
-            add_header Access-Control-Expose-Headers "Content-Location, Location" always;
-            proxy_hide_header Access-Control-Allow-Headers;
-            proxy_hide_header Access-Control-Allow-Credentials;
-            proxy_hide_header Access-Control-Expose-Headers;
-            proxy_hide_header Access-Control-Max-Age;
-
-            # Set single clean CORS headers
-            add_header Access-Control-Allow-Origin * always;
-            add_header Access-Control-Expose-Headers "Content-Location, Location" always;
         }
 
         # Frontend React application (proxied to frontend container)


### PR DESCRIPTION
## Why

External callers (e.g. an HTML file opened from disk with origin \`null\`) get blocked with:

\`\`\`
The 'Access-Control-Allow-Origin' header contains multiple values
'null, *, *', but only one is allowed.
\`\`\`

Three layers of CORS infrastructure were stacking:

1. Backend middleware echoes \`null\` (correct).
2. Nginx \`/fhir/\` block adds \`Access-Control-Allow-Origin: *\` — twice (lines 278 and 286 of prior config). With \`always\`, nginx appends on top of upstream.
3. Nginx \`/fhir/R4/\` block does the same once.

Result: \`null, *, *\`. Browsers reject.

## Fix

Drop CORS handling from nginx for both \`/fhir/\` and \`/fhir/R4/\`. The backend middleware (now permissive by default after PR #102) handles preflight, origin echo, credentials, and exposed headers. Single source of truth.

## Deploy

Volume-mounted config — no rebuild. Pull on host + nginx reload (or restart) to pick up.