### PR TITLE
feat(cql): surface FHIRHelpers tip on cryptic compile errors (#122)

### DIFF
--- a/backend/api/cds_hooks/cql_bridge.py
+++ b/backend/api/cds_hooks/cql_bridge.py
@@ -57,6 +57,27 @@ from .models import (
 _LIBRARY_DIRECTIVE_RE = re.compile(r"\s*library\s+[A-Za-z][A-Za-z0-9_]*\s+version\s+'")
 _COMMENT_STRIP_RE = re.compile(r"//[^\n]*\n|/\*.*?\*/", flags=re.DOTALL)
 
+# Two error shapes from the CQL→ELM compiler both have the same student fix:
+# add `include FHIRHelpers version '4.0.001'`. The first fires when CQL calls
+# any operator (ToString, ToDecimal, etc.) on a value of type FHIR.X — the
+# compiler can't find a matching signature without FHIRHelpers' implicit
+# converters. The second fires when the library references FHIRHelpers
+# explicitly (e.g. via `include FHIRHelpers version '4.0.000'`) and the
+# version isn't resolvable in HAPI's content catalog.
+_FHIR_TYPE_SIGNATURE_RE = re.compile(
+    r"Could not resolve call to operator \w+ with signature \(FHIR\.\w+\)"
+)
+_UNRESOLVED_FHIRHELPERS_RE = re.compile(
+    r"Could not resolve library name FHIRHelpers"
+)
+_FHIRHELPERS_HINT_DIAGNOSTIC = (
+    "Tip: Add `include FHIRHelpers version '4.0.001'` near the top of your "
+    "library (just below `using FHIR version '4.0.1'`). FHIRHelpers provides "
+    "the implicit converters CQL needs to call operators on FHIR-typed "
+    "values like Patient.id or Observation.value. See "
+    "docs/STUDENT_CQL_PRIMER.md → Common errors."
+)
+
 
 def _looks_like_full_library(cql_text: str) -> bool:
     """True if the input starts with a `library X version 'V'` directive.
@@ -142,8 +163,14 @@ class CQLBridge:
         need a subject for compile-time validation.
         """
         if _looks_like_full_library(cql_text):
-            return await self._validate_library(cql_text)
-        return await self._validate_expression(cql_text, subject_ref)
+            result = await self._validate_library(cql_text)
+        else:
+            result = await self._validate_expression(cql_text, subject_ref)
+        # Single augmentation point — covers expression + library paths AND
+        # every failure mode they handle internally (HTTP errors, request
+        # errors, compile-time OperationOutcomes), so students see the
+        # FHIRHelpers tip regardless of where the error originated.
+        return self._with_fhirhelpers_hint(result)
 
     async def _validate_expression(
         self,
@@ -491,6 +518,34 @@ class CQLBridge:
                 actions=actions or None,
             ))
         return suggestions
+
+    def _with_fhirhelpers_hint(self, result: ValidationResult) -> ValidationResult:
+        """Append a FHIRHelpers tip when issues match known fingerprint patterns.
+
+        The CQL→ELM compiler error messages for missing-FHIRHelpers are
+        cryptic for students (e.g. ``Could not resolve call to operator
+        ToString with signature (FHIR.id)``). Both fingerprints have the
+        same fix — adding ``include FHIRHelpers version '4.0.001'`` — so we
+        detect either and append a single info-severity hint. Deduplicated:
+        we never append the hint twice, even if the response surfaces
+        multiple matching errors.
+        """
+        if any(i.severity == "information" and i.diagnostics == _FHIRHELPERS_HINT_DIAGNOSTIC
+               for i in result.issues):
+            return result
+
+        for issue in result.issues:
+            diag = issue.diagnostics or ""
+            if (
+                _FHIR_TYPE_SIGNATURE_RE.search(diag)
+                or _UNRESOLVED_FHIRHELPERS_RE.search(diag)
+            ):
+                hint = ValidationIssue(
+                    severity="information",
+                    diagnostics=_FHIRHELPERS_HINT_DIAGNOSTIC,
+                )
+                return ValidationResult(ok=result.ok, issues=result.issues + [hint])
+        return result
 
     def _collect_outcome_issues(self, response: Any) -> List[ValidationIssue]:
         """Aggregate OperationOutcome.issue[] from anywhere in the response.

--- a/backend/tests/api/cds_hooks/test_cql_bridge.py
+++ b/backend/tests/api/cds_hooks/test_cql_bridge.py
@@ -455,6 +455,156 @@ class TestValidateCQLAutoRouting:
 
 
 # ---------------------------------------------------------------------------
+# FHIRHelpers hint detection (#122)
+# ---------------------------------------------------------------------------
+
+
+class TestFHIRHelpersHint:
+    """validate_cql should surface a friendly tip when the underlying CQL
+    compiler error fingerprints to a missing-FHIRHelpers situation."""
+
+    HINT_FRAGMENT = "include FHIRHelpers version '4.0.001'"
+
+    @pytest.mark.asyncio
+    async def test_expression_path_emits_hint_for_fhir_type_signature_error(self):
+        """`ToString(Patient.id)` without FHIRHelpers triggers a 'signature (FHIR.id)' error.
+
+        The bridge should append an info-severity hint pointing the student
+        at the FHIRHelpers include line.
+        """
+        bridge = CQLBridge(hapi_base_url="http://hapi.test/fhir")
+        with patch.object(bridge, "_post_operation", new=AsyncMock()) as mocked:
+            mocked.return_value = {
+                "resourceType": "OperationOutcome",
+                "issue": [{
+                    "severity": "error",
+                    "diagnostics": (
+                        "Could not resolve call to operator ToString "
+                        "with signature (FHIR.id)"
+                    ),
+                }],
+            }
+            result = await bridge.validate_cql("ToString(Patient.id)")
+
+        assert result.ok is False
+        hints = [i for i in result.issues if i.severity == "information"]
+        assert len(hints) == 1
+        assert self.HINT_FRAGMENT in (hints[0].diagnostics or "")
+        # The original error must remain — the hint is additive, not a replacement.
+        assert any(i.severity == "error" for i in result.issues)
+
+    @pytest.mark.asyncio
+    async def test_library_path_emits_hint_for_unresolved_fhirhelpers(self):
+        """`include FHIRHelpers version 'X.Y.Z'` where X.Y.Z isn't in HAPI
+        produces `Could not resolve library name FHIRHelpers`. Same hint applies."""
+        bridge = CQLBridge(hapi_base_url="http://hapi.test/fhir")
+        cql = (
+            "library Bad version '0.1.0'\n"
+            "using FHIR version '4.0.1'\n"
+            "include FHIRHelpers version '9.9.999'\n"
+            "context Patient\n"
+            "define X: ToString(Patient.id)"
+        )
+
+        with patch("api.cds_hooks.cql_dev_helper.upload_dev_library", new=AsyncMock()) as mock_upload:
+            mock_upload.return_value = ("ValidateProbeFH", "http://x/Library/ValidateProbeFH")
+            with patch.object(bridge, "_post_operation", new=AsyncMock()) as mocked_post:
+                mocked_post.return_value = {
+                    "resourceType": "Library",
+                    "contained": [{
+                        "resourceType": "OperationOutcome",
+                        "issue": [{
+                            "severity": "error",
+                            "diagnostics": "Could not resolve library name FHIRHelpers",
+                        }],
+                    }],
+                }
+                result = await bridge.validate_cql(cql)
+
+        assert result.ok is False
+        hints = [i for i in result.issues if i.severity == "information"]
+        assert len(hints) == 1
+        assert self.HINT_FRAGMENT in (hints[0].diagnostics or "")
+
+    @pytest.mark.asyncio
+    async def test_no_hint_when_unrelated_error(self):
+        """An error that doesn't match either fingerprint should NOT trigger the hint —
+        we don't want to spam students with FHIRHelpers advice for, say, a typo."""
+        bridge = CQLBridge(hapi_base_url="http://hapi.test/fhir")
+        with patch.object(bridge, "_post_operation", new=AsyncMock()) as mocked:
+            mocked.return_value = {
+                "resourceType": "OperationOutcome",
+                "issue": [{
+                    "severity": "error",
+                    "diagnostics": "Could not resolve identifier NoSuchIdentifier",
+                }],
+            }
+            result = await bridge.validate_cql("NoSuchIdentifier")
+
+        assert result.ok is False
+        assert not any(i.severity == "information" for i in result.issues)
+
+    @pytest.mark.asyncio
+    async def test_hint_is_deduplicated(self):
+        """Multiple matching errors must produce only ONE hint — repeated tips are noise."""
+        bridge = CQLBridge(hapi_base_url="http://hapi.test/fhir")
+        with patch.object(bridge, "_post_operation", new=AsyncMock()) as mocked:
+            mocked.return_value = {
+                "resourceType": "OperationOutcome",
+                "issue": [
+                    {
+                        "severity": "error",
+                        "diagnostics": (
+                            "Could not resolve call to operator ToString "
+                            "with signature (FHIR.id)"
+                        ),
+                    },
+                    {
+                        "severity": "error",
+                        "diagnostics": (
+                            "Could not resolve call to operator ToString "
+                            "with signature (FHIR.code)"
+                        ),
+                    },
+                ],
+            }
+            result = await bridge.validate_cql("ToString(Patient.id) | ToString(Observation.code)")
+
+        hints = [i for i in result.issues if i.severity == "information"]
+        assert len(hints) == 1
+
+    @pytest.mark.asyncio
+    async def test_hint_appended_on_http_error_path_when_outcome_matches(self):
+        """A 4xx with an OperationOutcome containing the fingerprint should still
+        get the hint — the issue body originated from HAPI, not from the bridge."""
+        bridge = CQLBridge(hapi_base_url="http://hapi.test/fhir")
+        bad_response = MagicMock(spec=httpx.Response)
+        bad_response.status_code = 400
+        bad_response.json.return_value = {
+            "resourceType": "OperationOutcome",
+            "issue": [{
+                "severity": "error",
+                "diagnostics": (
+                    "Could not resolve call to operator ToDecimal "
+                    "with signature (FHIR.decimal)"
+                ),
+            }],
+        }
+        bad_response.text = "..."
+
+        with patch.object(bridge, "_post_operation", new=AsyncMock()) as mocked:
+            mocked.side_effect = httpx.HTTPStatusError(
+                "400", request=MagicMock(), response=bad_response,
+            )
+            result = await bridge.validate_cql("ToDecimal(Observation.value)")
+
+        assert result.ok is False
+        hints = [i for i in result.issues if i.severity == "information"]
+        assert len(hints) == 1
+        assert self.HINT_FRAGMENT in (hints[0].diagnostics or "")
+
+
+# ---------------------------------------------------------------------------
 # apply — happy path & shape end-to-end
 # ---------------------------------------------------------------------------
 

--- a/docs/STUDENT_CQL_PRIMER.md
+++ b/docs/STUDENT_CQL_PRIMER.md
@@ -225,6 +225,27 @@ The Synthea data set includes plenty of common conditions.
 
 ## Common mistakes (saving you a few hours of debugging)
 
+### "Could not resolve call to operator ToString with signature (FHIR.id)" (or any FHIR.X)
+
+CQL needs `FHIRHelpers` to call operators (`ToString`, `ToDecimal`, `ToConcept`,
+etc.) on FHIR-typed values like `Patient.id`, `Observation.value`, or any
+`code`/`Coding` field. Without it, the compiler can't find a matching
+signature for "operator + FHIR type" and the error fingerprint always
+includes `signature (FHIR.something)`.
+
+**Fix**: add this line near the top of your library, just below
+`using FHIR version '4.0.1'`:
+
+```cql
+include FHIRHelpers version '4.0.001'
+```
+
+The test panel will now also append a hint with the same advice whenever
+it sees this fingerprint — so if you see "Tip: Add `include FHIRHelpers
+version '4.0.001'`" in the validation panel, the fix is exactly that one
+line. (Same hint fires if you wrote `include FHIRHelpers version '4.0.000'`
+or some other version HAPI doesn't have — use `'4.0.001'`.)
+
 ### "Could not resolve expression reference 'X'"
 
 Means HAPI couldn't find a `define` named X. Either you mistyped it, or


### PR DESCRIPTION
## Summary

- Detect two CQL→ELM compile-error fingerprints (`signature (FHIR.X)` and `Could not resolve library name FHIRHelpers`) and append a single info-severity hint with the exact remediation: `include FHIRHelpers version '4.0.001'`
- Augmentation applied at the single chokepoint in `validate_cql`, so every internal failure mode (HTTP error, request error, compile-time `OperationOutcome`) surfaces the hint regardless of which path produced the issue
- Deduplicated: even if multiple matching errors fire, the hint appears once
- Add 5 unit tests covering expression-path fingerprint, library-path fingerprint, no-hint-on-unrelated-error, dedup, and the HTTP-error path where the `OperationOutcome` comes back via 4xx
- Add a "Could not resolve call to operator ... (FHIR.X)" entry at the top of the existing "Common mistakes" section in `docs/STUDENT_CQL_PRIMER.md`, cross-referencing the new hint

Closes #122.

## Why this matters for students

Without context, a student who writes:

\`\`\`cql
library Demo version '0.1.0'
using FHIR version '4.0.1'
context Patient
define MRN: ToString(Patient.id)
\`\`\`

sees \`Could not resolve call to operator ToString with signature (FHIR.id)\`. That message gives no hint that the issue is a missing \`include\` line. With this change, the validation panel now also surfaces:

> ℹ️ Tip: Add \`include FHIRHelpers version '4.0.001'\` near the top of your library (just below \`using FHIR version '4.0.1'\`). FHIRHelpers provides the implicit converters CQL needs to call operators on FHIR-typed values like Patient.id or Observation.value. See docs/STUDENT_CQL_PRIMER.md → Common errors.

## Test plan

- [x] \`pytest tests/api/cds_hooks/test_cql_bridge.py -v\` — 48 pass (was 43; +5 new)
- [x] \`pytest tests/api/cds_hooks/test_cql_bridge.py::TestFHIRHelpersHint -v\` — all 5 hint tests pass
- [x] Full \`tests/api/cds_hooks/\` suite — 211 pass / 32 fail; identical to master (\`git stash\` baseline confirmed the 32 failures are pre-existing, unrelated to this PR)
- [ ] Manual: write CQL with \`define X: ToString(Patient.id)\` and no \`include FHIRHelpers\`. Click Validate in the wizard. Confirm the friendly hint surfaces alongside the original error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)