### PR TITLE
fix(fhir): unwrap interceptor-transformed Bundle in fhirClient.batch

### DIFF
--- a/frontend/src/core/fhir/services/__tests__/fhirClient.test.ts
+++ b/frontend/src/core/fhir/services/__tests__/fhirClient.test.ts
@@ -273,6 +273,37 @@ describe('FHIRClient', () => {
       expect(results[1].success).toBe(true);
     });
 
+    test('should unwrap responses pre-transformed by the standardizeResponse interceptor', async () => {
+      // FHIRResourceContext registers a global response interceptor that
+      // rewrites any Bundle into `{ resources, total, bundle }`. By the
+      // time `httpClient.post` resolves, `response.data` is the wrapped
+      // shape and no longer has a top-level `.entry`. Without unwrapping,
+      // batch() silently returned [] and every loader that depended on it
+      // (warmPatientCache, fetchPatientBundle) dispatched nothing — the
+      // user-visible symptom was a fully-empty patient summary.
+      const innerBundle = {
+        resourceType: 'Bundle',
+        type: 'batch-response',
+        entry: [
+          { response: { status: '200' }, resource: { resourceType: 'Patient', id: '1' } },
+          { response: { status: '200' }, resource: { resourceType: 'Bundle', type: 'searchset', total: 2, entry: [] } }
+        ]
+      };
+      const wrapped = { resources: [], total: 2, bundle: innerBundle };
+      mockAxiosInstance.post.mockResolvedValueOnce({ data: wrapped });
+
+      const results = await client.batch([
+        { method: 'GET', url: 'Patient/1' },
+        { method: 'GET', url: 'Condition?patient=1' }
+      ]);
+
+      expect(results).toHaveLength(2);
+      expect(results[0].success).toBe(true);
+      expect(results[0].resource).toEqual({ resourceType: 'Patient', id: '1' });
+      expect(results[1].success).toBe(true);
+      expect(results[1].resource?.resourceType).toBe('Bundle');
+    });
+
     test('should handle batch errors', async () => {
       const batchBundle = {
         resourceType: 'Bundle',

--- a/frontend/src/core/fhir/services/fhirClient.ts
+++ b/frontend/src/core/fhir/services/fhirClient.ts
@@ -1300,9 +1300,18 @@ class FHIRClient {
     return this.executeWithDeduplication(requestKey, () =>
       this.queueRequest(async () => {
         const response = await this.httpClient.post<Bundle>('/', bundle);
-        
+
+        // FHIRResourceContext registers a response interceptor that rewrites
+        // any Bundle response (including batch-response) into a wrapped shape
+        // `{ resources, total, bundle }`. Unwrap it so we always work with
+        // the raw Bundle's `.entry`. Without this, every batch silently
+        // resolves to [] and the warming/summary loaders dispatch nothing.
+        const rawBundle: Bundle = (response.data as any)?.bundle?.resourceType === 'Bundle'
+          ? (response.data as any).bundle
+          : (response.data as Bundle);
+
         // Process results
-        const results: BatchResult[] = response.data.entry?.map(entry => {
+        const results: BatchResult[] = rawBundle.entry?.map(entry => {
           const status = entry.response?.status || '';
           const success = status.startsWith('2');
           


### PR DESCRIPTION
## Symptom

Patient summary cards (Active Problems, Current Medications, Recent Vitals, Encounters, Procedures, Labs, Immunizations) all show **0** for patients that clearly have data. Reproduced live for patient \`2bd39c62-e311-77ee-12f1-a1f01f6a8305\`:
- HAPI direct: 15 conditions, 5 meds, 30 obs (vital-signs), 10 encounters, 2 lab reports.
- React state for the same patient: every relationship bucket empty, every resource type zero.
- Network tab: \`POST /fhir/R4/\` (the batch) returned 200 with ~130KB of correct Bundle data.

The data arrived. The React state never received it.

## Root cause

\`fhirClient.batch\` (fhirClient.ts:1284) does \`this.httpClient.post('/', bundle)\` and then reads \`response.data.entry\` to build the \`BatchResult[]\`.

But \`FHIRResourceContext\` registers a global axios response interceptor (FHIRResourceContext.js:1777) that rewrites any Bundle response into \`{ resources, total, bundle }\`. By the time \`batch()\` awaits the post, \`response.data\` is the wrapper — there's no top-level \`.entry\`.

\`response.data.entry?.map(...)\` short-circuits to \`undefined\`, the \`|| []\` kicks in, **\`batch()\` returns \`[]\`**, every caller sees an empty result, and zero resources get dispatched into state.

## Why this only became visible now

PR #109 routed \`setCurrentPatient\` through \`warmPatientCache\` instead of running \`Patient/$everything\` in parallel. Pre-#109 the broken batch was already silently returning \`[]\` — but the parallel \`\$everything\` populated *some* data (hence the original "1 of 13 medications" symptom). Once \`\$everything\` was removed, warming was the sole loader and the broken batch surfaced as "everything is zero."

Other callers (\`SummaryTab\`, \`useOptimizedPatientData\`) were silently failing too and now work as well.

## Fix

One-shape check in \`batch()\`: if \`response.data.bundle\` looks like the real Bundle, unwrap it; otherwise treat \`response.data\` as the raw Bundle (preserves test/no-interceptor path).

\`\`\`ts
const rawBundle: Bundle = (response.data as any)?.bundle?.resourceType === 'Bundle'
  ? (response.data as any).bundle
  : (response.data as Bundle);

const results: BatchResult[] = rawBundle.entry?.map(entry => { ... }) || [];
\`\`\`

## Test plan

- [x] New unit test in \`fhirClient.test.ts\` for the wrapped-response shape — asserts \`batch()\` returns the expected \`BatchResult[]\` rather than \`[]\`.
- [x] Existing batch tests (raw-Bundle path) still pass.
- [ ] Manual after deploy: open patient \`2bd39c62-...\` summary, expect cards to populate (15 problems, 5 meds, 10 encounters, 30 vitals, 2 labs).
- [ ] Manual: chart review, pharmacy, results tabs all populate.

## Confirmed via Playwright

Reproduced the empty cards live, captured the batch request URLs (correct), captured the batch response body (130KB, 9 entries, all data present), and inspected React state via \`browser_evaluate\` — confirmed currentPatient set, but \`relationships[patientId] === {}\` and every resource bucket empty. Diagnosis is concrete, not theoretical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)