### PR TITLE
fix(immunization-dialog): catalog-backed vaccine search + patient guards

### DIFF
--- a/frontend/src/components/clinical/workspace/dialogs/ImmunizationDialogEnhanced.js
+++ b/frontend/src/components/clinical/workspace/dialogs/ImmunizationDialogEnhanced.js
@@ -82,32 +82,65 @@ import { useDialogSave, useDialogValidation, VALIDATION_RULES } from './utils/di
 
 const searchImmunizations = async (query) => {
   try {
-    // Search for immunizations from existing resources
-    const searchParams = {
-      _count: 100,
-      _sort: '-date'
-    };
-    
-    if (query) {
-      searchParams._text = query;
-    }
-    
-    const bundle = await fhirClient.search('Immunization', searchParams);
-    const immunizations = bundle.entry?.map(entry => entry.resource) || [];
-    
-    // Extract unique vaccine codes
     const vaccineMap = new Map();
-    
+
+    // Pull candidate vaccines from the platform's CVX catalog.
+    //
+    // The earlier implementation searched HAPI's `Immunization` resources with
+    // `_text=<query>` to derive the vaccine list. That broke when Hibernate
+    // Search was disabled — HAPI started returning HAPI-1192 ("Fulltext search
+    // is not enabled on this service"), the search bombed, and students saw
+    // an empty vaccine picker on the chart-review immunization dialog.
+    //
+    // The local terminology index has all 287 CVX codes; `/api/catalogs/vaccines`
+    // serves them with substring filtering. Use that as the primary source.
+    if (query && query.length >= 2) {
+      try {
+        const params = new URLSearchParams({ search: query, limit: '50' });
+        const resp = await fetch(`/api/catalogs/vaccines?${params}`);
+        if (resp.ok) {
+          const catalog = await resp.json();
+          (Array.isArray(catalog) ? catalog : []).forEach(v => {
+            const code = v.cvx_code || v.vaccine_code || v.code;
+            const display = v.vaccine_name || v.display || code;
+            if (code && !vaccineMap.has(code)) {
+              vaccineMap.set(code, {
+                code,
+                display,
+                system: 'http://hl7.org/fhir/sid/cvx',
+              });
+            }
+          });
+        }
+      } catch (catalogErr) {
+        // Non-fatal: fall through to existing-Immunization extraction below
+        console.warn('Vaccine catalog lookup failed; falling back to history:', catalogErr);
+      }
+    }
+
+    // Also extract codes from existing Immunization resources so the picker
+    // surfaces vaccines that have been administered to patients in this
+    // dataset, even if the catalog miss-spells or omits them.
+    const bundle = await fhirClient.search('Immunization', {
+      _count: 100,
+      _sort: '-date',
+    });
+    const immunizations = bundle.entry?.map(entry => entry.resource) || [];
+
     immunizations.forEach(immunization => {
       if (immunization.vaccineCode?.coding) {
         immunization.vaccineCode.coding.forEach(coding => {
           const key = coding.code || coding.display;
           if (key && !vaccineMap.has(key)) {
-            vaccineMap.set(key, {
-              code: coding.code,
-              display: coding.display || immunization.vaccineCode.text || 'Unknown Vaccine',
-              system: coding.system
-            });
+            // Apply the same substring filter the catalog already applied
+            const haystack = (coding.display || immunization.vaccineCode.text || '').toLowerCase();
+            if (!query || haystack.includes(query.toLowerCase()) || (coding.code || '').includes(query)) {
+              vaccineMap.set(key, {
+                code: coding.code,
+                display: coding.display || immunization.vaccineCode.text || 'Unknown Vaccine',
+                system: coding.system,
+              });
+            }
           }
         });
       }
@@ -254,13 +287,15 @@ const ImmunizationDialogEnhanced = ({
     },
   });
 
-  // Load trending vaccines on mount
+  // Load trending vaccines on mount. `patient` is in the deps so the
+  // schedule recomputes once ClinicalContext finishes loading the patient
+  // (it's null on the first render the dialog sees).
   useEffect(() => {
     if (open && !immunization) {
       loadTrendingVaccines();
       loadVaccineSchedule();
     }
-  }, [open, immunization]);
+  }, [open, immunization, patient]);
 
   // Load existing immunization data
   useEffect(() => {
@@ -340,7 +375,14 @@ const ImmunizationDialogEnhanced = ({
   // Load recommended vaccine schedule based on patient age
   const loadVaccineSchedule = async () => {
     try {
-      // Calculate patient age
+      // Patient comes from ClinicalContext, which loads asynchronously after
+      // the dialog mounts. Bail out quietly until the resource is available
+      // — the useEffect re-runs on `patient` so the schedule will populate
+      // on the next render.
+      if (!patient?.birthDate) {
+        setVaccineSchedule([]);
+        return;
+      }
       const birthDate = new Date(patient.birthDate);
       const ageInYears = differenceInDays(new Date(), birthDate) / 365.25;
       
@@ -453,8 +495,8 @@ const ImmunizationDialogEnhanced = ({
       console.error('Error checking allergies:', error);
     }
     
-    // Check pregnancy status for live vaccines
-    if (patient.gender === 'female') {
+    // Check pregnancy status for live vaccines (no-op if patient hasn't loaded yet)
+    if (patient?.gender === 'female') {
       // In real system, would check for active pregnancy condition
       if (vaccine.display?.toLowerCase().includes('mmr') || 
           vaccine.display?.toLowerCase().includes('varicella')) {


### PR DESCRIPTION
## Why

Two bugs reported on the Chart Review tab's Immunization dialog, both visible in the browser console:

\`\`\`
TypeError: Cannot read properties of undefined (reading 'birthDate')
    at re (ImmunizationDialogEnhanced.js:344:42)

GET .../fhir/R4/Immunization?_count=100&_sort=-date&_text=se 400 (Bad Request)
HAPI-1192: Fulltext search is not enabled on this service, can not process parameter: _text
\`\`\`

## Bug 1 — vaccine search 400s

The dialog searched HAPI's \`Immunization\` resources with \`_text=<query>\` to derive the vaccine list. That requires Hibernate Search, which is disabled on this deployment to keep HAPI from OOM-ing. With HSearch off, every keystroke after the second character bombs.

**Fix:** switch to \`/api/catalogs/vaccines?search=<q>\` — the local terminology index has all 287 CVX codes and supports substring filtering. Keep the existing-Immunization scan as a fallback so vaccines administered to patients in this dataset still surface.

## Bug 2 — TypeError on \`patient.birthDate\`

\`patient\` from \`ClinicalContext\` is null on the first render the dialog sees. The schedule loader unconditionally read \`patient.birthDate\` and crashed. The useEffect also didn't list \`patient\` in its deps, so it never retried after the patient arrived.

**Fix:** guard the access (\`patient?.birthDate\`), no-op the schedule when patient isn't ready, add \`patient\` to the useEffect deps. Same null-safety on the downstream \`patient.gender === 'female'\` check.

## Test plan

- [x] Diff is scoped to one file.
- [ ] Manual: open Chart Review → click Add on the Immunizations card → type "fl" in search. Expect: candidate vaccines appear (Influenza variants, etc.), no 400 in the console, no TypeError.
- [ ] Manual: same flow on a patient with a known birthDate. Expect: vaccine schedule populates with age-appropriate recommendations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)