### PR TITLE
fix(orders): CPOE dialog actually persists new orders

### DIFF
--- a/frontend/src/components/clinical/workspace/tabs/EnhancedOrdersTab.js
+++ b/frontend/src/components/clinical/workspace/tabs/EnhancedOrdersTab.js
@@ -1398,9 +1398,29 @@ const EnhancedOrdersTab = ({
           const orderList = Array.isArray(orders) ? orders : [orders];
           const isEdit = saveMode === 'edit' || cpoeMode === 'edit';
 
-          // Publish events for each created/updated order
+          // Persist each order to HAPI. CPOEDialog/MedicationDialog only
+          // build the in-memory FHIR resource — they hand it here for the
+          // tab to actually write. Without this loop the dialog "succeeds"
+          // (snackbar + refresh) but the order never reaches the backend,
+          // and the tab list quietly stays unchanged.
+          const { fhirClient } = await import('../../../../core/fhir/services/fhirClient');
+          const persisted = [];
+          const failed = [];
           for (const order of orderList) {
             if (!order) continue;
+            try {
+              const result = (isEdit && order.id)
+                ? await fhirClient.update(order.resourceType, order.id, order)
+                : await fhirClient.create(order.resourceType, order);
+              persisted.push(result);
+            } catch (writeError) {
+              console.error('Failed to persist order:', writeError);
+              failed.push({ order, error: writeError });
+            }
+          }
+
+          // Publish events using the persisted resources (real IDs from HAPI)
+          for (const order of persisted) {
             const eventType = isEdit
               ? CLINICAL_EVENTS.ORDER_UPDATED || 'order.updated'
               : order.resourceType === 'MedicationRequest'
@@ -1422,13 +1442,28 @@ const EnhancedOrdersTab = ({
           refreshSearch();
           setCpoeEditOrder(null);
           setCpoeMode('add');
-          setSnackbar({
-            open: true,
-            message: isEdit
-              ? 'Order updated successfully'
-              : `${orderList.length} order(s) created successfully`,
-            severity: 'success'
-          });
+
+          if (failed.length > 0 && persisted.length === 0) {
+            setSnackbar({
+              open: true,
+              message: `Failed to ${isEdit ? 'update' : 'create'} order: ${failed[0].error?.message || 'unknown error'}`,
+              severity: 'error',
+            });
+          } else if (failed.length > 0) {
+            setSnackbar({
+              open: true,
+              message: `${persisted.length} of ${orderList.length} order(s) saved; ${failed.length} failed`,
+              severity: 'warning',
+            });
+          } else {
+            setSnackbar({
+              open: true,
+              message: isEdit
+                ? 'Order updated successfully'
+                : `${persisted.length} order(s) created successfully`,
+              severity: 'success'
+            });
+          }
         }}
       />
 


### PR DESCRIPTION
## Why

CPOE order entry looks like it works — the dialog opens, the user fills in fields, hits Save, gets a green snackbar saying "1 order(s) created successfully" — but the new order never appears in the All Orders tab. Refreshing pulls back the same orders that already existed.

## Root cause

\`CPOEDialog.js:90\` calls \`createServiceRequestResource(...)\` which returns an in-memory JS object (no HAPI write). It hands that object to its parent's \`onSave\`. The parent in \`EnhancedOrdersTab.js:1396\` only:

1. Publishes events
2. Calls \`refreshSearch()\`
3. Shows the snackbar

There was **no** \`fhirClient.create()\` call anywhere. The order existed only as a transient JS object that was thrown away when the dialog closed.

For comparison, \`ChartReviewTabOptimized.js:458\` (\`handleResourceSaved\`) does it correctly — \`fhirClient.update()\` for edits, \`fhirClient.create()\` for new resources.

## Fix

Add the missing persistence loop, mirroring the chart-review pattern. Edit mode → update; add mode → create. Use the persisted resources (with real HAPI-assigned IDs) for the events. Add error-aware snackbars: full failure shows the error, partial failure shows a warning, full success shows the previous green snackbar.

## Test plan

- [x] Diff stays in the onSave callback only — no other dialog logic changes.
- [ ] Manual: open Orders tab → New Order → fill in (lab, condition, indication) → Save. Verify the new order appears in the All Orders list and in HAPI.
- [ ] Manual: edit an existing order → Save. Verify the edit lands.
- [ ] Manual: simulate a write failure (revoke auth or block fhir endpoint via devtools) → confirm error snackbar appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)