### PR TITLE
fix(cds-studio): edit-mode saved-service-id uses slug, not DB row id

### DIFF
--- a/frontend/src/modules/cds-studio/components/builder/VisualBuilderWizard.jsx
+++ b/frontend/src/modules/cds-studio/components/builder/VisualBuilderWizard.jsx
@@ -224,7 +224,16 @@ const VisualBuilderWizard = ({ open, onClose, onSuccess, existingService = null 
           created_by: svc.created_by || user?.username || 'unknown'
         });
         setReferencedValueSets(data.value_sets || []);
-        setSavedServiceId(svc.id || existingService.id);
+        // Save the SLUG (service_id), not the integer DB row id. The
+        // PUT/DELETE/test endpoints route by `{service_id}` and look up
+        // `WHERE service_id == '<slug>'`. PR #110 fixed this for the
+        // freshly-saved path (handleSaveDraft → setSavedServiceId(
+        // response.data.service_id)) but the edit-mode hydration path
+        // here was unfixed: clicking Next on step 4 (Prefetch) calls
+        // handleSaveDraft, which PUTs to `/services/<dbId>` (e.g. /35),
+        // backend returns "Visual service '35' not found", error
+        // banner appears on the prefetch step. Use the slug here too.
+        setSavedServiceId(svc.service_id || existingService.service_id);
         setActiveStep(0);
       } catch (err) {
         if (cancelled) return;


### PR DESCRIPTION
## Symptom

Editing any deployed visual-builder service: opening the wizard, navigating to step 4 (Prefetch), then clicking Next surfaces an error banner pinned to the prefetch step:

> Visual service '35' not found

(integer varies — it's whatever DB row id was assigned to the service being edited).

## Root cause

Same anti-pattern PR #110 fixed for the freshly-saved path. The wizard's \`handleSaveDraft\` does \`PUT /api/cds-visual-builder/services/{savedServiceId}\`, and the backend routes by service_id slug — \`WHERE service_id == '<arg>'\`.

PR #110 fixed line 386 (post-save):
\`\`\`js
setSavedServiceId(response.data.service_id);  // slug
\`\`\`

But the parallel edit-mode hydration path at line 227 was unfixed:
\`\`\`js
setSavedServiceId(svc.id || existingService.id);  // DB int
\`\`\`

So in edit mode, \`savedServiceId\` became \`35\` (or whatever the integer row id was). Crossing step 4 → 5 auto-saves via \`handleNext\` → \`handleSaveDraft\` → \`PUT /services/35\` → backend's \`WHERE service_id == '35'\` matches nothing → 404 "Visual service '35' not found".

## Fix

One-line change to use \`svc.service_id || existingService.service_id\` (the slug), matching the post-save path. Comment expanded so this doesn't get reverted on future edits.

## Test plan

- [ ] Edit any existing visual-builder service. Navigate Service Configuration → Build Logic → Design Card → **Prefetch**. Click **Next**. Confirm: no error banner; advances to Test & Deploy.
- [ ] On Test & Deploy, click **Run Service Test** with a real patient. Confirm: still works (PR #110 path is unaffected).
- [ ] Click **Deploy Service** (which is "Save and Re-deploy" in edit mode). Confirm: succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)