### PR TITLE
feat(cds): forward CDS Hooks draftOrders to CQL via $apply data parameter

### DIFF
--- a/backend/api/cds_hooks/cql_bridge.py
+++ b/backend/api/cds_hooks/cql_bridge.py
@@ -335,10 +335,33 @@ class CQLBridge:
             else f"Encounter/{encounter_id}" if encounter_id else None
         )
 
+        # CDS Hooks 2.0 context-binding: surface `draftOrders` to CQL via the
+        # $apply `data` parameter. cqf-fhir-cr-hapi merges these entries into
+        # the data sources its CQL Data Provider consults — verified end-to-
+        # end in spike #126 (T2 inline merge, T4 status filter, T5 strict
+        # subject-context filter, T6 multi-retrieve consistency, T7 no
+        # caching across calls). With this wiring, an order-select CQL rule
+        # can write `[Immunization]` and see both persisted resources AND
+        # the in-progress draft from `context.draftOrders` — without any
+        # special parameters or platform-specific CQL.
+        #
+        # Skip empty / malformed bundles: sending Bundle{entry: []} is
+        # legal but adds engine work for zero benefit, and a non-Bundle
+        # value (or null) should never reach $apply as `data`.
+        draft_orders = ctx.get("draftOrders")
+        data_bundle = (
+            draft_orders
+            if isinstance(draft_orders, dict)
+            and draft_orders.get("resourceType") == "Bundle"
+            and draft_orders.get("entry")
+            else None
+        )
+
         result = await self.apply(
             plan_definition_id,
             subject_ref=subject_ref,
             encounter_ref=encounter_ref,
+            data_bundle=data_bundle,
             source_label=source_label,
         )
         return CDSHookResponse(cards=result.cards, systemActions=None)

