### PR TITLE
chore(jest): whitelist axios in transformIgnorePatterns

### DIFF
--- a/frontend/craco.config.js
+++ b/frontend/craco.config.js
@@ -148,9 +148,29 @@ module.exports = {
   babel: {
     plugins: [
       // Remove console.log in production
-      ...(process.env.NODE_ENV === 'production' 
+      ...(process.env.NODE_ENV === 'production'
         ? [['transform-remove-console', { exclude: ['error', 'warn'] }]]
         : []),
     ],
+  },
+  jest: {
+    configure: (jestConfig) => {
+      // axios v1.x ships ESM-only and CRA's default transformIgnorePatterns
+      // bans everything under node_modules from babel transformation,
+      // which means `import axios from 'axios'` blows up in tests with
+      // "SyntaxError: Cannot use import statement outside a module".
+      //
+      // Whitelist axios (and any future ESM-only deps we identify) so
+      // jest transforms them through babel like our own source. Without
+      // this, every test that transitively imports axios needs a
+      // hand-rolled `jest.mock('axios', ...)` at the top — see prior
+      // PRs #113 and #117 for the workaround.
+      const esmOnlyDeps = ['axios'];
+      jestConfig.transformIgnorePatterns = [
+        `[/\\\\]node_modules[/\\\\](?!(${esmOnlyDeps.join('|')})[/\\\\])`,
+        '^.+\\.module\\.(css|sass|scss)$',
+      ];
+      return jestConfig;
+    },
   },
 };

--- a/frontend/src/services/__tests__/cdsHooksClient.parallel.test.js
+++ b/frontend/src/services/__tests__/cdsHooksClient.parallel.test.js
@@ -13,37 +13,10 @@
  * card ordering still matches the input service list so on-screen
  * placement is stable.
  */
-// axios v1.x ships ESM and isn't transformed by the project's jest
-// config; mock it before the cdsHooksClient module loads. The tests
-// stub `executeHook` directly via spyOn, so the underlying HTTP client
-// is never exercised — the mock just needs to satisfy the import +
-// `axios.create({...})` call at module load.
-jest.mock('axios', () => ({
-  __esModule: true,
-  default: {
-    create: () => ({
-      get: jest.fn(),
-      post: jest.fn(),
-      put: jest.fn(),
-      delete: jest.fn(),
-      interceptors: {
-        request: { use: jest.fn() },
-        response: { use: jest.fn() },
-      },
-    }),
-  },
-  create: () => ({
-    get: jest.fn(),
-    post: jest.fn(),
-    put: jest.fn(),
-    delete: jest.fn(),
-    interceptors: {
-      request: { use: jest.fn() },
-      response: { use: jest.fn() },
-    },
-  }),
-}));
-
+// CRACO's jest.transformIgnorePatterns now whitelists axios so the
+// per-file ESM mock dance previous PRs needed (#113, #117) is no
+// longer required. The cdsPrefetchResolver mock stays — it stubs out
+// network behavior the tests don't want to exercise, not an ESM workaround.
 jest.mock('../cdsPrefetchResolver', () => ({
   cdsPrefetchResolver: {
     resolvePrefetchTemplates: jest.fn().mockResolvedValue(null),


### PR DESCRIPTION
## Why

axios v1.x ships ESM-only. CRA's default jest config bans everything under \`node_modules\` from babel transformation, so any test that transitively imports axios blows up with:

\`\`\`
SyntaxError: Cannot use import statement outside a module
```ESM</axios/lib/axios.js
\`\`\`

The workaround in PRs #113 and #117 was a per-file \`jest.mock('axios', () => ({ create: () => ({ ... }) }))\` block at the top of every affected test. Recurring tax, easy to forget, ugly to maintain.

## Fix

One config change in \`craco.config.js\` adds a \`jest.configure\` that extends \`transformIgnorePatterns\` to whitelist axios (and any future ESM-only deps):

\`\`\`js
jest: {
  configure: (jestConfig) => {
    const esmOnlyDeps = ['axios'];
    jestConfig.transformIgnorePatterns = [
      \`[/\\\\\\\\]node_modules[/\\\\\\\\](?!(\${esmOnlyDeps.join('|')})[/\\\\\\\\])\`,
      '^.+\\\\.module\\\\.(css|sass|scss)\$',
    ];
    return jestConfig;
  },
},
\`\`\`

Also removed the now-unnecessary per-file axios mock from \`src/services/__tests__/cdsHooksClient.parallel.test.js\`. Other mocks in that file (cdsPrefetchResolver) are kept — they stub network behavior, not ESM imports.

## Verification

\`\`\`
PASS src/services/__tests__/cdsHooksClient.parallel.test.js (6 tests)
PASS src/hooks/cds/__tests__/useOrderSelectHook.test.js (10 tests)
PASS src/utils/__tests__/cdsDraftBundle.test.js (7 tests)
PASS src/modules/cds-studio/utils/__tests__/cqlDefineExtractor.test.js (12 tests)

Tests:       35 passed, 35 total
\`\`\`

The previously-failing fhirClient tests (\`src/services/__tests__/fhirClient.test.js\`, \`src/core/fhir/services/__tests__/fhirClient.test.ts\`) progress past the axios ESM error but still fail for **unrelated pre-existing reasons** (missing \`axios-mock-adapter\` package, JS/TS interop issue on FHIRClient class export). Those failures pre-date this change and are out of scope. Worth a follow-up cleanup.

## Test plan

- [x] All 4 currently-passing test suites still pass
- [x] cdsHooksClient.parallel.test.js passes without its per-file axios mock
- [ ] Future PRs that import axios in tests don't need a per-file mock

🤖 Generated with [Claude Code](https://claude.com/claude-code)