### PR TITLE
refactor(hooks): remove legacy useCDSHooks.js shim

### DIFF
--- a/frontend/src/components/clinical/workspace/dialogs/CPOEDialog.js
+++ b/frontend/src/components/clinical/workspace/dialogs/CPOEDialog.js
@@ -16,7 +16,7 @@ import {
   ORDER_CATEGORIES
 } from './config/serviceRequestDialogConfig';
 import { useAuth } from '../../../../contexts/AuthContext';
-import { useOrderSelectHook } from '../../../../hooks/useCDSHooks';
+import { useOrderSelectHook } from '../../../../hooks/cds/useCDSHooks';
 
 const CPOEDialog = ({ 
   open, 

--- a/frontend/src/components/clinical/workspace/dialogs/ImmunizationDialogEnhanced.js
+++ b/frontend/src/components/clinical/workspace/dialogs/ImmunizationDialogEnhanced.js
@@ -81,7 +81,7 @@ import { CLINICAL_EVENTS } from '../../../../constants/clinicalEvents';
 import { fhirClient } from '../../../../core/fhir/services/fhirClient';
 import cdsClinicalDataService from '../../../../services/cdsClinicalDataService';
 import { useDialogSave, useDialogValidation, VALIDATION_RULES } from './utils/dialogHelpers';
-import { useOrderSelectHook } from '../../../../hooks/useCDSHooks';
+import { useOrderSelectHook } from '../../../../hooks/cds/useCDSHooks';
 import CDSCard from '../../cds/CDSCard';
 
 const searchImmunizations = async (query) => {

--- a/frontend/src/components/clinical/workspace/dialogs/MedicationDialogEnhanced.js
+++ b/frontend/src/components/clinical/workspace/dialogs/MedicationDialogEnhanced.js
@@ -95,7 +95,7 @@ import { useFHIRResource } from '../../../../contexts/FHIRResourceContext';
 import { useCDS, CDS_HOOK_TYPES } from '../../../../contexts/CDSContext';
 import { useClinicalWorkflow } from '../../../../contexts/ClinicalWorkflowContext';
 import { useAuth } from '../../../../contexts/AuthContext';
-import { useOrderSelectHook } from '../../../../hooks/useCDSHooks';
+import { useOrderSelectHook } from '../../../../hooks/cds/useCDSHooks';
 import CDSCard from '../../cds/CDSCard';
 import { CLINICAL_EVENTS } from '../../../../constants/clinicalEvents';
 import { useDialogSave, useDialogValidation, VALIDATION_RULES } from './utils/dialogHelpers';

--- a/frontend/src/components/clinical/workspace/dialogs/OrderSigningDialog.js
+++ b/frontend/src/components/clinical/workspace/dialogs/OrderSigningDialog.js
@@ -32,7 +32,7 @@ import {
   Warning as WarningIcon,
   Psychology as CDSIcon
 } from '@mui/icons-material';
-import { useCDSHooks } from '../../../../hooks/useCDSHooks';
+import { useCDSHooks } from '../../../../hooks/cds/useCDSHooks';
 import { useClinical } from '../../../../contexts/ClinicalContext';
 import { useAuth } from '../../../../contexts/AuthContext';
 import CDSCard from '../../cds/CDSCard';

--- a/frontend/src/components/clinical/workspace/tabs/EnhancedOrdersTab.js
+++ b/frontend/src/components/clinical/workspace/tabs/EnhancedOrdersTab.js
@@ -65,7 +65,7 @@ import VirtualizedList from '../../../common/VirtualizedList';
 import { exportClinicalData, EXPORT_COLUMNS } from '../../../../core/export/exportUtils';
 import { getMedicationName } from '../../../../core/fhir/utils/medicationDisplayUtils';
 import { useCDS, CDS_HOOK_TYPES } from '../../../../contexts/CDSContext';
-import { useOrderSelectHook } from '../../../../hooks/useCDSHooks';
+import { useOrderSelectHook } from '../../../../hooks/cds/useCDSHooks';
 import CDSCard from '../../cds/CDSCard';
 import { getStatusColor, getSeverityColor } from '../../../../themes/clinicalThemeUtils';
 import websocketService from '../../../../services/websocket';

--- a/frontend/src/hooks/useCDSHooks.js
+++ b/frontend/src/hooks/useCDSHooks.js
@@ -1,2 +1,0 @@
-// Re-export from new location for backwards compatibility
-export * from './cds/useCDSHooks';


### PR DESCRIPTION
## What

\`frontend/src/hooks/useCDSHooks.js\` was a one-line re-export shim:

\`\`\`js
export * from './cds/useCDSHooks';
\`\`\`

Kept for backward compat after the canonical location moved to \`hooks/cds/useCDSHooks.js\`. Five call sites still import through the shim path, so every contributor working in this area has to discover both files exist, trace the re-export, and confirm exports match before trusting anything they read.

## Change

Five import sites updated to point at the canonical \`hooks/cds/useCDSHooks\`:

| File | Hook imported |
|---|---|
| \`components/clinical/workspace/tabs/EnhancedOrdersTab.js\` | useOrderSelectHook |
| \`components/clinical/workspace/dialogs/CPOEDialog.js\` | useOrderSelectHook |
| \`components/clinical/workspace/dialogs/MedicationDialogEnhanced.js\` | useOrderSelectHook |
| \`components/clinical/workspace/dialogs/ImmunizationDialogEnhanced.js\` | useOrderSelectHook |
| \`components/clinical/workspace/dialogs/OrderSigningDialog.js\` | useCDSHooks |

Shim file deleted.

## Verification

\`grep -rn "from.*hooks/useCDSHooks'"\` returns zero matches after the change. The five consumers above were the only ones using the legacy path. No behavior change — same hook, same implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)