### PR TITLE
feat(cds-studio): ValueSet authoring rework — composer + catalog (#131)

### DIFF
--- a/backend/api/cds_studio/value_set_composer.py
+++ b/backend/api/cds_studio/value_set_composer.py
@@ -292,12 +292,33 @@ async def create_value_set(
             detail="vs_id cannot start with 'wintehr-' (reserved for system terminology)",
         )
 
-    # Conflict check — caller must DELETE before re-creating.
+    # Conflict check — surface the existing VS payload so the composer can
+    # offer "Open to modify" instead of forcing the student to manually
+    # delete-then-recreate. The error detail is a structured payload (not
+    # a flat string) so the frontend can show row data; FastAPI passes
+    # `detail` through verbatim into the JSON body.
     existing = await db.execute(
         select(VisualValueSet).where(VisualValueSet.vs_id == vs_id)
     )
-    if existing.scalar_one_or_none():
-        raise HTTPException(status_code=409, detail=f"ValueSet '{vs_id}' already exists")
+    existing_row = existing.scalar_one_or_none()
+    if existing_row:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "message": f"ValueSet '{vs_id}' already exists",
+                "vs_id": existing_row.vs_id,
+                "name": existing_row.name,
+                "title": existing_row.title,
+                "hapi_canonical_url": existing_row.hapi_canonical_url,
+                "created_by": existing_row.created_by,
+                "code_count": len(existing_row.codes or []),
+                "owned_by_caller": (
+                    existing_row.created_by == getattr(current_user, "id", None)
+                    if getattr(current_user, "id", None)
+                    else False
+                ),
+            },
+        )
 
     resource = build_value_set_resource(
         vs_id=vs_id,

--- a/frontend/src/modules/cds-studio/components/builder/VisualBuilderWizard.jsx
+++ b/frontend/src/modules/cds-studio/components/builder/VisualBuilderWizard.jsx
@@ -59,6 +59,13 @@ import axios from 'axios';
 
 const CQL_SERVICE_TYPE = 'cql-based';
 
+// Matches `valueset "Name": '<canonical_url>'` — same shape the backend
+// regex in cql_artifact_builder.py:_VALUESET_DECL_RE recognizes. The /m
+// flag is essential because students write one declaration per line.
+// Lives at module scope so the useEffect that consumes it doesn't need to
+// list a fresh regex object in its dependency array on every render.
+const VALUESET_DECL_RE = /^\s*valueset\s+"([^"]+)"\s*:\s*'([^']+)'\s*$/gm;
+
 // Step 1 label varies by service type — `renderConditionBuilder` renders
 // either ConditionBuilder (visual) or CQLEditor (CQL). The step list itself
 // uses a single neutral label so the stepper looks the same for both paths.
@@ -171,17 +178,93 @@ const VisualBuilderWizard = ({ open, onClose, onSuccess, existingService = null 
     return out;
   }, [isCQLService, serviceConfig.cql_source]);
 
