### PR TITLE
fix(cds-studio): wizard test panel actually works pre-deploy

### DIFF
--- a/frontend/src/modules/cds-studio/components/builder/VisualBuilderWizard.jsx
+++ b/frontend/src/modules/cds-studio/components/builder/VisualBuilderWizard.jsx
@@ -249,10 +249,13 @@ const VisualBuilderWizard = ({ open, onClose, onSuccess, existingService = null 
 
     setError(null);
 
-    // Save draft before moving into Test & Deploy. The testing UI needs a
-    // real backend service to invoke, and the FHIR-preview tab in the CQL
-    // editor needs to fetch the generated Library + PlanDefinition.
-    if (activeStep === STEP_PREFETCH && !savedServiceId) {
+    // Save (or re-save) the draft before moving into Test & Deploy. The
+    // testing UI needs a real backend service to invoke, and the FHIR-
+    // preview tab in the CQL editor needs to fetch the generated
+    // Library + PlanDefinition. We always re-save on entry so edits in
+    // step 2/3/4 after the first save get persisted — without this the
+    // test panel runs against the previously-saved CQL.
+    if (activeStep === STEP_PREFETCH) {
       await handleSaveDraft();
     }
 
@@ -321,12 +324,42 @@ const VisualBuilderWizard = ({ open, onClose, onSuccess, existingService = null 
     setError(null);
 
     try {
-      const response = await axios.post(
-        '/api/cds-visual-builder/services',
-        serviceConfig
-      );
+      // First save: POST to create. Subsequent saves (re-entering step 5
+      // after edits in step 2/3/4): PUT to update the existing draft so
+      // the test panel runs against current CQL/card config, not the
+      // initial snapshot. The PUT path also re-materializes the HAPI
+      // Library + PlanDefinition so $apply sees the latest code.
+      let response;
+      if (savedServiceId) {
+        response = await axios.put(
+          `/api/cds-visual-builder/services/${savedServiceId}`,
+          {
+            name: serviceConfig.name,
+            description: serviceConfig.description,
+            service_type: serviceConfig.service_type,
+            category: serviceConfig.category,
+            hook_type: serviceConfig.hook_type,
+            conditions: isCQLService ? undefined : serviceConfig.conditions,
+            cql_source: isCQLService ? serviceConfig.cql_source : undefined,
+            card_config: serviceConfig.card,
+            display_config: serviceConfig.display_config,
+            prefetch_config: serviceConfig.prefetch,
+          }
+        );
+      } else {
+        response = await axios.post(
+          '/api/cds-visual-builder/services',
+          serviceConfig
+        );
+      }
 
-      setSavedServiceId(response.data.id);
+      // The test endpoint URL is `/services/{service_id}/test` — the
+      // *string* identifier. The backend response includes both the
+      // integer DB row id (`id`) and the string identifier (`service_id`).
+      // Previously we set savedServiceId to `id`, so the test endpoint
+      // got "/services/123/test" and 404'd because no service has
+      // `service_id == "123"`. Use service_id.
+      setSavedServiceId(response.data.service_id);
       return response.data;
     } catch (err) {
       console.error('Error saving draft:', err);
@@ -368,7 +401,7 @@ const VisualBuilderWizard = ({ open, onClose, onSuccess, existingService = null 
         );
       } else if (!serviceId) {
         const savedService = await handleSaveDraft();
-        serviceId = savedService.id;
+        serviceId = savedService.service_id;
       }
 
       // Deploy. For new services this is the first stable-version upload;


### PR DESCRIPTION
## Why

The Test & Deploy step's "Run Service Test" button worked only after Deploy. Two bugs combined:

### Bug 1 — id type confusion
\`handleSaveDraft\` did:
\`\`\`js
setSavedServiceId(response.data.id)
\`\`\`
The backend response has both \`id\` (integer DB row) and \`service_id\` (string identifier). The test endpoint URL is \`/services/{service_id}/test\`. So the test request went to \`/services/123/test\`, the backend looked up \`service_id == "123"\`, found nothing, returned 404, and the test panel showed "Failed to test service."

Same bug in the deploy handler (\`serviceId = savedService.id\`).

### Bug 2 — re-saves never fired
The save-on-step-5-entry was guarded by \`!savedServiceId\`. First entry into Test & Deploy: save draft, test works. Then edit the CQL or card config in step 2/3, navigate back to step 5: no save fires. Test runs against the already-saved snapshot from earlier, not the in-memory edits. Indistinguishable from "test didn't work."

## Fix

- Use \`service_id\` instead of \`id\` in both setSavedServiceId callsites and the deploy handler.
- Drop the \`!savedServiceId\` guard. \`handleSaveDraft\` now POSTs on first save and PUTs on subsequent saves, so re-entering step 5 always persists current edits before the test runs.

## Test plan

- [x] Diff scoped to one component.
- [ ] Manual: New Service → fill steps 1-4 → enter step 5 → Run Service Test on a known patient. Expect: card returned (or "no cards: Applicability false") instead of 404.
- [ ] Manual: edit CQL in step 2 → navigate back to step 5 → re-test. Expect: new CQL behavior reflected, not the old one.
- [ ] Manual: Deploy. Verify it still creates the service with the correct stable id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)