### PR TITLE
fix(orders): invalidate search cache on order events

### DIFF
--- a/frontend/src/components/clinical/workspace/tabs/EnhancedOrdersTab.js
+++ b/frontend/src/components/clinical/workspace/tabs/EnhancedOrdersTab.js
@@ -746,17 +746,30 @@ const EnhancedOrdersTab = ({
   }, [patientId]);
 
   // Handle incremental order updates
-  const handleOrderUpdate = useCallback((eventType, eventData) => {
+  const handleOrderUpdate = useCallback(async (eventType, eventData) => {
     // Extract the order from the event data
     const order = eventData.order || eventData.medication || eventData.resource;
-    
+
     if (!order) {
       console.warn('[EnhancedOrdersTab] No order in event data');
       return;
     }
 
-    // For now, refresh the search to get updated data
-    // In a full implementation, we would update the state incrementally
+    // Invalidate the order-search service cache before refreshing.
+    // enhancedOrderSearchService caches FHIR search bundles for 5 minutes
+    // keyed by URL; without this clear, the refresh below hands back the
+    // stale bundle from before the create/update and the new order won't
+    // appear in the tab until the page is refreshed (or the TTL expires).
+    // This is what users see as "the websocket fires but nothing changes."
+    try {
+      const { default: enhancedOrderSearch } = await import('../../../../services/enhancedOrderSearch');
+      enhancedOrderSearch.clearCache?.();
+    } catch (err) {
+      console.warn('[EnhancedOrdersTab] Failed to clear order-search cache:', err);
+    }
+
+    // Refresh the search to get updated data.
+    // In a full implementation, we would update the state incrementally.
     refreshSearch();
 
     // Show notification for important events


### PR DESCRIPTION
## Why

User-visible symptom: place an order via CPOE (or cancel/sign one), and the Orders tab doesn't show the change until you refresh the page. Same for medications and any other order-touching flow.

> "Isn't this the whole point of the websocket?"

Yes — the websocket plumbing IS wired correctly. \`EnhancedOrdersTab.js:704\` subscribes to ORDER_PLACED / MEDICATION_PRESCRIBED / ORDER_CANCELLED / ORDER_SIGNED. \`handleOrderUpdate\` runs. \`refreshSearch()\` runs.

The bug is one layer down: \`enhancedOrderSearchService\` caches FHIR search bundles for **5 minutes** keyed by URL. The "refresh" hands back the cached bundle from before the write. The new order is in HAPI but invisible to the UI until either the cache TTL expires or the page reloads (which discards the cache by remounting the component).

Manually refreshing the page worked because the search service is recreated; the websocket-driven refresh failed because nothing invalidated the cache.

## Fix

\`handleOrderUpdate\` is the central choke point for every order-touching flow on this tab — local CPOE creates, local cancels, local signs, and remote websocket events from other tabs all funnel through it. Clear the search service's cache at the top of that function before calling \`refreshSearch()\`.

\`enhancedOrderSearch\` already exposes \`clearCache()\`. It just was never called.

## Test plan

- [x] Diff scoped to one function in one file.
- [ ] Manual: Orders tab → New Order → fill in & save. Expect: order appears in the list within ~1 second, no page refresh needed.
- [ ] Manual: cancel an order → expect: status flips to "cancelled" in the list, no refresh.
- [ ] Manual: sign a draft order → expect: status flips to "active" in the list, no refresh.
- [ ] Manual (multi-tab): create an order in tab A, watch tab B (same patient). Expect: tab B updates within ~1s via the websocket subscription.

🤖 Generated with [Claude Code](https://claude.com/claude-code)