### PR TITLE
feat(cds-studio): wire metrics writer + lifecycle actions (#125, #130)

### DIFF
--- a/backend/api/cds_hooks/cds_hooks_router.py
+++ b/backend/api/cds_hooks/cds_hooks_router.py
@@ -50,7 +50,8 @@ from .feedback import (
     get_feedback_manager,
     process_cds_feedback,
     get_service_analytics,
-    log_hook_execution
+    log_service_execution,
+    log_service_failure,
 )
 from .models import (
     CDSHookRequest,
@@ -611,27 +612,20 @@ async def execute_service(
         # Calculate execution time
         execution_time_ms = int((datetime.now() - start_time).total_seconds() * 1000)
 
-        # Log execution (fire and forget)
-        try:
-            patient_id = request.context.get('patientId') if isinstance(request.context, dict) else None
-            user_id = request.context.get('userId') if isinstance(request.context, dict) else None
-
-            await log_hook_execution(
-                db=db,
-                service_id=service_id,
-                hook_type=request.hook.value,
-                patient_id=patient_id,
-                user_id=user_id,
-                context=request.context if isinstance(request.context, dict) else request.context.dict(),
-                request_data=request.dict(),
-                response_data={"cards": [c.dict() for c in cards]},
-                cards_returned=len(cards),
-                execution_time_ms=execution_time_ms,
-                success=True,
-                error_message=None
-            )
-        except Exception as log_error:
-            logger.warning(f"Failed to log hook execution: {log_error}")
+        # Log execution (fire-and-forget — never breaks the hook response)
+        patient_id = request.context.get('patientId') if isinstance(request.context, dict) else None
+        user_id = request.context.get('userId') if isinstance(request.context, dict) else None
+        await log_service_execution(
+            db,
+            service_id=service_id,
+            patient_id=patient_id,
+            user_id=user_id,
+            hook_instance=request.hookInstance,
+            success=True,
+            execution_time_ms=execution_time_ms,
+            cards_returned=len(cards),
+            error_message=None,
+        )
 
         return CDSHookResponse(cards=cards)
 
@@ -639,24 +633,54 @@ async def execute_service(
         raise
     except httpx.HTTPStatusError as e:
         logger.error(f"FHIR server error executing CDS service {service_id}: {e.response.status_code}")
+        await log_service_failure(
+            db, service_id=service_id, request_context=request.context,
+            hook_instance=request.hookInstance, start_time=start_time,
+            error_message=f"FHIR {e.response.status_code}",
+        )
         return CDSHookResponse(cards=[])
     except (httpx.RequestError, httpx.TimeoutException) as e:
         logger.error(f"Connection error executing CDS service {service_id}: {e}")
+        await log_service_failure(
+            db, service_id=service_id, request_context=request.context,
+            hook_instance=request.hookInstance, start_time=start_time,
+            error_message=f"Connection: {e}",
+        )
         return CDSHookResponse(cards=[])
     except CDSExecutionError as e:
         logger.error(f"CDS execution error for service {service_id}: {e.message}")
+        await log_service_failure(
+            db, service_id=service_id, request_context=request.context,
+            hook_instance=request.hookInstance, start_time=start_time,
+            error_message=e.message,
+        )
         return CDSHookResponse(cards=[])
     except DatabaseQueryError as e:
         logger.error(f"Database error executing CDS service {service_id}: {e.message}")
+        await log_service_failure(
+            db, service_id=service_id, request_context=request.context,
+            hook_instance=request.hookInstance, start_time=start_time,
+            error_message=e.message,
+        )
         return CDSHookResponse(cards=[])
     except (ValueError, TypeError, KeyError, AttributeError) as e:
         logger.error(f"Data error executing CDS service {service_id}: {e}")
+        await log_service_failure(
+            db, service_id=service_id, request_context=request.context,
+            hook_instance=request.hookInstance, start_time=start_time,
+            error_message=f"Data: {e}",
+        )
         # CDS Hooks should be non-blocking - return empty cards on error
         return CDSHookResponse(cards=[])
     except Exception as e:
         # Catch-all for any other errors (e.g., external service failures)
         # CDS Hooks should be non-blocking - return empty cards on error
         logger.error(f"Unexpected error executing CDS service {service_id}: {e}")
+        await log_service_failure(
+            db, service_id=service_id, request_context=request.context,
+            hook_instance=request.hookInstance, start_time=start_time,
+            error_message=str(e),
+        )
         return CDSHookResponse(cards=[])
 
 

--- a/backend/api/cds_hooks/feedback/__init__.py
+++ b/backend/api/cds_hooks/feedback/__init__.py
@@ -10,7 +10,8 @@ from .persistence import (
     get_feedback_manager,
     process_cds_feedback,
     get_service_analytics,
-    log_hook_execution,
+    log_service_execution,
+    log_service_failure,
 )
 
 __all__ = [
@@ -22,5 +23,6 @@ __all__ = [
     "get_feedback_manager",
     "process_cds_feedback",
     "get_service_analytics",
-    "log_hook_execution",
+    "log_service_execution",
+    "log_service_failure",
 ]

--- a/backend/api/cds_hooks/feedback/persistence.py
+++ b/backend/api/cds_hooks/feedback/persistence.py
@@ -577,58 +577,106 @@ async def get_service_analytics(db: AsyncSession, service_id: str, days: int = 3
         logger.error(f"Data error getting service analytics: {e}")
         return {}
 
-async def log_hook_execution(db: AsyncSession,
-                           service_id: str,
-                           hook_type: str,
-                           patient_id: Optional[str],
-                           user_id: Optional[str],
-                           context: Dict[str, Any],
-                           request_data: Dict[str, Any],
-                           response_data: Dict[str, Any],
-                           cards_returned: int,
-                           execution_time_ms: int,
-                           success: bool = True,
-                           error_message: Optional[str] = None) -> int:
-    """Log CDS hook execution for monitoring and analytics"""
+async def log_service_execution(
+    db: AsyncSession,
+    *,
+    service_id: str,
+    patient_id: Optional[str],
+    user_id: Optional[str],
+    hook_instance: Optional[str],
+    success: bool,
+    execution_time_ms: int,
+    cards_returned: int,
+    error_message: Optional[str] = None,
+) -> Optional[int]:
+    """Append one row to cds_visual_builder.execution_logs for analytics.
+
+    Single source of truth for service execution metrics — the table is
+    read by both `get_service_analytics` (per-service deep dive) and
+    `service.py:_get_service_metrics` (per-service summary shown in the
+    Services Registry table). Writes here populate "Executions (24h)",
+    "Success Rate", avg/p95 latency, and execution_by_date.
+
+    Failures are non-fatal: the hook fire itself has already happened by
+    the time we log, so a DB error here must never propagate up and turn a
+    successful card response into a 500. Returns the row id on success or
+    None on failure.
+
+    No FK constraint on service_id — built-in services that aren't in
+    `cds_visual_builder.service_configs` log freely. The schema migration
+    in `06_cds_visual_builder.sql` drops `fk_service_log` for this reason.
+    """
     try:
         insert_sql = text("""
-            INSERT INTO cds_hooks.execution_log (
-                service_id, hook_type, patient_id, user_id,
-                context, request_data, response_data,
-                cards_returned, execution_time_ms, success, error_message
+            INSERT INTO cds_visual_builder.execution_logs (
+                service_id, patient_id, user_id, hook_instance,
+                success, execution_time_ms, cards_returned, error_message
             ) VALUES (
-                :service_id, :hook_type, :patient_id, :user_id,
-                :context, :request_data, :response_data,
-                :cards_returned, :execution_time_ms, :success, :error_message
+                :service_id, :patient_id, :user_id, :hook_instance,
+                :success, :execution_time_ms, :cards_returned, :error_message
             ) RETURNING id
         """)
 
         result = await db.execute(insert_sql, {
             'service_id': service_id,
-            'hook_type': hook_type,
             'patient_id': patient_id,
             'user_id': user_id,
-            'context': json.dumps(context) if context else None,
-            'request_data': json.dumps(request_data) if request_data else None,
-            'response_data': json.dumps(response_data) if response_data else None,
-            'cards_returned': cards_returned,
-            'execution_time_ms': execution_time_ms,
+            'hook_instance': hook_instance,
             'success': success,
-            'error_message': error_message
+            'execution_time_ms': execution_time_ms,
+            'cards_returned': cards_returned,
+            'error_message': error_message,
         })
 
         await db.commit()
 
         log_id = result.scalar()
-        logger.debug(f"Logged hook execution {log_id} for service {service_id}")
-
         return log_id
 
     except (SQLAlchemyError, OperationalError, IntegrityError) as e:
         await db.rollback()
-        logger.error(f"Database error logging hook execution: {e}")
-        return 0
-    except (json.JSONDecodeError, ValueError, TypeError) as e:
+        logger.warning(f"Failed to log execution for service {service_id}: {e}")
+        return None
+    except (ValueError, TypeError) as e:
         await db.rollback()
-        logger.error(f"Data error logging hook execution: {e}")
-        return 0
+        logger.warning(f"Data error logging execution for service {service_id}: {e}")
+        return None
+
+
+async def log_service_failure(
+    db: AsyncSession,
+    *,
+    service_id: str,
+    request_context: Any,
+    hook_instance: Optional[str],
+    start_time: datetime,
+    error_message: str,
+) -> None:
+    """Best-effort wrapper around log_service_execution for the exception
+    arms of execute_service. Extracts patient/user from `request_context`
+    (which may be a dict or a Pydantic model), computes elapsed ms from
+    start_time, truncates the error_message so a multi-MB upstream payload
+    doesn't poison the TEXT column, and swallows any further exceptions
+    so the original error's response path stays intact.
+    """
+    try:
+        execution_time_ms = int((datetime.now() - start_time).total_seconds() * 1000)
+        if isinstance(request_context, dict):
+            patient_id = request_context.get('patientId')
+            user_id = request_context.get('userId')
+        else:
+            patient_id = getattr(request_context, 'patientId', None)
+            user_id = getattr(request_context, 'userId', None)
+        await log_service_execution(
+            db,
+            service_id=service_id,
+            patient_id=patient_id,
+            user_id=user_id,
+            hook_instance=hook_instance,
+            success=False,
+            execution_time_ms=execution_time_ms,
+            cards_returned=0,
+            error_message=(error_message[:1000] if error_message else None),
+        )
+    except Exception as log_error:
+        logger.warning(f"Could not log failure for service {service_id}: {log_error}")

--- a/backend/api/cds_studio/visual_builder_router.py
+++ b/backend/api/cds_studio/visual_builder_router.py
@@ -1093,6 +1093,67 @@ async def deploy_visual_service(
         raise HTTPException(status_code=500, detail=str(e))
 
 
+class _ServiceStatusUpdate(BaseModel):
+    """Status transition request — accepts the lowercase frontend values."""
+    status: str = Field(..., description="'active' or 'inactive'")
+
+
+@router.put("/services/{service_id}/status")
+async def update_service_status(
+    service_id: str,
+    body: _ServiceStatusUpdate,
+    db: AsyncSession = Depends(get_db_session),
+    current_user: User = Depends(get_current_user_or_demo),
+):
+    """Unified status setter used by the Services Registry toggle.
+
+    The frontend prefers a single PUT over separate POST /deploy and POST
+    /deactivate endpoints because the table renders one row-level
+    "Activate/Deactivate" menu item that flips based on current status.
+    This route normalizes the lowercase 'active'/'inactive' payload to the
+    uppercase enum values service_configs.status expects, then writes via
+    the same SQLAlchemy path the dedicated endpoints use.
+    """
+    requested = (body.status or "").lower()
+    if requested not in ("active", "inactive"):
+        raise HTTPException(
+            status_code=422,
+            detail="status must be 'active' or 'inactive'",
+        )
+    new_status = "ACTIVE" if requested == "active" else "INACTIVE"
+
+    try:
+        query = select(VisualServiceConfig).where(
+            VisualServiceConfig.service_id == service_id
+        )
+        result = await db.execute(query)
+        service = result.scalar_one_or_none()
+
+        if not service:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Visual service '{service_id}' not found",
+            )
+
+        service.status = new_status
+        if new_status == "ACTIVE":
+            service.last_deployed_at = datetime.utcnow()
+        await db.commit()
+
+        logger.info(f"Service {service_id} status set to {new_status}")
+        return {
+            "service_id": service_id,
+            "status": new_status,
+        }
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error updating status for {service_id}: {e}", exc_info=True)
+        await db.rollback()
+        raise HTTPException(status_code=500, detail=str(e))
+
+
 @router.post("/services/{service_id}/deactivate")
 async def deactivate_visual_service(
     service_id: str,
@@ -1170,39 +1231,55 @@ async def get_service_analytics(
                 detail=f"Visual service '{service_id}' not found"
             )
 
-        # Fetch from service_analytics table
-        analytics_query = text("""
-            SELECT total_executions, total_cards_shown, cards_accepted,
-                   cards_dismissed, avg_execution_time_ms
-            FROM cds_visual_builder.service_analytics
+        # Aggregate everything from execution_logs — single source of truth
+        # for service execution metrics. The legacy `service_analytics`
+        # rollup table was dropped because nothing wrote to it.
+        exec_aggregate_query = text("""
+            SELECT
+                COUNT(*) AS total_executions,
+                COALESCE(SUM(cards_returned), 0) AS cards_shown,
+                COALESCE(AVG(execution_time_ms), 0)::numeric(10, 2) AS avg_execution_time_ms
+            FROM cds_visual_builder.execution_logs
             WHERE service_id = :service_id
         """)
-        analytics_result = await db.execute(analytics_query, {"service_id": service_id})
-        analytics_row = analytics_result.first()
+        aggregate_result = await db.execute(exec_aggregate_query, {"service_id": service_id})
+        aggregate_row = aggregate_result.first()
 
-        total_executions = 0
-        cards_shown = 0
+        total_executions = aggregate_row.total_executions if aggregate_row else 0
+        cards_shown = aggregate_row.cards_shown if aggregate_row else 0
+        avg_exec_time = float(aggregate_row.avg_execution_time_ms) if aggregate_row else 0.0
+
+        # Card-feedback counts come from cds_hooks.feedback — kept separate
+        # because the feedback table tracks per-card outcomes whereas
+        # execution_logs only knows how many cards were returned.
+        feedback_query = text("""
+            SELECT
+                COUNT(*) FILTER (WHERE outcome = 'accepted') AS cards_accepted,
+                COUNT(*) FILTER (WHERE outcome = 'overridden') AS cards_dismissed
+            FROM cds_hooks.feedback
+            WHERE service_id = :service_id
+        """)
         cards_accepted = 0
         cards_dismissed = 0
-        avg_exec_time = 0.0
-
-        if analytics_row:
-            total_executions = analytics_row.total_executions or 0
-            cards_shown = analytics_row.total_cards_shown or 0
-            cards_accepted = analytics_row.cards_accepted or 0
-            cards_dismissed = analytics_row.cards_dismissed or 0
-            avg_exec_time = float(analytics_row.avg_execution_time_ms or 0)
+        try:
+            feedback_result = await db.execute(feedback_query, {"service_id": service_id})
+            feedback_row = feedback_result.first()
+            if feedback_row:
+                cards_accepted = feedback_row.cards_accepted or 0
+                cards_dismissed = feedback_row.cards_dismissed or 0
+        except Exception:
+            pass  # Feedback table may not exist yet — degrade gracefully.
 
         acceptance_rate = 0.0
         if cards_shown > 0:
             acceptance_rate = round((cards_accepted / cards_shown) * 100, 2)
 
-        # Get execution counts by date from execution_logs
+        # Daily execution counts for the last 30 days
         exec_by_date_query = text("""
-            SELECT DATE(created_at) as exec_date, COUNT(*) as count
+            SELECT DATE(executed_at) as exec_date, COUNT(*) as count
             FROM cds_visual_builder.execution_logs
             WHERE service_id = :service_id
-            GROUP BY DATE(created_at)
+            GROUP BY DATE(executed_at)
             ORDER BY exec_date DESC
             LIMIT 30
         """)

--- a/backend/tests/api/cds_hooks/test_ops_reliability.py
+++ b/backend/tests/api/cds_hooks/test_ops_reliability.py
@@ -1,0 +1,228 @@
+"""
+Tests for Phase 1 CDS Studio operations reliability (#125 + #130):
+- log_service_execution writes to cds_visual_builder.execution_logs
+- _log_failure invokes log_service_execution with success=False
+- log_service_execution swallows DB errors (non-fatal)
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+from datetime import datetime
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from api.cds_hooks.feedback.persistence import log_service_execution
+
+
+def _mk_db(scalar_value=42):
+    """Mock AsyncSession that records the INSERT call and returns a row id."""
+    db = AsyncMock()
+    result = MagicMock()
+    result.scalar = MagicMock(return_value=scalar_value)
+    db.execute = AsyncMock(return_value=result)
+    db.commit = AsyncMock()
+    db.rollback = AsyncMock()
+    return db
+
+
+@pytest.mark.asyncio
+async def test_log_service_execution_inserts_with_all_fields():
+    """The helper must call db.execute exactly once with all positional params
+    forwarded to the SQL INSERT, then commit."""
+    db = _mk_db(scalar_value=99)
+
+    row_id = await log_service_execution(
+        db,
+        service_id="diabetes-screening",
+        patient_id="Patient/123",
+        user_id="Practitioner/u1",
+        hook_instance="abc-uuid",
+        success=True,
+        execution_time_ms=42,
+        cards_returned=2,
+        error_message=None,
+    )
+
+    assert row_id == 99
+    db.execute.assert_awaited_once()
+    db.commit.assert_awaited_once()
+    # The bound params on the INSERT — second positional arg to execute()
+    _, params = db.execute.call_args.args
+    assert params["service_id"] == "diabetes-screening"
+    assert params["patient_id"] == "Patient/123"
+    assert params["user_id"] == "Practitioner/u1"
+    assert params["hook_instance"] == "abc-uuid"
+    assert params["success"] is True
+    assert params["execution_time_ms"] == 42
+    assert params["cards_returned"] == 2
+    assert params["error_message"] is None
+
+
+@pytest.mark.asyncio
+async def test_log_service_execution_records_failure_with_error_message():
+    """Failure path: success=False + error_message gets persisted as-is."""
+    db = _mk_db(scalar_value=7)
+
+    row_id = await log_service_execution(
+        db,
+        service_id="broken-cql-service",
+        patient_id=None,
+        user_id=None,
+        hook_instance=None,
+        success=False,
+        execution_time_ms=120,
+        cards_returned=0,
+        error_message="HAPI 500: Could not compile CQL",
+    )
+
+    assert row_id == 7
+    _, params = db.execute.call_args.args
+    assert params["success"] is False
+    assert params["error_message"] == "HAPI 500: Could not compile CQL"
+    assert params["cards_returned"] == 0
+
+
+@pytest.mark.asyncio
+async def test_log_service_execution_swallows_db_errors():
+    """A logging failure must NEVER propagate — the hook fire it's attached
+    to has already happened by the time we log, so any DB hiccup here is a
+    metrics blind spot, not a user-visible 500. Verifies the helper returns
+    None and rolls back instead of raising."""
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=IntegrityError("INSERT", {}, Exception("FK gone")))
+    db.commit = AsyncMock()
+    db.rollback = AsyncMock()
+
+    row_id = await log_service_execution(
+        db,
+        service_id="ghost-service",
+        patient_id="Patient/123",
+        user_id="Practitioner/u1",
+        hook_instance="x",
+        success=True,
+        execution_time_ms=10,
+        cards_returned=0,
+    )
+
+    assert row_id is None
+    db.rollback.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_log_service_failure_extracts_dict_context():
+    """log_service_failure extracts patientId/userId from a dict
+    request_context and forwards them to log_service_execution with
+    success=False."""
+    from unittest.mock import patch as mock_patch
+    from api.cds_hooks.feedback.persistence import log_service_failure
+
+    db = AsyncMock()
+    start = datetime.now()
+
+    with mock_patch(
+        "api.cds_hooks.feedback.persistence.log_service_execution",
+        new=AsyncMock(return_value=1),
+    ) as mock_log:
+        await log_service_failure(
+            db,
+            service_id="svc-1",
+            request_context={"patientId": "Patient/p7", "userId": "Practitioner/u2"},
+            hook_instance="hi-uuid",
+            start_time=start,
+            error_message="Boom from upstream",
+        )
+
+    mock_log.assert_awaited_once()
+    kwargs = mock_log.call_args.kwargs
+    assert kwargs["service_id"] == "svc-1"
+    assert kwargs["patient_id"] == "Patient/p7"
+    assert kwargs["user_id"] == "Practitioner/u2"
+    assert kwargs["hook_instance"] == "hi-uuid"
+    assert kwargs["success"] is False
+    assert kwargs["cards_returned"] == 0
+    assert "Boom from upstream" in kwargs["error_message"]
+
+
+@pytest.mark.asyncio
+async def test_log_service_failure_extracts_model_context():
+    """request_context may be a Pydantic model instead of a dict; the
+    helper uses getattr so both shapes work."""
+    from unittest.mock import patch as mock_patch
+    from api.cds_hooks.feedback.persistence import log_service_failure
+
+    ctx = MagicMock()
+    ctx.patientId = "Patient/x"
+    ctx.userId = "Practitioner/y"
+    # Force isinstance(ctx, dict) → False
+    type(ctx).__bool__ = lambda self: True
+    db = AsyncMock()
+
+    with mock_patch(
+        "api.cds_hooks.feedback.persistence.log_service_execution",
+        new=AsyncMock(return_value=1),
+    ) as mock_log:
+        await log_service_failure(
+            db,
+            service_id="svc",
+            request_context=ctx,
+            hook_instance=None,
+            start_time=datetime.now(),
+            error_message="err",
+        )
+
+    kwargs = mock_log.call_args.kwargs
+    assert kwargs["patient_id"] == "Patient/x"
+    assert kwargs["user_id"] == "Practitioner/y"
+
+
+@pytest.mark.asyncio
+async def test_log_service_failure_truncates_long_error_messages():
+    """Long stack traces or upstream payloads must be trimmed so the
+    error_message TEXT column doesn't get poisoned with multi-MB payloads.
+    Truncation cap is 1000 chars."""
+    from unittest.mock import patch as mock_patch
+    from api.cds_hooks.feedback.persistence import log_service_failure
+
+    db = AsyncMock()
+    huge = "x" * 5000
+
+    with mock_patch(
+        "api.cds_hooks.feedback.persistence.log_service_execution",
+        new=AsyncMock(return_value=1),
+    ) as mock_log:
+        await log_service_failure(
+            db,
+            service_id="svc",
+            request_context={},
+            hook_instance=None,
+            start_time=datetime.now(),
+            error_message=huge,
+        )
+
+    kwargs = mock_log.call_args.kwargs
+    assert len(kwargs["error_message"]) == 1000
+
+
+@pytest.mark.asyncio
+async def test_log_service_failure_never_raises_even_if_logger_crashes():
+    """If log_service_execution itself blows up (e.g. DB pool exhausted),
+    log_service_failure must catch and continue so the exception arm of
+    execute_service still returns its CDSHookResponse(cards=[])."""
+    from unittest.mock import patch as mock_patch
+    from api.cds_hooks.feedback.persistence import log_service_failure
+
+    db = AsyncMock()
+
+    with mock_patch(
+        "api.cds_hooks.feedback.persistence.log_service_execution",
+        new=AsyncMock(side_effect=RuntimeError("connection pool exhausted")),
+    ):
+        # Must not raise
+        await log_service_failure(
+            db,
+            service_id="svc",
+            request_context={},
+            hook_instance=None,
+            start_time=datetime.now(),
+            error_message="err",
+        )

--- a/frontend/src/modules/cds-studio/pages/ServicesRegistry/ServicesTable.jsx
+++ b/frontend/src/modules/cds-studio/pages/ServicesRegistry/ServicesTable.jsx
@@ -20,7 +20,14 @@ import {
   Select,
   FormControl,
   InputLabel,
-  Tooltip
+  Tooltip,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+  Button,
+  Snackbar
 } from '@mui/material';
 import {
   MoreVert as MoreVertIcon,
@@ -46,6 +53,13 @@ const ServicesTable = ({ onSelectService, onEditService, onRefresh }) => {
   });
   const [anchorEl, setAnchorEl] = useState(null);
   const [selectedService, setSelectedService] = useState(null);
+  // Delete confirmation lives in its own state slot so closing the row
+  // menu (which clears selectedService) doesn't strand the dialog with
+  // nothing to act on. snackbar surfaces API failures that the inline
+  // <Alert> would miss when triggered from inside the dialog.
+  const [deleteTarget, setDeleteTarget] = useState(null);
+  const [deleting, setDeleting] = useState(false);
+  const [snackbar, setSnackbar] = useState({ open: false, message: '', severity: 'error' });
 
   const loadServices = async () => {
     try {
@@ -90,29 +104,42 @@ const ServicesTable = ({ onSelectService, onEditService, onRefresh }) => {
 
   const handleToggleStatus = async () => {
     if (!selectedService) return;
+    const target = selectedService;
+    handleMenuClose();
 
     try {
-      const newStatus = selectedService.status === 'active' ? 'inactive' : 'active';
-      await cdsStudioApi.updateServiceStatus(selectedService.service_id, newStatus);
+      const newStatus = target.status === 'active' ? 'inactive' : 'active';
+      await cdsStudioApi.updateServiceStatus(target.service_id, newStatus);
       await loadServices();
     } catch (err) {
-      setError(err.message);
+      setSnackbar({ open: true, message: err.message || 'Failed to update status', severity: 'error' });
     }
+  };
+
+  const openDeleteDialog = () => {
+    if (!selectedService) return;
+    // Capture the service object NOW — handleMenuClose() clears
+    // selectedService and the dialog needs to remember which row to
+    // delete on confirm. Without this snapshot, racing menu-close +
+    // dialog-confirm could fire delete against null.
+    setDeleteTarget(selectedService);
     handleMenuClose();
   };
 
-  const handleDelete = async () => {
-    if (!selectedService) return;
+  const confirmDelete = async () => {
+    if (!deleteTarget) return;
 
-    if (window.confirm(`Delete service "${selectedService.title}"?`)) {
-      try {
-        await cdsStudioApi.deleteService(selectedService.service_id);
-        await loadServices();
-      } catch (err) {
-        setError(err.message);
-      }
+    setDeleting(true);
+    try {
+      await cdsStudioApi.deleteService(deleteTarget.service_id);
+      setDeleteTarget(null);
+      await loadServices();
+      setSnackbar({ open: true, message: `Deleted "${deleteTarget.title}"`, severity: 'success' });
+    } catch (err) {
+      setSnackbar({ open: true, message: err.message || 'Failed to delete service', severity: 'error' });
+    } finally {
+      setDeleting(false);
     }
-    handleMenuClose();
   };
 
   const getStatusIcon = (status) => {
@@ -332,10 +359,52 @@ const ServicesTable = ({ onSelectService, onEditService, onRefresh }) => {
         <MenuItem onClick={handleToggleStatus}>
           {selectedService?.status === 'active' ? 'Deactivate' : 'Activate'}
         </MenuItem>
-        <MenuItem onClick={handleDelete} sx={{ color: 'error.main' }}>
+        <MenuItem onClick={openDeleteDialog} sx={{ color: 'error.main' }}>
           Delete
         </MenuItem>
       </Menu>
+
+      {/* Delete confirmation — replaces window.confirm so styling
+          matches the rest of the studio and works in environments where
+          the native dialog is suppressed. deleteTarget gates the open
+          state and carries the service through the async confirm. */}
+      <Dialog open={Boolean(deleteTarget)} onClose={() => !deleting && setDeleteTarget(null)}>
+        <DialogTitle>Delete service?</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            {deleteTarget && (
+              <>
+                This will remove <strong>{deleteTarget.title}</strong> (
+                <code>{deleteTarget.service_id}</code>) from the registry.
+                Execution history is preserved but the service stops firing.
+              </>
+            )}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteTarget(null)} disabled={deleting}>
+            Cancel
+          </Button>
+          <Button onClick={confirmDelete} color="error" disabled={deleting} autoFocus>
+            {deleting ? 'Deleting...' : 'Delete'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Snackbar
+        open={snackbar.open}
+        autoHideDuration={5000}
+        onClose={() => setSnackbar((prev) => ({ ...prev, open: false }))}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+      >
+        <Alert
+          severity={snackbar.severity}
+          onClose={() => setSnackbar((prev) => ({ ...prev, open: false }))}
+          variant="filled"
+        >
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
     </Box>
   );
 };

--- a/postgres-init/01-init-wintehr.sql
+++ b/postgres-init/01-init-wintehr.sql
@@ -107,20 +107,12 @@ CREATE TABLE IF NOT EXISTS cds_hooks.hook_configurations (
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
--- CDS Hooks execution log
-CREATE TABLE IF NOT EXISTS cds_hooks.execution_log (
-    id BIGSERIAL PRIMARY KEY,
-    hook_id VARCHAR(255) NOT NULL,
-    execution_id UUID DEFAULT gen_random_uuid(),
-    patient_id VARCHAR(255),
-    user_id VARCHAR(255),
-    context JSONB,
-    cards JSONB,
-    execution_time_ms INTEGER,
-    status VARCHAR(50) NOT NULL,
-    error_message TEXT,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
+-- CDS Hooks execution log — DROPPED.
+-- Was written by feedback/persistence.log_hook_execution (now removed)
+-- but the function's INSERT columns never matched this table's schema, so
+-- every write silently failed. Reads went to cds_visual_builder.execution_logs
+-- instead. The unified writer is now log_service_execution → that table.
+DROP TABLE IF EXISTS cds_hooks.execution_log CASCADE;
 
 -- ========================================================================
 -- Indexes for Performance
@@ -139,9 +131,7 @@ CREATE INDEX IF NOT EXISTS idx_audit_outcome ON audit.events(outcome);
 -- CDS Hooks indexes
 CREATE INDEX IF NOT EXISTS idx_cds_hooks_config_active ON cds_hooks.hook_configurations(is_active);
 CREATE INDEX IF NOT EXISTS idx_cds_hooks_config_type ON cds_hooks.hook_configurations(hook_type);
-CREATE INDEX IF NOT EXISTS idx_cds_hooks_log_hook ON cds_hooks.execution_log(hook_id);
-CREATE INDEX IF NOT EXISTS idx_cds_hooks_log_patient ON cds_hooks.execution_log(patient_id);
-CREATE INDEX IF NOT EXISTS idx_cds_hooks_log_created ON cds_hooks.execution_log(created_at);
+-- (Indexes for cds_hooks.execution_log removed alongside the dropped table.)
 
 -- ========================================================================
 -- Functions and Triggers
@@ -252,13 +242,13 @@ BEGIN
     SELECT COUNT(*) INTO table_count
     FROM information_schema.tables
     WHERE (table_schema = 'auth' AND table_name IN ('users', 'roles', 'user_roles'))
-       OR (table_schema = 'cds_hooks' AND table_name IN ('hook_configurations', 'execution_log'))
+       OR (table_schema = 'cds_hooks' AND table_name = 'hook_configurations')
        OR (table_schema = 'audit' AND table_name = 'events');
 
-    IF table_count = 6 THEN
+    IF table_count = 5 THEN
         RAISE NOTICE '✅ All core tables created successfully';
     ELSE
-        RAISE EXCEPTION '❌ Table creation failed. Expected 6, found %', table_count;
+        RAISE EXCEPTION '❌ Table creation failed. Expected 5, found %', table_count;
     END IF;
 END$$;
 

--- a/postgres-init/06_cds_visual_builder.sql
+++ b/postgres-init/06_cds_visual_builder.sql
@@ -98,40 +98,18 @@ CREATE TABLE IF NOT EXISTS cds_visual_builder.service_versions (
 ALTER TABLE cds_visual_builder.service_versions
     ADD COLUMN IF NOT EXISTS cql_source TEXT;
 
--- Service Analytics Table
-CREATE TABLE IF NOT EXISTS cds_visual_builder.service_analytics (
-    id SERIAL PRIMARY KEY,
-    service_id VARCHAR(255) NOT NULL,
-
-    -- Execution Metrics
-    total_executions INTEGER DEFAULT 0,
-    successful_executions INTEGER DEFAULT 0,
-    failed_executions INTEGER DEFAULT 0,
-
-    -- Performance Metrics
-    avg_execution_time_ms DECIMAL(10, 2),
-    min_execution_time_ms DECIMAL(10, 2),
-    max_execution_time_ms DECIMAL(10, 2),
-
-    -- Card Metrics
-    total_cards_shown INTEGER DEFAULT 0,
-    cards_accepted INTEGER DEFAULT 0,
-    cards_dismissed INTEGER DEFAULT 0,
-
-    -- User Feedback
-    avg_user_rating DECIMAL(3, 2),
-    total_ratings INTEGER DEFAULT 0,
-
-    -- Time Windows
-    last_execution_at TIMESTAMP WITH TIME ZONE,
-    metrics_updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-
-    CONSTRAINT fk_service FOREIGN KEY (service_id)
-        REFERENCES cds_visual_builder.service_configs(service_id)
-        ON DELETE CASCADE
-);
-
 -- Service Execution Log Table
+--
+-- Single source of truth for service execution metrics. Populated by
+-- backend/api/cds_hooks/feedback/persistence.py::log_service_execution,
+-- which is called from every arm of execute_service (success + failure).
+--
+-- No FK constraint on service_id — built-in services (which live in
+-- code rather than in service_configs) need to be able to log too. The
+-- legacy `service_analytics` rollup table was dropped (see migration
+-- block below) because nothing ever wrote to it; `get_service_analytics`
+-- and `service.py::_get_service_metrics` now aggregate directly from
+-- this table.
 CREATE TABLE IF NOT EXISTS cds_visual_builder.execution_logs (
     id SERIAL PRIMARY KEY,
     service_id VARCHAR(255) NOT NULL,
@@ -151,12 +129,17 @@ CREATE TABLE IF NOT EXISTS cds_visual_builder.execution_logs (
     stack_trace TEXT,
 
     -- Timestamp
-    executed_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-
-    CONSTRAINT fk_service_log FOREIGN KEY (service_id)
-        REFERENCES cds_visual_builder.service_configs(service_id)
-        ON DELETE CASCADE
+    executed_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
+
+-- Migrations for existing deployments — idempotent.
+-- 1. Drop the legacy service_analytics rollup table; nothing wrote to it
+--    and analytics now compute from execution_logs directly.
+DROP TABLE IF EXISTS cds_visual_builder.service_analytics CASCADE;
+-- 2. Drop the FK on execution_logs.service_id so built-in services (which
+--    aren't in service_configs) can also log execution metrics.
+ALTER TABLE cds_visual_builder.execution_logs
+    DROP CONSTRAINT IF EXISTS fk_service_log;
 
 -- Student-authored ValueSets (Phase 2 of the CQL feature; created here so the
 -- schema is consistent in one file).
@@ -288,8 +271,7 @@ COMMENT ON COLUMN cds_visual_builder.service_configs.cql_source IS 'CQL text for
 COMMENT ON COLUMN cds_visual_builder.service_configs.library_canonical_url IS 'HAPI canonical URL of the Library generated from cql_source';
 COMMENT ON COLUMN cds_visual_builder.service_configs.plan_definition_canonical_url IS 'HAPI canonical URL of the PlanDefinition wrapper that runs the CQL';
 COMMENT ON TABLE cds_visual_builder.service_versions IS 'Version history for service configurations';
-COMMENT ON TABLE cds_visual_builder.service_analytics IS 'Performance and usage analytics for services';
-COMMENT ON TABLE cds_visual_builder.execution_logs IS 'Execution logs for debugging and monitoring';
+COMMENT ON TABLE cds_visual_builder.execution_logs IS 'Execution metrics — written by execute_service, read by analytics + service registry table';
 COMMENT ON TABLE cds_visual_builder.value_sets IS 'Student-authored ValueSets; mirrored to HAPI as FHIR ValueSet resources';
 
 DO $$


### PR DESCRIPTION
Two CDS Studio operations bugs in one PR — same module, related domain.

## #125 — Metrics writer

**Pre-existing**: `execute_service` called `log_hook_execution` which INSERT'd into `cds_hooks.execution_log` — but that table's schema and the helper's INSERT columns never matched. Every write raised an IntegrityError and was swallowed by the broad except. Meanwhile analytics endpoints read from a *different* table, `cds_visual_builder.execution_logs`, which had no writer at all. Every Services Registry row showed "Executions (24h): 0, Success Rate: 0%" — for every service, every time.

**Fix** — single writer/reader on `cds_visual_builder.execution_logs`:
- Replace `log_hook_execution` with `log_service_execution` matching the actual table schema; called on success path
- New `log_service_failure` helper centralizes exception-arm logging from all 6 exception handlers in `execute_service` (extracts patient/user from dict or model contexts, truncates error to 1000 chars, swallows its own errors)
- Refactor `get_service_analytics` to compute aggregates directly from `execution_logs`; card-feedback counts move to a separate query on `cds_hooks.feedback` (degrades gracefully)
- Drop the legacy `service_analytics` rollup table (no writer existed)
- Drop the FK on `execution_logs.service_id` via idempotent ALTER so built-in services can log too
- Drop the orphan `cds_hooks.execution_log` table whose schema was permanently misaligned with its sole writer

## #130 — Lifecycle action paths

**Pre-existing**: frontend called `PUT /services/{id}/status` but no such route existed (only POST /deactivate, POST /deploy, DELETE). Errors set into a brief inline Alert. Delete used `window.confirm` — bare JS dialog, looks foreign in the MUI shell.

**Fix**:
- Add `PUT /services/{id}/status` (body `{status: 'active'|'inactive'}`, 422 on invalid; normalizes to uppercase enum; sets `last_deployed_at` on activate)
- `ServicesTable.jsx`: replace `window.confirm` with controlled MUI <Dialog>; selected service snapshotted into `deleteTarget` state before menu close to prevent null-race on async confirm
- Replace silent `setError` with <Snackbar> for both success and failure messages

## Tests

- New `backend/tests/api/cds_hooks/test_ops_reliability.py` — 7 unit tests:
  - `log_service_execution` insert with all fields ✓
  - failure-path persistence (success=False, error_message) ✓
  - DB error swallowing (IntegrityError) ✓
  - dict context extraction ✓
  - model context extraction ✓
  - error-message truncation (5000 → 1000) ✓
  - never-raise contract on internal exceptions ✓
- Regression: existing `test_cql_bridge.py` (48 tests) — all green
- Frontend lint clean on touched file (1 pre-existing warning unrelated to PR)

## Migration notes

The SQL changes are idempotent — `DROP TABLE IF EXISTS` / `DROP CONSTRAINT IF EXISTS`. Running deploy on the prod server will:
1. Drop `cds_visual_builder.service_analytics` (no rows; was unused)
2. Drop the FK `fk_service_log` on `cds_visual_builder.execution_logs`
3. Drop `cds_hooks.execution_log` (no data of value; writes had been failing silently)

Fresh installs get a cleaner schema with one ledger table.

Closes #125, #130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)