### PR TITLE
fix(cds-studio): Delete menu item actually deletes (#130 follow-up)

### DIFF
--- a/backend/api/cds_studio/service.py
+++ b/backend/api/cds_studio/service.py
@@ -1012,20 +1012,51 @@ class CDSStudioService:
                 except Exception as e:
                     logger.error(f"Error hard-deleting local config for {service_id}: {e}")
 
-            # Remove PlanDefinition from HAPI FHIR
-            try:
-                bundle = await self.hapi_client.search("PlanDefinition", {
-                    "name": service_id,
-                    "_count": "1"
-                })
-                entries = bundle.get("entry", [])
-                if entries:
-                    plan_id = entries[0].get("resource", {}).get("id")
-                    if plan_id:
-                        await self.hapi_client.delete("PlanDefinition", plan_id)
-                        logger.info(f"Hard-deleted PlanDefinition {plan_id} for {service_id}")
-            except Exception as e:
-                logger.error(f"Error deleting FHIR PlanDefinition for {service_id}: {e}")
+            # Remove PlanDefinition from HAPI FHIR. Three lookup strategies,
+            # tried in order — services land in HAPI via different paths
+            # depending on origin:
+            #   1. vb-{service_id} — the canonical id for visual-builder
+            #      services authored through the wizard
+            #   2. service_id directly — the id imported services and
+            #      manually-uploaded test PlanDefinitions use (e.g. the
+            #      data-param-spike-051407 incident)
+            #   3. PlanDefinition?name=service_id — fallback for services
+            #      whose id was renamed but `name` still matches
+            #
+            # Each strategy is wrapped so a 404 in one doesn't short-circuit
+            # the next. Deletion of PD is non-fatal — the DB row is already
+            # gone above, so a missed HAPI delete at worst leaves an orphan
+            # PlanDefinition that ServicesTable shows as a "built-in" entry.
+            candidate_ids = []
+            for read_id in (f"vb-{service_id}", service_id):
+                try:
+                    pd = await self.hapi_client.read("PlanDefinition", read_id)
+                    if pd and pd.get("id"):
+                        candidate_ids.append(pd["id"])
+                except Exception:
+                    pass
+
+            if not candidate_ids:
+                try:
+                    bundle = await self.hapi_client.search("PlanDefinition", {
+                        "name": service_id,
+                        "_count": "5",
+                    })
+                    for entry in bundle.get("entry", []) or []:
+                        pd_id = entry.get("resource", {}).get("id")
+                        if pd_id and pd_id not in candidate_ids:
+                            candidate_ids.append(pd_id)
+                except Exception as e:
+                    logger.warning(f"PlanDefinition name-search failed for {service_id}: {e}")
+
+            for pd_id in candidate_ids:
+                try:
+                    await self.hapi_client.delete("PlanDefinition", pd_id)
+                    logger.info(f"Hard-deleted PlanDefinition/{pd_id} for {service_id}")
+                except Exception as e:
+                    logger.error(f"Error deleting PlanDefinition/{pd_id} for {service_id}: {e}")
+            if not candidate_ids:
+                logger.info(f"No PlanDefinition found in HAPI for {service_id}; DB row removed only")
         else:
             # Soft delete: set to inactive/retired
             await self.update_service_status(service_id, ServiceStatus.INACTIVE)

--- a/frontend/src/modules/cds-studio/pages/ServicesRegistry/ServicesTable.jsx
+++ b/frontend/src/modules/cds-studio/pages/ServicesRegistry/ServicesTable.jsx
@@ -131,7 +131,13 @@ const ServicesTable = ({ onSelectService, onEditService, onRefresh }) => {
 
     setDeleting(true);
     try {
-      await cdsStudioApi.deleteService(deleteTarget.service_id);
+      // hard_delete=true so "Delete" actually removes the row from the DB
+      // AND the PlanDefinition from HAPI. Without it the backend's
+      // soft-delete path just flips status → INACTIVE, which is what
+      // "Deactivate" already does from the same menu — making the two
+      // menu items indistinguishable in effect. Users expect Delete to
+      // be destructive; that's also what the confirmation copy implies.
+      await cdsStudioApi.deleteService(deleteTarget.service_id, true);
       setDeleteTarget(null);
       await loadServices();
       setSnackbar({ open: true, message: `Deleted "${deleteTarget.title}"`, severity: 'success' });


### PR DESCRIPTION
User reported "I tried deleting a service, data-param-spike-051407, but it is still showing."

## Root cause (traced live in prod)

1. Frontend's \`cdsStudioApi.deleteService(id)\` defaults \`hardDelete=false\`
2. Backend's \`delete_service(hard_delete=False)\` calls \`update_service_status(...,INACTIVE)\` — **the same code path "Deactivate" uses**. So Delete and Deactivate did effectively the same thing (flip status), making them indistinguishable from the user's perspective.
3. For services that exist as PlanDefinitions in HAPI without a matching \`service_configs\` row (e.g. spike/test services uploaded directly), even that status flip is a no-op — the search for \`PlanDefinition/vb-{id}\` and \`hook-service-id\` extension both miss, so the PD stays \`status=active\` in HAPI.
4. The studio's services-list endpoint sees the orphan PD and classifies it as "built-in" (no service-origin extension) — so the deleted service kept showing in the registry table.

## Fix

**Frontend** (\`ServicesTable.jsx\`):
- \`confirmDelete\` now calls \`deleteService(id, true)\` — Delete is destructive. The separate "Deactivate" menu item still routes through PUT /status as the non-destructive option.

**Backend** (\`service.py::delete_service\` hard-delete branch):
- Three lookup strategies tried in order:
  1. \`PlanDefinition/vb-{service_id}\` — canonical wizard-authored
  2. \`PlanDefinition/{service_id}\` — direct id (covers imported / manually-uploaded PDs, including the spike service that triggered the report)
  3. \`?name={service_id}\` search — fallback for renamed ids
- Each wrapped so a 404 doesn't short-circuit the next.

## Cleanup

The orphan PD that triggered the report was already cleared manually in prod (\`DELETE /fhir/R4/PlanDefinition/data-param-spike-051407\` → SUCCESSFUL_DELETE) so the user's immediate issue is resolved. This PR prevents future occurrences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)