### PR TITLE
fix(cds-studio): card form locks when CQL has CardSummary/Detail (any form)

### DIFF
--- a/frontend/src/modules/cds-studio/components/builder/VisualBuilderWizard.jsx
+++ b/frontend/src/modules/cds-studio/components/builder/VisualBuilderWizard.jsx
@@ -54,7 +54,7 @@ import ServiceTester from '../testing/ServiceTester';
 import { SERVICE_TYPES } from '../../types/serviceTypes';
 import cdsStudioApi from '../../services/cdsStudioApi';
 import { useAuth } from '../../../../contexts/AuthContext';
-import { extractCardDefinesFromCQL } from '../../utils/cqlDefineExtractor';
+import { extractCardDefinesFromCQL, detectCardDefines } from '../../utils/cqlDefineExtractor';
 import axios from 'axios';
 
 const CQL_SERVICE_TYPE = 'cql-based';
@@ -139,13 +139,37 @@ const VisualBuilderWizard = ({ open, onClose, onSuccess, existingService = null 
   const isEditMode = Boolean(existingService);
   const isCQLService = serviceConfig.service_type === CQL_SERVICE_TYPE;
 
-  // When CQL defines string-literal CardSummary / CardDetail, surface them
-  // as overrides so CardDesigner shows a read-only preview instead of an
-  // empty input. The CQL value wins at $apply time anyway.
-  const cqlCardOverrides = useMemo(
-    () => (isCQLService ? extractCardDefinesFromCQL(serviceConfig.cql_source) : {}),
-    [isCQLService, serviceConfig.cql_source]
-  );
+  // When CQL defines CardSummary / CardDetail, surface them as overrides
+  // so CardDesigner shows a read-only treatment instead of an editable
+  // input the runtime would silently ignore. Two cases:
+  //
+  //   - Literal define (`define CardSummary: 'fixed string'`):
+  //     extractCardDefinesFromCQL returns the unquoted value. CardDesigner
+  //     shows it as a read-only preview ("from CQL CardSummary: <value>").
+  //
+  //   - Expression define (`define CardSummary: 'a' + ToString(b)`):
+  //     extractor returns nothing (the rendered text depends on patient
+  //     data the wizard can't evaluate). detectCardDefines tags it as
+  //     'expression' so CardDesigner can still lock the field with a
+  //     "computed by CQL — see editor" hint instead of letting the
+  //     student type a static string the runtime will throw away.
+  const cqlCardOverrides = useMemo(() => {
+    if (!isCQLService) return {};
+    const literals = extractCardDefinesFromCQL(serviceConfig.cql_source);
+    const presence = detectCardDefines(serviceConfig.cql_source);
+    const out = {};
+    if (presence.summary) {
+      out.summary = literals.summary !== undefined
+        ? { kind: 'literal', value: literals.summary }
+        : { kind: 'expression' };
+    }
+    if (presence.detail) {
+      out.detail = literals.detail !== undefined
+        ? { kind: 'literal', value: literals.detail }
+        : { kind: 'expression' };
+    }
+    return out;
+  }, [isCQLService, serviceConfig.cql_source]);
 
   // After a ValueSet is created or edited inside the composer, refresh the
   // referenced-VS list so the inline panel reflects the new code count.

--- a/frontend/src/modules/cds-studio/components/builders/CardDesigner.jsx
+++ b/frontend/src/modules/cds-studio/components/builders/CardDesigner.jsx
@@ -404,11 +404,22 @@ const CardDesigner = ({
                 <Divider sx={{ mb: 2 }} />
 
                 <Stack spacing={2}>
-                  {/* Summary — read-only preview when CQL provides CardSummary */}
-                  {cqlOverrides.summary !== undefined ? (
+                  {/* Summary — locked when CQL has any CardSummary define
+                      (literal preview if we can show it, otherwise an
+                      "expression — see CQL editor" placeholder). The CQL
+                      value overrides the static action.title at $apply
+                      time regardless, so an editable input here would
+                      let the student type a string the runtime ignores. */}
+                  {cqlOverrides.summary?.kind === 'literal' ? (
                     <CqlOverridePreview
                       label="Summary (from CQL CardSummary)"
-                      value={cqlOverrides.summary}
+                      value={cqlOverrides.summary.value}
+                      onJumpToCQL={onJumpToCQL}
+                    />
+                  ) : cqlOverrides.summary?.kind === 'expression' ? (
+                    <CqlOverridePreview
+                      label="Summary (computed by CQL CardSummary)"
+                      value="Computed at runtime — edit the expression in the CQL editor."
                       onJumpToCQL={onJumpToCQL}
                     />
                   ) : (
@@ -423,11 +434,18 @@ const CardDesigner = ({
                     />
                   )}
 
-                  {/* Detail — read-only preview when CQL provides CardDetail */}
-                  {cqlOverrides.detail !== undefined ? (
+                  {/* Detail — same locked treatment when CQL has CardDetail. */}
+                  {cqlOverrides.detail?.kind === 'literal' ? (
                     <CqlOverridePreview
                       label="Detail (from CQL CardDetail)"
-                      value={cqlOverrides.detail}
+                      value={cqlOverrides.detail.value}
+                      onJumpToCQL={onJumpToCQL}
+                      multiline
+                    />
+                  ) : cqlOverrides.detail?.kind === 'expression' ? (
+                    <CqlOverridePreview
+                      label="Detail (computed by CQL CardDetail)"
+                      value="Computed at runtime — edit the expression in the CQL editor."
                       onJumpToCQL={onJumpToCQL}
                       multiline
                     />

--- a/frontend/src/modules/cds-studio/utils/__tests__/cqlDefineExtractor.test.js
+++ b/frontend/src/modules/cds-studio/utils/__tests__/cqlDefineExtractor.test.js
@@ -1,4 +1,4 @@
-import { extractCardDefinesFromCQL } from '../cqlDefineExtractor';
+import { extractCardDefinesFromCQL, detectCardDefines } from '../cqlDefineExtractor';
 
 describe('extractCardDefinesFromCQL', () => {
   test('extracts simple string-literal CardSummary and CardDetail', () => {
@@ -60,5 +60,54 @@ describe('extractCardDefinesFromCQL', () => {
     const cql = `define CardSummary: 'X'`;
     expect(extractCardDefinesFromCQL(cql)).toEqual({ summary: 'X' });
     expect(extractCardDefinesFromCQL(cql)).toEqual({ summary: 'X' });
+  });
+});
+
+describe('detectCardDefines', () => {
+  test('tags string-literal defines as literal', () => {
+    const cql = `
+      define CardSummary: 'fixed text'
+      define CardDetail: 'more fixed text'
+    `;
+    expect(detectCardDefines(cql)).toEqual({
+      summary: 'literal',
+      detail: 'literal',
+    });
+  });
+
+  test('tags expression defines as expression', () => {
+    // Concatenation, conditionals, function calls — all expressions.
+    const cql = `
+      define CardSummary:
+        'Patient last A1c was ' + ToString(LastA1cValue) + '%'
+      define CardDetail:
+        if HasSevereDiabetes then 'urgent' else 'routine'
+    `;
+    expect(detectCardDefines(cql)).toEqual({
+      summary: 'expression',
+      detail: 'expression',
+    });
+  });
+
+  test('mix of literal and expression', () => {
+    const cql = `
+      define CardSummary: 'simple'
+      define CardDetail: 'a' + 'b'
+    `;
+    expect(detectCardDefines(cql)).toEqual({
+      summary: 'literal',
+      detail: 'expression',
+    });
+  });
+
+  test('returns empty object when neither define is present', () => {
+    const cql = `define Applicability: true`;
+    expect(detectCardDefines(cql)).toEqual({});
+  });
+
+  test('handles empty input gracefully', () => {
+    expect(detectCardDefines('')).toEqual({});
+    expect(detectCardDefines(null)).toEqual({});
+    expect(detectCardDefines(undefined)).toEqual({});
   });
 });

--- a/frontend/src/modules/cds-studio/utils/cqlDefineExtractor.js
+++ b/frontend/src/modules/cds-studio/utils/cqlDefineExtractor.js
@@ -1,22 +1,26 @@
 /**
- * Extract `define CardSummary: 'literal'` and `define CardDetail: 'literal'`
- * from a CQL source. Returns `{ summary?: string, detail?: string }`.
+ * Extract `define CardSummary:` / `define CardDetail:` info from a CQL
+ * source. Two related functions:
+ *
+ *   extractCardDefinesFromCQL(cql) → { summary?: string, detail?: string }
+ *     Only literal-string defines. Returns the unquoted body. Used to
+ *     show the CQL value as a read-only preview when the value is
+ *     statically knowable.
+ *
+ *   detectCardDefines(cql) → { summary?: 'literal'|'expression',
+ *                              detail?:  'literal'|'expression' }
+ *     Detects whether each define exists at all and what kind it is.
+ *     Used to lock the corresponding form field even for expression
+ *     defines — those still override the static card_config at $apply
+ *     time, so a student typing a static summary while the CQL has a
+ *     CardSummary expression sees their text silently ignored at
+ *     runtime. The form should make that visible (read-only with a
+ *     "computed by CQL — edit there" hint) instead of pretending the
+ *     input is meaningful.
  *
  * The platform's CQL artifact builder (cql_artifact_builder.py) wires
  * CardSummary/CardDetail defines into PlanDefinition.action.dynamicValue
- * so they override the static action.title/description at $apply time.
- * That means a student who defines CardSummary in CQL doesn't also need
- * to type a static summary into the Card Designer — the CQL value wins
- * at runtime regardless. The wizard uses this extractor to recognize
- * that case and show the CQL value as a read-only preview instead of
- * an empty input.
- *
- * Only matches simple string-literal defines. Complex expressions
- * (concatenation, `if/then/else`, `ToString(...)` calls) are evaluated
- * at $apply time and aren't visible to the wizard preview — that's
- * honest, since the rendered card text depends on patient data the
- * preview doesn't have. Students see the dynamic value in the Test
- * step.
+ * so the CQL value always wins over card_config at $apply time.
  */
 
 // `define\s+(CardSummary|CardDetail)\s*:\s*'<single-quoted body>'`
@@ -26,8 +30,14 @@
 // concatenation/conditional/etc": if there's any non-whitespace token
 // after the closing quote (a `+`, `if`, `(`, comment, etc.), the value
 // is a complex expression and the wizard preview can't faithfully render
-// it — so we don't match. The body permits escaped single quotes (`\'`).
+// it — so we don't match here. The body permits escaped single quotes (`\'`).
 const STRING_LITERAL_DEFINE = /define\s+(CardSummary|CardDetail)\s*:\s*'((?:[^'\\]|\\.)*)'\s*(?=\bdefine\b|$)/g;
+
+// Looser pattern that just detects whether a `define CardSummary` /
+// `define CardDetail` exists at all, regardless of body shape. Used in
+// combination with the literal extractor: literal → show value;
+// matched here but not by literal extractor → expression.
+const ANY_CARD_DEFINE = /define\s+(CardSummary|CardDetail)\s*:/g;
 
 export function extractCardDefinesFromCQL(cqlSource) {
   if (!cqlSource) return {};
@@ -39,6 +49,21 @@ export function extractCardDefinesFromCQL(cqlSource) {
   while ((match = STRING_LITERAL_DEFINE.exec(cqlSource)) !== null) {
     const key = match[1] === 'CardSummary' ? 'summary' : 'detail';
     out[key] = match[2].replace(/\\'/g, "'");
+  }
+  return out;
+}
+
+export function detectCardDefines(cqlSource) {
+  if (!cqlSource) return {};
+  const literals = extractCardDefinesFromCQL(cqlSource);
+  const out = {};
+  let match;
+  ANY_CARD_DEFINE.lastIndex = 0;
+  // eslint-disable-next-line no-cond-assign
+  while ((match = ANY_CARD_DEFINE.exec(cqlSource)) !== null) {
+    const key = match[1] === 'CardSummary' ? 'summary' : 'detail';
+    if (out[key]) continue; // first definition wins (CQL itself rejects duplicates)
+    out[key] = literals[key] !== undefined ? 'literal' : 'expression';
   }
   return out;
 }


### PR DESCRIPTION
## Why

The wizard already replaced the static Summary/Detail inputs with a read-only "from CQL" preview when the CQL had a **literal-string** CardSummary/CardDetail define. But most CQL students (and Claude when generating CQL) write those defines as expressions:

\`\`\`
define CardSummary:
  'Patient last A1c was ' + ToString(LastA1cValue) + '%'
\`\`\`

The literal-only extractor returned nothing for these. The form showed an editable input. The user typed their own static summary, deployed — and at runtime the CQL's dynamicValue extension overrode their input. **User-visible symptom: "edits to the card page do not seem to override the CQL defaults."**

## Fix

Detect expression defines too:

- New \`detectCardDefines(cql)\` returns \`{summary?: 'literal'|'expression'}\` alongside the existing literal extractor.
- \`cqlCardOverrides\` in the wizard now carries \`{kind, value?}\` per field instead of a bare string.
- CardDesigner renders three states per field:
  - **literal** → read-only preview of the literal value (existing path)
  - **expression** → read-only "Computed at runtime — edit in CQL editor"
  - **undefined** → editable input (existing path)

Both locked states keep the same Edit-in-CQL affordance.

## Backend behavior

Unchanged. \`cql_artifact_builder\` still wires CardSummary/CardDetail into \`PlanDefinition.action.dynamicValue\` regardless of literal-vs-expression. The runtime contract is the same. This is purely a UI honesty patch — show the user that the form field is unreachable when CQL provides the value.

## Test plan

- [x] Diff scoped to wizard + extractor + tests.
- [x] Extractor tests extended with 4 new cases for `detectCardDefines`.
- [ ] Manual: New CQL service with `define CardSummary: 'x' + ToString(y)`. Expect: Step 3 shows a locked "Computed at runtime — edit in CQL editor" preview, not an empty input.
- [ ] Manual: Same with `define CardSummary: 'simple text'`. Expect: read-only preview showing "simple text" (existing behavior, unchanged).
- [ ] Manual: New service with no CardSummary define. Expect: editable input (existing behavior, unchanged).
- [ ] Manual: edit existing deployed service that has both static card_config.summary AND CQL CardSummary expression. Expect: form locks, runtime behavior unchanged (CQL still wins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)