### PR TITLE
fix(cds-studio): PUT /services/{id}/status accepts JSON body (#130 follow-up)

### DIFF
--- a/backend/api/cds_studio/router.py
+++ b/backend/api/cds_studio/router.py
@@ -9,6 +9,7 @@ Main router for CDS Management Studio providing endpoints for:
 """
 
 from fastapi import APIRouter, HTTPException, Depends, Query
+from pydantic import BaseModel
 from typing import List, Optional
 import logging
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -256,10 +257,21 @@ async def get_system_metrics(
 # Service Management Endpoints
 # ============================================================================
 
+class _ServiceStatusUpdate(BaseModel):
+    """JSON body for `PUT /services/{id}/status`.
+
+    The frontend ServicesTable toggles with a single PUT carrying
+    `{status: "active"|"inactive"}` in the body — wraps the enum here so
+    FastAPI parses from the JSON body rather than from the query string
+    (which is what a bare `status: ServiceStatus` parameter would do).
+    """
+    status: ServiceStatus
+
+
 @router.put("/services/{service_id}/status")
 async def update_service_status(
     service_id: str,
-    status: ServiceStatus,
+    body: _ServiceStatusUpdate,
     studio_service: CDSStudioService = Depends(get_studio_service)
 ):
     """
@@ -268,12 +280,12 @@ async def update_service_status(
     Updates PlanDefinition status in HAPI FHIR.
     """
     try:
-        await studio_service.update_service_status(service_id, status)
+        await studio_service.update_service_status(service_id, body.status)
         return {
             "success": True,
             "service_id": service_id,
-            "status": status,
-            "message": f"Service status updated to {status}"
+            "status": body.status,
+            "message": f"Service status updated to {body.status}"
         }
     except HTTPException:
         raise

--- a/backend/api/cds_studio/visual_builder_router.py
+++ b/backend/api/cds_studio/visual_builder_router.py
@@ -1093,67 +1093,6 @@ async def deploy_visual_service(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-class _ServiceStatusUpdate(BaseModel):
-    """Status transition request — accepts the lowercase frontend values."""
-    status: str = Field(..., description="'active' or 'inactive'")
-
-
-@router.put("/services/{service_id}/status")
-async def update_service_status(
-    service_id: str,
-    body: _ServiceStatusUpdate,
-    db: AsyncSession = Depends(get_db_session),
-    current_user: User = Depends(get_current_user_or_demo),
-):
-    """Unified status setter used by the Services Registry toggle.
-
-    The frontend prefers a single PUT over separate POST /deploy and POST
-    /deactivate endpoints because the table renders one row-level
-    "Activate/Deactivate" menu item that flips based on current status.
-    This route normalizes the lowercase 'active'/'inactive' payload to the
-    uppercase enum values service_configs.status expects, then writes via
-    the same SQLAlchemy path the dedicated endpoints use.
-    """
-    requested = (body.status or "").lower()
-    if requested not in ("active", "inactive"):
-        raise HTTPException(
-            status_code=422,
-            detail="status must be 'active' or 'inactive'",
-        )
-    new_status = "ACTIVE" if requested == "active" else "INACTIVE"
-
-    try:
-        query = select(VisualServiceConfig).where(
-            VisualServiceConfig.service_id == service_id
-        )
-        result = await db.execute(query)
-        service = result.scalar_one_or_none()
-
-        if not service:
-            raise HTTPException(
-                status_code=404,
-                detail=f"Visual service '{service_id}' not found",
-            )
-
-        service.status = new_status
-        if new_status == "ACTIVE":
-            service.last_deployed_at = datetime.utcnow()
-        await db.commit()
-
-        logger.info(f"Service {service_id} status set to {new_status}")
-        return {
-            "service_id": service_id,
-            "status": new_status,
-        }
-
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Error updating status for {service_id}: {e}", exc_info=True)
-        await db.rollback()
-        raise HTTPException(status_code=500, detail=str(e))
-
-
 @router.post("/services/{service_id}/deactivate")
 async def deactivate_visual_service(
     service_id: str,


### PR DESCRIPTION
Phase 1 (PR #135) added a new PUT route in visual_builder_router.py to fix the silent 404 on `cdsStudioApi.updateServiceStatus()`. But the inventory agent missed that an OLDER route already existed at the right prefix in `cds_studio/router.py:259` — it just took \`status\` as a bare function parameter, which Pydantic V2 + FastAPI interprets as a QUERY parameter, not a body field.

So the frontend's PUT with \`{status: "active"}\` in the JSON body 422'd because FastAPI was looking for \`?status=active\`. The new route I added in #135 was unreachable (wrong prefix).

## Changes

- Wrap the param in a Pydantic body model in \`cds_studio/router.py\` so the JSON body parses correctly
- Delete the duplicate orphan route in \`visual_builder_router.py\` (unreachable at \`/api/cds-visual-builder/*\` while the frontend hits \`/api/cds-studio/*\`)

## Verified live

\`\`\`
# Before this fix (on master post-#135):
$ curl -X PUT .../api/cds-studio/services/colonoscopy-screening/status -d '{"status":"active"}'
422 {"detail":[{"loc":["query","status"],"msg":"Field required"}]}

# After this fix:
$ curl -X PUT .../api/cds-studio/services/colonoscopy-screening/status -d '{"status":"active"}'
200 {"success":true,"service_id":"colonoscopy-screening","status":"active"}

$ curl -X PUT .../api/cds-studio/services/colonoscopy-screening/status -d '{"status":"banana"}'
422  # pydantic enum rejection
\`\`\`

Closes the actual #130 acceptance criterion. Test suite unchanged (no new tests — the existing services-table flow is the verification path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)