+  // Derive the referenced ValueSets directly from the CQL declarations.
+  // Closes #124: a VS composed via the composer inserts a declaration into
+  // the CQL editor → this effect parses that declaration → resolves the
+  // canonical URL against listValueSets → updates the panel. Works in
+  // create mode too (no service_id yet), unlike refreshFromBackend.
+  //
+  // We list all VSes once per CQL change rather than fetching each
+  // declaration individually — student catalogs stay small enough that the
+  // one-shot list is cheaper than N round-trips, and the same call result
+  // serves any subsequent declarations the same way.
+  useEffect(() => {
+    if (!open || !isCQLService) return;
+    const cql = serviceConfig.cql_source || '';
+    const declarations = [];
+    let match;
+    VALUESET_DECL_RE.lastIndex = 0;
+    while ((match = VALUESET_DECL_RE.exec(cql)) !== null) {
+      declarations.push({ name: match[1], canonical_url: match[2] });
+    }
+    if (declarations.length === 0) {
+      setReferencedValueSets([]);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const all = await cdsStudioApi.listValueSets({ limit: 500 });
+        if (cancelled) return;
+        const byUrl = new Map((all || []).map((vs) => [vs.hapi_canonical_url, vs]));
+        const resolved = declarations.map(({ name, canonical_url }) => {
+          const hit = byUrl.get(canonical_url);
+          if (hit) {
+            return {
+              name: hit.name,
+              canonical_url: hit.hapi_canonical_url,
+              vs_id: hit.vs_id,
+              title: hit.title,
+              description: hit.description,
+              codes: hit.codes || [],
+            };
+          }
+          // Unresolved URL — declaration points at a VS we haven't found
+          // (could be system terminology like wintehr-* or a deleted user
+          // VS). Surface it as a stub so the panel can still show the name
+          // and a "not found" affordance.
+          return {
+            name,
+            canonical_url,
+            vs_id: null,
+            title: null,
+            description: null,
+            codes: [],
+            unresolved: true,
+          };
+        });
+        setReferencedValueSets(resolved);
+      } catch (err) {
+        console.warn('Failed to resolve referenced ValueSets from CQL:', err);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, isCQLService, serviceConfig.cql_source]);
+
   // After a ValueSet is created or edited inside the composer, refresh the
-  // referenced-VS list so the inline panel reflects the new code count.
-  // Only meaningful in edit mode (we have a deployed service to query); in
-  // create mode there's nothing for /full-edit-state to return yet.
+  // referenced-VS list. The CQL-derive effect above handles re-resolution
+  // on cql_source change, but on Open-to-Modify the URL hasn't changed —
+  // only the code list did. Re-list to pick up the new codes count.
   const refreshReferencedValueSets = async () => {
-    if (!isEditMode || !serviceConfig.service_id) return;
+    if (!isCQLService) return;
     try {
-      const { data } = await axios.get(
-        `/api/cds-visual-builder/services/${serviceConfig.service_id}/full-edit-state`
+      const all = await cdsStudioApi.listValueSets({ limit: 500 });
+      const byUrl = new Map((all || []).map((vs) => [vs.hapi_canonical_url, vs]));
+      setReferencedValueSets((prev) =>
+        prev.map((entry) => {
+          const fresh = entry.canonical_url ? byUrl.get(entry.canonical_url) : null;
+          if (!fresh) return entry;
+          return {
+            ...entry,
+            title: fresh.title,
+            description: fresh.description,
+            codes: fresh.codes || [],
+            unresolved: false,
+          };
+        })
       );
-      setReferencedValueSets(data.value_sets || []);
     } catch (err) {
       console.warn('Failed to refresh referenced ValueSets', err);
     }

--- a/frontend/src/modules/cds-studio/components/builders/ValueSetComposer.jsx
+++ b/frontend/src/modules/cds-studio/components/builders/ValueSetComposer.jsx
@@ -32,6 +32,7 @@ import {
   Divider,
   FormControl,
   IconButton,
+  InputAdornment,
   InputLabel,
   MenuItem,
   Paper,
@@ -44,6 +45,8 @@ import {
   TableHead,
   TableRow,
   TextField,
+  ToggleButton,
+  ToggleButtonGroup,
   Tooltip,
   Typography,
 } from '@mui/material';
@@ -51,6 +54,10 @@ import {
   Add as AddIcon,
   Close as CloseIcon,
   Delete as DeleteIcon,
+  Edit as EditIcon,
+  Search as SearchIcon,
+  Check as CheckIcon,
+  ExpandMore as ExpandMoreIcon,
 } from '@mui/icons-material';
 
 import catalogService from '../../../../services/CatalogIntegrationService';
@@ -107,7 +114,24 @@ const ValueSetComposer = ({
   suggestedName = '',
   editingValueSet = null,
 }) => {
-  const isEditMode = Boolean(editingValueSet);
+  // External edit-mode (parent passed an existing VS) starts in 'create'
+  // mode pre-populated for editing. Internal edit-mode (user clicked
+  // "Open to modify" in browse mode) ALSO switches to 'create' mode but
+  // tracks the source VS in `localEditing` so the save path PUTs instead
+  // of POSTs. mode toggles between 'create' (default, when no
+  // editingValueSet was passed in) and 'browse' (pick an existing one).
+  const [mode, setMode] = useState(editingValueSet ? 'create' : 'create');
+  const [localEditing, setLocalEditing] = useState(null);
+  const effectiveEditing = editingValueSet || localEditing;
+  const isEditMode = Boolean(effectiveEditing);
+
+  // Browse-pane state — populated by listValueSets when mode='browse'
+  const [browseQuery, setBrowseQuery] = useState('');
+  const [browseLoading, setBrowseLoading] = useState(false);
+  const [browseResults, setBrowseResults] = useState([]);
+  const [browseExpandedId, setBrowseExpandedId] = useState(null);
+  const [browseError, setBrowseError] = useState(null);
+
   // Form fields
   const [name, setName] = useState(suggestedName);
   const [title, setTitle] = useState('');
@@ -133,24 +157,16 @@ const ValueSetComposer = ({
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState(null);
 
-  // Reset on open. In edit mode, hydrate from the supplied editingValueSet
-  // so the user sees the current name/title/description/codes; in create
-  // mode start fresh with the suggested name.
+  // Reset on open. External edit-mode (editingValueSet prop) hydrates the
+  // composer immediately. Fresh-open in create mode starts blank with the
+  // suggested name. localEditing is cleared so a previous browse-then-modify
+  // session doesn't leak between dialog opens.
   useEffect(() => {
     if (!open) return;
+    setLocalEditing(null);
+    setMode('create');
     if (editingValueSet) {
-      setName(editingValueSet.name || '');
-      setTitle(editingValueSet.title || '');
-      setDescription(editingValueSet.description || '');
-      setSelected(
-        Array.isArray(editingValueSet.codes)
-          ? editingValueSet.codes.map((c) => ({
-              system: c.system,
-              code: c.code,
-              display: c.display,
-            }))
-          : []
-      );
+      hydrateFromValueSet(editingValueSet);
     } else {
       setName(suggestedName);
       setTitle('');
@@ -164,7 +180,76 @@ const ValueSetComposer = ({
     setManualDisplay('');
     setManualError(null);
     setSaveError(null);
+    setBrowseQuery('');
+    setBrowseResults([]);
+    setBrowseError(null);
+    setBrowseExpandedId(null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, suggestedName, editingValueSet]);
+
+  // Shared hydration helper — used by external edit-mode AND by browse's
+  // "Open to modify" action.
+  const hydrateFromValueSet = useCallback((vs) => {
+    setName(vs.name || '');
+    setTitle(vs.title || '');
+    setDescription(vs.description || '');
+    setSelected(
+      Array.isArray(vs.codes)
+        ? vs.codes.map((c) => ({ system: c.system, code: c.code, display: c.display }))
+        : []
+    );
+  }, []);
+
+  // Debounced fetch for the browse pane. Runs when mode='browse' and the
+  // query changes. listValueSets is a thin GET wrapper, so we don't need
+  // pagination at this scale (student-authored catalog is small).
+  useEffect(() => {
+    if (!open || mode !== 'browse') return;
+    let cancelled = false;
+    const handle = setTimeout(async () => {
+      setBrowseLoading(true);
+      setBrowseError(null);
+      try {
+        const results = await cdsStudioApi.listValueSets({
+          search: browseQuery.trim() || undefined,
+          limit: 100,
+        });
+        if (!cancelled) setBrowseResults(Array.isArray(results) ? results : []);
+      } catch (err) {
+        if (!cancelled) {
+          setBrowseError(err?.message || 'Failed to load ValueSets');
+          setBrowseResults([]);
+        }
+      } finally {
+        if (!cancelled) setBrowseLoading(false);
+      }
+    }, 200);
+    return () => {
+      cancelled = true;
+      clearTimeout(handle);
+    };
+  }, [open, mode, browseQuery]);
+
+  const handleUseExisting = useCallback((vs) => {
+    // "Use this" — just hand the reference back to the parent so the
+    // editor inserts a `valueset "Name": '<url>'` line. No DB writes,
+    // no modal switch — close immediately.
+    onSave?.({
+      name: vs.name,
+      hapi_canonical_url: vs.hapi_canonical_url,
+      vs_id: vs.vs_id,
+    });
+    onClose?.();
+  }, [onSave, onClose]);
+
+  const handleOpenToModify = useCallback((vs) => {
+    // Switch into create-mode (the form), but mark this VS as the edit
+    // target so save calls PUT instead of POST. Hydrate fields from the
+    // chosen VS — same flow as external edit-mode.
+    setLocalEditing(vs);
+    hydrateFromValueSet(vs);
+    setMode('create');
+  }, [hydrateFromValueSet]);
 
   // Debounced catalog search.
   useEffect(() => {
@@ -269,7 +354,7 @@ const ValueSetComposer = ({
       // expansion cache, so the next $apply for any service that
       // references this VS sees the new codes.
       const result = isEditMode
-        ? await cdsStudioApi.updateValueSet(editingValueSet.vs_id, payload)
+        ? await cdsStudioApi.updateValueSet(effectiveEditing.vs_id, payload)
         : await cdsStudioApi.createValueSet(payload);
       onSave?.({
         name: result.name,
@@ -282,20 +367,208 @@ const ValueSetComposer = ({
     } finally {
       setSaving(false);
     }
-  }, [canSave, name, title, description, selected, onSave, onClose, isEditMode, editingValueSet]);
+  }, [canSave, name, title, description, selected, onSave, onClose, isEditMode, effectiveEditing]);
 
   return (
     <Dialog open={open} onClose={saving ? undefined : onClose} maxWidth="md" fullWidth>
       <DialogTitle sx={{ display: 'flex', alignItems: 'center' }}>
-        {isEditMode ? `Edit ValueSet — ${editingValueSet.name}` : 'Compose a ValueSet'}
+        {isEditMode ? `Edit ValueSet — ${effectiveEditing.name}` : 'ValueSet'}
         <Box sx={{ flex: 1 }} />
         <IconButton onClick={onClose} disabled={saving} size="small">
           <CloseIcon fontSize="small" />
         </IconButton>
       </DialogTitle>
 
+      {/* Mode toggle — hidden when the parent opened us in external
+          edit-mode (editingValueSet prop). In that case there's nothing
+          to browse for; the caller wants to edit a specific VS. */}
+      {!editingValueSet && (
+        <Box sx={{ px: 3, pt: 2 }}>
+          <ToggleButtonGroup
+            value={mode}
+            exclusive
+            onChange={(_e, next) => next && setMode(next)}
+            size="small"
+            fullWidth
+          >
+            <ToggleButton value="create">Create new</ToggleButton>
+            <ToggleButton value="browse">Use or modify existing</ToggleButton>
+          </ToggleButtonGroup>
+        </Box>
+      )}
+
       <DialogContent dividers>
+        {mode === 'browse' && (
+          <Stack spacing={2}>
+            <TextField
+              value={browseQuery}
+              onChange={(e) => setBrowseQuery(e.target.value)}
+              placeholder="Search ValueSets by name, title, or description…"
+              fullWidth
+              autoFocus
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <SearchIcon fontSize="small" />
+                  </InputAdornment>
+                ),
+                endAdornment: browseLoading ? <CircularProgress size={18} /> : null,
+              }}
+            />
+            {browseError && <Alert severity="error">{browseError}</Alert>}
+            <Paper variant="outlined" sx={{ maxHeight: 480, overflow: 'auto', borderRadius: 1 }}>
+              {!browseLoading && browseResults.length === 0 && (
+                <Typography
+                  variant="body2"
+                  color="text.secondary"
+                  sx={{ p: 3, textAlign: 'center' }}
+                >
+                  No ValueSets match — switch to "Create new" to author one, or
+                  loosen the search.
+                </Typography>
+              )}
+              {browseResults.map((vs) => {
+                const expanded = browseExpandedId === vs.vs_id;
+                const codeCount = Array.isArray(vs.codes) ? vs.codes.length : 0;
+                const origin = (vs.vs_id || '').startsWith('wintehr-') ? 'system' : 'user';
+                return (
+                  <Box
+                    key={vs.vs_id}
+                    sx={{
+                      borderBottom: '1px solid',
+                      borderColor: 'divider',
+                      '&:last-child': { borderBottom: 'none' },
+                    }}
+                  >
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 1.5,
+                        px: 2,
+                        py: 1.5,
+                        cursor: 'pointer',
+                        '&:hover': { bgcolor: 'action.hover' },
+                      }}
+                      onClick={() => setBrowseExpandedId(expanded ? null : vs.vs_id)}
+                    >
+                      <ExpandMoreIcon
+                        fontSize="small"
+                        sx={{
+                          transition: '0.15s transform',
+                          transform: expanded ? 'rotate(0deg)' : 'rotate(-90deg)',
+                          color: 'text.secondary',
+                        }}
+                      />
+                      <Box sx={{ flex: 1, minWidth: 0 }}>
+                        <Typography variant="body1" noWrap>
+                          {vs.title || vs.name}
+                        </Typography>
+                        <Typography variant="caption" color="text.secondary" noWrap>
+                          {vs.name}
+                          {vs.created_by && ` · by ${vs.created_by}`}
+                        </Typography>
+                      </Box>
+                      <Tooltip title={`${codeCount} codes`}>
+                        <Chip
+                          label={codeCount}
+                          size="small"
+                          variant="outlined"
+                          sx={{ minWidth: 48 }}
+                        />
+                      </Tooltip>
+                      <Chip
+                        label={origin === 'system' ? 'system' : 'user'}
+                        size="small"
+                        color={origin === 'system' ? 'default' : 'primary'}
+                        variant="outlined"
+                      />
+                      <Button
+                        size="small"
+                        startIcon={<CheckIcon />}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleUseExisting(vs);
+                        }}
+                      >
+                        Use
+                      </Button>
+                      {origin === 'user' && (
+                        <Button
+                          size="small"
+                          startIcon={<EditIcon />}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleOpenToModify(vs);
+                          }}
+                        >
+                          Modify
+                        </Button>
+                      )}
+                    </Box>
+                    {expanded && (
+                      <Box sx={{ px: 4, pb: 1.5 }}>
+                        {vs.description && (
+                          <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                            {vs.description}
+                          </Typography>
+                        )}
+                        {Array.isArray(vs.codes) && vs.codes.length > 0 ? (
+                          <TableContainer component={Paper} variant="outlined">
+                            <Table size="small">
+                              <TableHead>
+                                <TableRow>
+                                  <TableCell>System</TableCell>
+                                  <TableCell>Code</TableCell>
+                                  <TableCell>Display</TableCell>
+                                </TableRow>
+                              </TableHead>
+                              <TableBody>
+                                {vs.codes.slice(0, 20).map((c) => (
+                                  <TableRow key={`${c.system}|${c.code}`}>
+                                    <TableCell sx={{ fontFamily: 'monospace', fontSize: 12 }}>
+                                      {c.system?.split('/').pop()}
+                                    </TableCell>
+                                    <TableCell sx={{ fontFamily: 'monospace', fontSize: 12 }}>
+                                      {c.code}
+                                    </TableCell>
+                                    <TableCell>{c.display || ''}</TableCell>
+                                  </TableRow>
+                                ))}
+                              </TableBody>
+                            </Table>
+                            {vs.codes.length > 20 && (
+                              <Typography
+                                variant="caption"
+                                color="text.secondary"
+                                sx={{ p: 1, display: 'block', textAlign: 'center' }}
+                              >
+                                …and {vs.codes.length - 20} more
+                              </Typography>
+                            )}
+                          </TableContainer>
+                        ) : (
+                          <Typography variant="caption" color="text.secondary">
+                            No codes loaded.
+                          </Typography>
+                        )}
+                      </Box>
+                    )}
+                  </Box>
+                );
+              })}
+            </Paper>
+          </Stack>
+        )}
+
+        {mode === 'create' && (
         <Stack spacing={3}>
+          {localEditing && (
+            <Alert severity="info" sx={{ borderRadius: 1 }}>
+              Editing existing ValueSet <strong>{localEditing.name}</strong>. Save will update
+              the codes in HAPI; services that reference this VS see the change on next $apply.
+            </Alert>
+          )}
           {/* Section 1: Identity */}
           <Box>
             <Typography variant="subtitle2" gutterBottom>
@@ -532,20 +805,23 @@ const ValueSetComposer = ({
 
           {saveError && <Alert severity="error">{saveError}</Alert>}
         </Stack>
+        )}
       </DialogContent>
 
       <DialogActions>
         <Button onClick={onClose} disabled={saving}>
           Cancel
         </Button>
-        <Button
-          variant="contained"
-          onClick={handleSave}
-          disabled={!canSave}
-          startIcon={saving ? <CircularProgress size={16} /> : null}
-        >
-          Save ValueSet
-        </Button>
+        {mode === 'create' && (
+          <Button
+            variant="contained"
+            onClick={handleSave}
+            disabled={!canSave}
+            startIcon={saving ? <CircularProgress size={16} /> : null}
+          >
+            {isEditMode ? 'Save changes' : 'Save ValueSet'}
+          </Button>
+        )}
       </DialogActions>
     </Dialog>
   );

--- a/frontend/src/modules/cds-studio/pages/CDSStudioPage.jsx
+++ b/frontend/src/modules/cds-studio/pages/CDSStudioPage.jsx
@@ -21,7 +21,8 @@ import {
   VpnKey as CredentialsIcon,
   Dashboard as DashboardIcon,
   BuildCircle as VisualBuilderIcon,
-  ViewModule as TemplateIcon
+  ViewModule as TemplateIcon,
+  LibraryBooks as ValueSetCatalogIcon,
 } from '@mui/icons-material';
 import ServicesTable from '../pages/ServicesRegistry/ServicesTable';
 import ServiceDetailPanel from '../components/ServiceDetailPanel';
@@ -30,6 +31,7 @@ import ExternalServiceDialog from '../components/ExternalServiceDialog';
 import DiscoveryImportDialog from '../components/DiscoveryImportDialog';
 import CredentialsManager from './CredentialsManager';
 import MonitoringDashboard from './MonitoringDashboard';
+import ValueSetCatalog from './ValueSetCatalog/ValueSetCatalog';
 import VisualBuilderWizard from '../components/builder/VisualBuilderWizard';
 import TemplateServiceBuilder from '../components/templates/TemplateServiceBuilder';
 
@@ -50,6 +52,7 @@ const CDSStudioPage = () => {
   const [discoveryImportDialogOpen, setDiscoveryImportDialogOpen] = useState(false);
   const [credentialsDialogOpen, setCredentialsDialogOpen] = useState(false);
   const [monitoringDialogOpen, setMonitoringDialogOpen] = useState(false);
+  const [valueSetCatalogOpen, setValueSetCatalogOpen] = useState(false);
   const [newServiceMenuAnchor, setNewServiceMenuAnchor] = useState(null);
 
   const handleSelectService = (service) => {
@@ -126,6 +129,13 @@ const CDSStudioPage = () => {
               onClick={() => setDiscoveryImportDialogOpen(true)}
             >
               Discovery Import
+            </Button>
+            <Button
+              variant="outlined"
+              startIcon={<ValueSetCatalogIcon />}
+              onClick={() => setValueSetCatalogOpen(true)}
+            >
+              ValueSets
             </Button>
             <Button
               variant="outlined"
@@ -291,6 +301,13 @@ const CDSStudioPage = () => {
       >
         <MonitoringDashboard />
       </Dialog>
+
+      {/* ValueSet Catalog — manage student-authored and system ValueSets.
+          Self-contained dialog component manages its own Edit/Delete flows. */}
+      <ValueSetCatalog
+        open={valueSetCatalogOpen}
+        onClose={() => setValueSetCatalogOpen(false)}
+      />
     </Box>
   );
 };

--- a/frontend/src/modules/cds-studio/pages/ValueSetCatalog/ValueSetCatalog.jsx
+++ b/frontend/src/modules/cds-studio/pages/ValueSetCatalog/ValueSetCatalog.jsx
@@ -1,0 +1,378 @@
+/**
+ * ValueSet Catalog — manager surface for all student-authored and system
+ * ValueSets used across the CDS Studio.
+ *
+ * Lives as a Dialog because the rest of the studio surfaces (Credentials,
+ * Monitoring) are also dialogs off the AppBar — keeps the navigation
+ * pattern consistent and avoids carving a new top-level route. Future
+ * deep-link work can lift this to its own route without touching the
+ * internal API.
+ *
+ * Three actions per row:
+ *   - "View codes" — expand inline to see the code list (no DB hit beyond
+ *     the initial list).
+ *   - "Edit" — opens ValueSetComposer in edit mode; save PUTs through
+ *     cdsStudioApi.updateValueSet.
+ *   - "Delete" — confirm dialog → cdsStudioApi.deleteValueSet (soft).
+ *     Disabled for `wintehr-*` system VSes (those are seeded from
+ *     terminology and shouldn't be student-deletable).
+ *
+ * Errors surface via a Snackbar so closing the inner confirm dialog
+ * doesn't take the message with it.
+ */
+
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  IconButton,
+  InputAdornment,
+  Paper,
+  Snackbar,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import {
+  Close as CloseIcon,
+  Delete as DeleteIcon,
+  Edit as EditIcon,
+  ExpandMore as ExpandMoreIcon,
+  Refresh as RefreshIcon,
+  Search as SearchIcon,
+} from '@mui/icons-material';
+
+import cdsStudioApi from '../../services/cdsStudioApi';
+import ValueSetComposer from '../../components/builders/ValueSetComposer';
+
+const isSystemVS = (vs) => (vs?.vs_id || '').startsWith('wintehr-');
+
+const ValueSetCatalog = ({ open, onClose }) => {
+  const [query, setQuery] = useState('');
+  const [valueSets, setValueSets] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [expandedId, setExpandedId] = useState(null);
+  const [editing, setEditing] = useState(null);
+  const [deleteTarget, setDeleteTarget] = useState(null);
+  const [deleting, setDeleting] = useState(false);
+  const [snackbar, setSnackbar] = useState({ open: false, message: '', severity: 'error' });
+
+  const load = useCallback(async (q) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const results = await cdsStudioApi.listValueSets({
+        search: q?.trim() || undefined,
+        limit: 200,
+      });
+      setValueSets(Array.isArray(results) ? results : []);
+    } catch (err) {
+      setError(err?.message || 'Failed to load ValueSets');
+      setValueSets([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  // Re-fetch on open and on debounced query change. 200ms matches the
+  // composer's catalog search debounce — fast enough to feel responsive,
+  // slow enough to avoid request-per-keystroke.
+  useEffect(() => {
+    if (!open) return;
+    const handle = setTimeout(() => load(query), 200);
+    return () => clearTimeout(handle);
+  }, [open, query, load]);
+
+  const confirmDelete = useCallback(async () => {
+    if (!deleteTarget) return;
+    setDeleting(true);
+    try {
+      await cdsStudioApi.deleteValueSet(deleteTarget.vs_id);
+      setSnackbar({
+        open: true,
+        message: `Deleted "${deleteTarget.title || deleteTarget.name}"`,
+        severity: 'success',
+      });
+      setDeleteTarget(null);
+      await load(query);
+    } catch (err) {
+      setSnackbar({
+        open: true,
+        message: err?.message || 'Failed to delete ValueSet',
+        severity: 'error',
+      });
+    } finally {
+      setDeleting(false);
+    }
+  }, [deleteTarget, query, load]);
+
+  const handleEditorSaved = useCallback(() => {
+    setEditing(null);
+    load(query);
+    setSnackbar({ open: true, message: 'ValueSet updated', severity: 'success' });
+  }, [query, load]);
+
+  return (
+    <>
+      <Dialog open={open} onClose={onClose} maxWidth="lg" fullWidth PaperProps={{ sx: { height: '90vh' } }}>
+        <DialogTitle sx={{ display: 'flex', alignItems: 'center' }}>
+          ValueSet Catalog
+          <Box sx={{ flex: 1 }} />
+          <Tooltip title="Refresh">
+            <IconButton onClick={() => load(query)} size="small">
+              <RefreshIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+          <IconButton onClick={onClose} size="small">
+            <CloseIcon fontSize="small" />
+          </IconButton>
+        </DialogTitle>
+
+        <DialogContent dividers>
+          <Stack spacing={2}>
+            <TextField
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search by name, title, or description…"
+              fullWidth
+              autoFocus
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <SearchIcon fontSize="small" />
+                  </InputAdornment>
+                ),
+                endAdornment: loading ? <CircularProgress size={18} /> : null,
+              }}
+            />
+
+            {error && <Alert severity="error">{error}</Alert>}
+
+            <TableContainer component={Paper} variant="outlined" sx={{ flex: 1 }}>
+              <Table size="small" stickyHeader>
+                <TableHead>
+                  <TableRow>
+                    <TableCell width={40} />
+                    <TableCell>Name</TableCell>
+                    <TableCell>Title</TableCell>
+                    <TableCell align="right">Codes</TableCell>
+                    <TableCell>Created by</TableCell>
+                    <TableCell>Origin</TableCell>
+                    <TableCell align="right">Actions</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {!loading && valueSets.length === 0 && (
+                    <TableRow>
+                      <TableCell colSpan={7} align="center">
+                        <Typography variant="body2" color="text.secondary" sx={{ py: 4 }}>
+                          {query ? 'No matches — try a different search.' : 'No ValueSets yet.'}
+                        </Typography>
+                      </TableCell>
+                    </TableRow>
+                  )}
+
+                  {valueSets.map((vs) => {
+                    const expanded = expandedId === vs.vs_id;
+                    const system = isSystemVS(vs);
+                    const codeCount = Array.isArray(vs.codes) ? vs.codes.length : 0;
+                    return (
+                      <React.Fragment key={vs.vs_id}>
+                        <TableRow
+                          hover
+                          onClick={() => setExpandedId(expanded ? null : vs.vs_id)}
+                          sx={{ cursor: 'pointer' }}
+                        >
+                          <TableCell>
+                            <ExpandMoreIcon
+                              fontSize="small"
+                              sx={{
+                                transition: '0.15s transform',
+                                transform: expanded ? 'rotate(0deg)' : 'rotate(-90deg)',
+                              }}
+                            />
+                          </TableCell>
+                          <TableCell>
+                            <Typography variant="body2" fontFamily="monospace">
+                              {vs.name}
+                            </Typography>
+                          </TableCell>
+                          <TableCell>{vs.title || <em>—</em>}</TableCell>
+                          <TableCell align="right">
+                            <Chip label={codeCount} size="small" variant="outlined" />
+                          </TableCell>
+                          <TableCell>{vs.created_by || <em>—</em>}</TableCell>
+                          <TableCell>
+                            <Chip
+                              label={system ? 'system' : 'user'}
+                              size="small"
+                              color={system ? 'default' : 'primary'}
+                              variant="outlined"
+                            />
+                          </TableCell>
+                          <TableCell align="right" onClick={(e) => e.stopPropagation()}>
+                            <Tooltip title={system ? 'System ValueSets cannot be edited' : 'Edit'}>
+                              <span>
+                                <IconButton
+                                  size="small"
+                                  disabled={system}
+                                  onClick={() => setEditing(vs)}
+                                >
+                                  <EditIcon fontSize="small" />
+                                </IconButton>
+                              </span>
+                            </Tooltip>
+                            <Tooltip title={system ? 'System ValueSets cannot be deleted' : 'Delete'}>
+                              <span>
+                                <IconButton
+                                  size="small"
+                                  disabled={system}
+                                  onClick={() => setDeleteTarget(vs)}
+                                >
+                                  <DeleteIcon fontSize="small" />
+                                </IconButton>
+                              </span>
+                            </Tooltip>
+                          </TableCell>
+                        </TableRow>
+                        {expanded && (
+                          <TableRow>
+                            <TableCell colSpan={7} sx={{ bgcolor: 'background.default' }}>
+                              <Box sx={{ p: 2 }}>
+                                {vs.description && (
+                                  <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                                    {vs.description}
+                                  </Typography>
+                                )}
+                                <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
+                                  Canonical URL: <code>{vs.hapi_canonical_url}</code>
+                                </Typography>
+                                {Array.isArray(vs.codes) && vs.codes.length > 0 ? (
+                                  <TableContainer component={Paper} variant="outlined">
+                                    <Table size="small">
+                                      <TableHead>
+                                        <TableRow>
+                                          <TableCell>System</TableCell>
+                                          <TableCell>Code</TableCell>
+                                          <TableCell>Display</TableCell>
+                                        </TableRow>
+                                      </TableHead>
+                                      <TableBody>
+                                        {vs.codes.slice(0, 50).map((c) => (
+                                          <TableRow key={`${c.system}|${c.code}`}>
+                                            <TableCell sx={{ fontFamily: 'monospace', fontSize: 12 }}>
+                                              {c.system?.split('/').pop()}
+                                            </TableCell>
+                                            <TableCell sx={{ fontFamily: 'monospace', fontSize: 12 }}>
+                                              {c.code}
+                                            </TableCell>
+                                            <TableCell>{c.display || ''}</TableCell>
+                                          </TableRow>
+                                        ))}
+                                      </TableBody>
+                                    </Table>
+                                    {vs.codes.length > 50 && (
+                                      <Typography
+                                        variant="caption"
+                                        color="text.secondary"
+                                        sx={{ p: 1, display: 'block', textAlign: 'center' }}
+                                      >
+                                        …and {vs.codes.length - 50} more
+                                      </Typography>
+                                    )}
+                                  </TableContainer>
+                                ) : (
+                                  <Typography variant="caption" color="text.secondary">
+                                    No codes.
+                                  </Typography>
+                                )}
+                              </Box>
+                            </TableCell>
+                          </TableRow>
+                        )}
+                      </React.Fragment>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </Stack>
+        </DialogContent>
+
+        <DialogActions>
+          <Typography variant="caption" color="text.secondary" sx={{ flex: 1, pl: 2 }}>
+            {valueSets.length} ValueSet{valueSets.length === 1 ? '' : 's'}
+            {query && ' matching'}
+          </Typography>
+          <Button onClick={onClose}>Close</Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Inline editor for the catalog's row-action "Edit" button. */}
+      <ValueSetComposer
+        open={Boolean(editing)}
+        onClose={() => setEditing(null)}
+        onSave={handleEditorSaved}
+        editingValueSet={editing}
+      />
+
+      {/* Delete confirmation — matches the ServicesTable pattern. */}
+      <Dialog open={Boolean(deleteTarget)} onClose={() => !deleting && setDeleteTarget(null)}>
+        <DialogTitle>Delete ValueSet?</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            {deleteTarget && (
+              <>
+                This will remove <strong>{deleteTarget.title || deleteTarget.name}</strong>{' '}
+                (<code>{deleteTarget.vs_id}</code>). Any service that references this
+                ValueSet via <code>valueset "{deleteTarget.name}": '…'</code> will stop
+                resolving until the declaration is updated.
+              </>
+            )}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteTarget(null)} disabled={deleting}>
+            Cancel
+          </Button>
+          <Button onClick={confirmDelete} color="error" disabled={deleting} autoFocus>
+            {deleting ? 'Deleting…' : 'Delete'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Snackbar
+        open={snackbar.open}
+        autoHideDuration={5000}
+        onClose={() => setSnackbar((p) => ({ ...p, open: false }))}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+      >
+        <Alert
+          severity={snackbar.severity}
+          onClose={() => setSnackbar((p) => ({ ...p, open: false }))}
+          variant="filled"
+        >
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
+    </>
+  );
+};
+
+export default ValueSetCatalog;


### PR DESCRIPTION
Closes #131. Subsumes #124 and #129.

## What changed

### Composer rework (Approach A)

`ValueSetComposer.jsx` gains a top-level "Create new" / "Use or modify existing" toggle. The new browse pane:
- Lists existing VSes with debounced search
- **Use** button → hands the canonical URL to the parent so CQLEditor inserts `valueset "Name": '<url>'` (no DB writes)
- **Modify** button → hydrates the composer form and flips Save to PUT instead of POST
- Inline expand-to-preview shows the code list per row
- System VSes (`wintehr-*`) get an unmodifiable badge

Both externally-driven (`editingValueSet` prop) and internally-driven (browse → Modify) edit modes converge on a single `effectiveEditing` variable.

### Wizard derives `referencedValueSets` from CQL — #124

The wizard's right-pane VS list previously only refreshed via `/full-edit-state` in edit mode, so a freshly-composed VS never showed until reload. Fixed:
- Parse `serviceConfig.cql_source` on every change with the same regex shape the backend uses (`cql_artifact_builder.py:_VALUESET_DECL_RE`)
- Resolve each canonical URL against a single `listValueSets` call
- Works in create mode too — no service_id required
- Unresolved URLs (deleted user VSes, system terminology) surface as stubs with the declared name + "not found" affordance

### New ValueSet Catalog page (Approach B)

`pages/ValueSetCatalog/ValueSetCatalog.jsx` — manager surface listing all VSes:
- Row-level Edit / Delete actions (using the same `ValueSetComposer` in edit mode)
- Inline expand-to-view-codes
- Delete confirm Dialog + Snackbar feedback (consistent with PR #135's ServicesTable pattern)
- Wired into `CDSStudioPage` via a "ValueSets" button in the AppBar

I kept this as a Dialog rather than a standalone route to match the existing Credentials/Monitoring pattern. Can be promoted to its own route later without internal-API changes.

### Backend 409 enrichment

`value_set_composer.py::create_value_set` now returns a structured `detail` payload on collision (`vs_id`, `name`, `title`, `canonical_url`, `created_by`, `code_count`, `owned_by_caller`) instead of a flat string. The frontend can offer "Open to modify" instead of forcing the student to manually delete-then-recreate.

## Test plan

- [x] `test_cql_bridge.py` regression: 48/48 pass
- [x] `test_cql_artifact_builder.py` regression: 19/19 pass  
- [x] Frontend lint clean on all 4 modified files (0 errors, 0 warnings)
- [x] `test_value_set_composer.py` skipped locally (pre-existing SQLAlchemy/Python 3.9 toolchain blocker on master too) — will run in Docker on deploy
- [ ] Manual: open the wizard, click "Compose ValueSet" → toggle "Use or modify existing" → search → click Use → confirm declaration inserted into CQL
- [ ] Manual: same flow but click Modify → edit codes → save → confirm referenced-VS panel reflects new code count
- [ ] Manual: AppBar → ValueSets button opens catalog dialog → confirm rows render with system/user badges, expand works, edit + delete actions function

## Out of scope

- "View Usage" (which services reference a given VS) — defer, needs a new backend endpoint
- Standalone `/cds-studio/value-sets` route — kept modal for now; promote later if deep-linking is needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)