--- a/backend/tests/api/cds_hooks/test_cql_bridge.py
+++ b/backend/tests/api/cds_hooks/test_cql_bridge.py
@@ -8,6 +8,7 @@ Coverage:
 - validate_cql, apply, derive_data_requirements: HAPI interaction (mocked)
 """
 
+import json
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -579,6 +580,168 @@ class TestExecuteForHook:
 
         with pytest.raises(ValueError, match="patientId"):
             await bridge.execute_for_hook("pd1", request)
+
+
+# ---------------------------------------------------------------------------
+# execute_for_hook + draftOrders → $apply data parameter (issue #127)
+#
+# CDS Hooks 2.0 carries the in-progress order(s) being composed in
+# context.draftOrders. The bridge surfaces this to CQL via the $apply `data`
+# parameter — cqf-fhir-cr-hapi merges those entries into the CQL Data
+# Provider's view, so a `[Immunization]` retrieve sees both persisted
+# resources and the draft. Verified end-to-end by spike #126.
+# ---------------------------------------------------------------------------
+
+
+def _make_request_with_context(hook_type, ctx):
+    import uuid
+    return CDSHookRequest(
+        hook=hook_type,
+        hookInstance=str(uuid.uuid4()),
+        context=ctx,
+    )
+
+
+def _make_immunization_bundle(*coding_codes):
+    """Build a draftOrders Bundle with one Immunization per CVX code."""
+    return {
+        "resourceType": "Bundle",
+        "id": "cds-draft-test",
+        "type": "collection",
+        "entry": [
+            {"resource": {
+                "resourceType": "Immunization",
+                "id": f"draft-{i + 1}",
+                "status": "completed",
+                "vaccineCode": {
+                    "coding": [{
+                        "system": "http://hl7.org/fhir/sid/cvx",
+                        "code": code,
+                    }],
+                },
+                "patient": {"reference": "Patient/p1"},
+            }}
+            for i, code in enumerate(coding_codes)
+        ],
+    }
+
+
+class TestExecuteForHookDraftOrders:
+    """draftOrders flows through to $apply as the `data` parameter."""
+
+    @pytest.mark.asyncio
+    async def test_draft_orders_forwarded_as_data_parameter(self):
+        bridge = CQLBridge(hapi_base_url="http://hapi.test/fhir")
+        bundle = _make_immunization_bundle("03")
+        request = _make_request_with_context(
+            HookType.ORDER_SELECT,
+            {
+                "patientId": "p1",
+                "userId": "Practitioner/demo",
+                "selections": ["Bundle/cds-draft-test#Immunization/draft-1"],
+                "draftOrders": bundle,
+            },
+        )
+        cp = make_careplan([{"title": "x"}])
+
+        with patch.object(bridge, "_post_operation", new=AsyncMock()) as mocked:
+            mocked.return_value = cp
+            await bridge.execute_for_hook("pd1", request)
+
+        _, body = mocked.call_args[0]
+        params_by_name = {p["name"]: p for p in body["parameter"]}
+        assert "data" in params_by_name, "draftOrders should be forwarded as `data` parameter"
+        # Pass-through: the bundle reaches $apply byte-equal to context.draftOrders.
+        assert params_by_name["data"]["resource"] == bundle
+
+    @pytest.mark.asyncio
+    async def test_no_draft_orders_skips_data_parameter(self):
+        """patient-view and other hooks without draftOrders should not send `data`."""
+        bridge = CQLBridge(hapi_base_url="http://hapi.test/fhir")
+        request = _make_request_with_context(
+            HookType.PATIENT_VIEW,
+            {"patientId": "p1", "userId": "Practitioner/demo"},
+        )
+        cp = make_careplan([{"title": "x"}])
+
+        with patch.object(bridge, "_post_operation", new=AsyncMock()) as mocked:
+            mocked.return_value = cp
+            await bridge.execute_for_hook("pd1", request)
+
+        _, body = mocked.call_args[0]
+        param_names = [p["name"] for p in body["parameter"]]
+        assert "data" not in param_names
+
+    @pytest.mark.asyncio
+    async def test_empty_draft_orders_bundle_skips_data_parameter(self):
+        """Bundle with entry=[] — legal FHIR but no value sending it on."""
+        bridge = CQLBridge(hapi_base_url="http://hapi.test/fhir")
+        request = _make_request_with_context(
+            HookType.ORDER_SELECT,
+            {
+                "patientId": "p1",
+                "draftOrders": {
+                    "resourceType": "Bundle",
+                    "type": "collection",
+                    "entry": [],
+                },
+            },
+        )
+        cp = make_careplan([{"title": "x"}])
+
+        with patch.object(bridge, "_post_operation", new=AsyncMock()) as mocked:
+            mocked.return_value = cp
+            await bridge.execute_for_hook("pd1", request)
+
+        _, body = mocked.call_args[0]
+        param_names = [p["name"] for p in body["parameter"]]
+        assert "data" not in param_names
+
+    @pytest.mark.asyncio
+    async def test_malformed_draft_orders_skipped_gracefully(self):
+        """Bridge tolerates non-Bundle / null / wrong-shape draftOrders."""
+        bridge = CQLBridge(hapi_base_url="http://hapi.test/fhir")
+        cp = make_careplan([{"title": "x"}])
+
+        for bad in [
+            None,
+            "not a bundle",
+            42,
+            {"resourceType": "Patient", "id": "p1"},   # wrong resourceType
+            {"resourceType": "Bundle"},                  # missing entry
+        ]:
+            request = _make_request_with_context(
+                HookType.ORDER_SELECT,
+                {"patientId": "p1", "draftOrders": bad},
+            )
+            with patch.object(bridge, "_post_operation", new=AsyncMock()) as mocked:
+                mocked.return_value = cp
+                await bridge.execute_for_hook("pd1", request)
+            _, body = mocked.call_args[0]
+            param_names = [p["name"] for p in body["parameter"]]
+            assert "data" not in param_names, f"data param leaked for malformed bundle: {bad!r}"
+
+    @pytest.mark.asyncio
+    async def test_draft_orders_passed_through_unchanged(self):
+        """Bridge should not mutate or filter the bundle — it goes to $apply as-is."""
+        bridge = CQLBridge(hapi_base_url="http://hapi.test/fhir")
+        bundle = _make_immunization_bundle("03", "21", "37")
+        original_snapshot = json.dumps(bundle, sort_keys=True)
+        request = _make_request_with_context(
+            HookType.ORDER_SELECT,
+            {"patientId": "p1", "draftOrders": bundle},
+        )
+        cp = make_careplan([{"title": "x"}])
+
+        with patch.object(bridge, "_post_operation", new=AsyncMock()) as mocked:
+            mocked.return_value = cp
+            await bridge.execute_for_hook("pd1", request)
+
+        # Bundle is byte-equal both in the call AND in the original (no mutation).
+        _, body = mocked.call_args[0]
+        forwarded = next(p for p in body["parameter"] if p["name"] == "data")["resource"]
+        assert forwarded == bundle
+        assert json.dumps(bundle, sort_keys=True) == original_snapshot
 
 
 # ---------------------------------------------------------------------------

--- a/docs/STUDENT_CQL_PRIMER.md
+++ b/docs/STUDENT_CQL_PRIMER.md
@@ -277,6 +277,133 @@ ValueSet again — the flush will fire on save.
 
 ---
 
+## Reacting to the order being composed (order-select hooks)
+
+For hooks that fire during order composition (`order-select`, sometimes
+`medication-prescribe`), the CDS Hooks request carries the in-progress
+draft order in `context.draftOrders` — a Bundle of resources the clinician
+is currently selecting but hasn't yet signed/saved.
+
+The platform's CQL bridge forwards this Bundle to HAPI's `$apply` operation
+as the `data` parameter. cqf-fhir-cr-hapi merges those entries into the
+data the CQL Data Provider consults, so a retrieve like `[Immunization]`
+returns **both** persisted resources from the patient's record AND the
+draft from the hook payload — automatically. You don't declare any special
+parameters; the standard CQL retrieve syntax just works.
+
+### Worked example: live-vaccine contraindication for immunocompromised patients
+
+Fires when an immunocompromised adult is selecting a live attenuated vaccine.
+Targets `order-select`. The draft Immunization being composed appears in
+`[Immunization]` retrievals alongside the patient's persisted vaccine
+history.
+
+```cql
+library LiveVaccineContraindication version '1.0.0'
+
+using FHIR version '4.0.1'
+include FHIRHelpers version '4.0.1' called FHIRHelpers
+
+context Patient
+
+// Patient phenotype: severe immunocompromise per CDC ACIP definition.
+// CD4 < 200 cells/mm³ measured in the last 6 months.
+
+define IsAdult: AgeInYears() >= 18
+
+define MostRecentCD4:
+  First([Observation] O
+    where exists (O.code.coding C where C.system = 'http://loinc.org'
+                                     and C.code = '24467-3')
+      and O.status in {'final', 'amended', 'corrected'}
+      and (O.effective as FHIR.dateTime).value after Now() - 6 months
+    sort by (effective as FHIR.dateTime).value desc)
+
+define MostRecentCD4Value: (MostRecentCD4.value as Quantity).value
+
+define HasSevereImmunocompromise:
+  MostRecentCD4 is not null and MostRecentCD4Value < 200
+
+// The draft Immunization the clinician is selecting lands in
+// [Immunization] retrievals automatically (via context-binding from
+// CDS Hooks 2.0 draftOrders to the $apply data parameter). We match
+// it using a where-clause on the coding rather than a
+// [Resource: "VS"] retrieve — see "ValueSet retrievals" caveat below.
+
+define IsLiveVaccineBeingSelected:
+  exists ([Immunization] I
+    where exists (I.vaccineCode.coding C
+      where C.system = 'http://hl7.org/fhir/sid/cvx'
+        and C.code in {'03', '21', '37', '94', '111', '25', '75'}))
+      // 03=MMR, 21=varicella, 37=Yellow Fever, 94=MMRV,
+      // 111=influenza live, 25=typhoid, 75=Smallpox
+
+define Applicability:
+  IsAdult and HasSevereImmunocompromise and IsLiveVaccineBeingSelected
+
+define CardSummary:
+  'Live vaccine contraindicated: CD4 ' + ToString(MostRecentCD4Value) + ' cells/mm³'
+
+define CardDetail:
+  'Patient has CD4 ' + ToString(MostRecentCD4Value)
+    + ' cells/mm³ — severe immunocompromise per CDC ACIP. Live, '
+    + 'replicating vaccines are contraindicated due to risk of '
+    + 'disseminated infection from the attenuated organism. '
+    + 'Cancel and consider an inactivated alternative if available, '
+    + 'or defer pending infectious disease consultation.'
+```
+
+This rule fires only when **all three** are true — the patient is an
+adult, has severe immunocompromise (CD4 < 200), AND is selecting a live
+vaccine. None of the three predicates needs special hook-context plumbing;
+standard CQL syntax sees both persisted and draft data.
+
+### What's available where
+
+The platform forwards `context.draftOrders` for `order-select` firings on:
+
+- `CPOEDialog` (lab / imaging / procedure orders → `ServiceRequest` drafts)
+- `MedicationDialogEnhanced` (medication picks → `MedicationRequest` drafts;
+  also fires the existing `medication-prescribe` hook for compatibility)
+- `ImmunizationDialogEnhanced` (vaccine picks → `Immunization` drafts)
+- `EnhancedOrdersTab` (existing-orders checkbox path → whatever resource
+  type the order is)
+
+When the bridge receives a hook request with `context.draftOrders` set, it
+attaches the bundle as the `data` parameter on `$apply`. When `draftOrders`
+is missing or empty, the parameter is omitted (so patient-view hooks and
+other non-composition flows are unchanged).
+
+### Trade-offs and constraints
+
+**Subject filtering is strict.** If `draftOrders` includes resources
+referencing a different patient than the hook's `subject`, the engine
+filters them out. Drafts always need to align with the patient context to
+be visible to CQL. This is good — it keeps cross-patient leakage
+impossible at the engine level.
+
+**ValueSet retrievals can fail.** A retrieve like
+`[Immunization: "Live Replicating Vaccines"]` against a freshly-uploaded
+ValueSet can cause the entire library to fail compilation in this HAPI
+deployment — an orthogonal issue with HAPI's terminology cache (HSearch
+disabled). Workaround: use `where`-clause matching against known coding
+values, as in the worked example above. Both produce equivalent semantics;
+the where-clause version sidesteps the VS-expansion path entirely.
+
+**The `data` parameter is additive, not a replacement.** CQL retrieves
+still consult patient-compartment data (the persisted resources HAPI has
+stored). Drafts appear *alongside* the persisted set, not instead of it.
+Don't try to use this mechanism to override patient data; use it to react
+to the draft in flight.
+
+**Multi-resource composition (future).** When CPOE evolves to multi-order
+drafting (issue #116), all drafted resources land in `context.draftOrders`
+together. CQL retrieves like `[Immunization]` already handle this case
+without changes — each draft Immunization in the bundle becomes an
+independent entry in the retrieve result.
+
+---
+
 ## What happens when you Deploy
 
 1. Your CQL is re-uploaded to HAPI at a stable, versioned canonical URL


### PR DESCRIPTION
Closes #127.

## What

CDS Hooks 2.0 carries the in-progress order being composed in \`context.draftOrders\` (a Bundle of draft resources). Until now CQL-backed services received only \`subject=Patient/{id}\` on the \`\$apply\` call — \`draftOrders\` was invisible to CQL. So a rule like \`exists ([Immunization: "Live Vaccines"])\` that tries to detect the order being selected always failed: the draft isn't in HAPI storage, and CQL retrievals only consult the patient compartment.

\`CQLBridge.execute_for_hook\` now extracts \`context.draftOrders\` and forwards it via the existing \`data_bundle\` kwarg on \`apply()\`. The \`\$apply\` Parameters body gets a \`data\` entry containing the bundle. cqf-fhir-cr-hapi merges those entries into the data sources its CQL Data Provider consults.

## Why this works (verified by #126)

Spike #126 confirmed cqf-fhir-cr-hapi handles inline \`data\` correctly:

- Inline data merges into \`[Resource]\` retrieves ✓
- \`where\`-clause filters apply to inline ✓
- Subject-context filtering is strict (no cross-patient leakage) ✓
- Merge persists across multiple retrievals in one evaluation ✓
- No caching across consecutive \`\$apply\` calls ✓

Only failure was VS-filtered retrievals (\`[Resource: "VS"]\`), which is a pre-existing HAPI ValueSet-expansion issue orthogonal to this work. Documented as a constraint with a workaround in the primer.

## CQL author experience

Zero changes to existing services. New services that want to react to drafts just write \`[Resource]\` and both persisted + draft entries appear. No special parameters, no CDS-Hooks-specific CQL syntax.

A worked example in \`docs/STUDENT_CQL_PRIMER.md\` shows VaxGuard-style live-vaccine contraindication using the new pattern.

## Tests

\`\`\`
43 passed (38 existing + 5 new)
\`\`\`

The 5 new cases in \`TestExecuteForHookDraftOrders\`:
- draftOrders forwarded as \`data\` parameter
- missing draftOrders skips \`data\` parameter (patient-view, etc. unchanged)
- empty Bundle skips \`data\` parameter (avoid sending entry=[])
- malformed/non-Bundle inputs skipped gracefully
- bundle is passed through byte-equal (no mutation)

## Out of scope (deliberate)

- **VaxGuard2.0 itself** — student-authored; the docs show the pattern, owner can update if desired.
- **HAPI VS-expansion fix** — orthogonal; affects much more than just this codepath.
- **Multi-resource composition** — already supported by this change; just needs issue #116 to ship the multi-order UX.

## Test plan post-deploy

- [ ] Open Melvin857's chart (CD4 = 112, well under 200)
- [ ] Open immunization dialog → pick MMR (CVX 03)
- [ ] Confirm order-composition-context still fires (regression check)
- [ ] In DevTools network tab, inspect the \`POST /api/cds-services/{id}\` call body for any CQL-backed order-select service registered: confirm the request includes \`context.draftOrders\` as expected
- [ ] Confirm the upstream \`POST /fhir/PlanDefinition/{id}/\$apply\` request body now includes a \`data\` parameter (visible in HAPI logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)