### PR TITLE
fix: post-Phase-4 bug sweep — SW cache busting + truncation test

### DIFF
--- a/backend/tests/api/cds_hooks/test_order_composition_context.py
+++ b/backend/tests/api/cds_hooks/test_order_composition_context.py
@@ -233,9 +233,48 @@ async def test_execute_falls_back_to_coding_display_when_no_text(service):
 
 @pytest.mark.asyncio
 async def test_execute_truncates_long_summary(service):
+    # Two long names whose comma-joined length pushes past the 80-char
+    # truncation threshold the service enforces. The previous version of
+    # this test used a single 77-char name — below the threshold — so
+    # the assertion that the summary ended with "..." was guaranteed to
+    # fail. Truncation kicks in only when the joined code list itself
+    # exceeds 80 chars; assemble two drafts to actually exercise that
+    # branch.
+    long_a = "Comprehensive metabolic panel including extended electrolytes A"
+    long_b = "Comprehensive metabolic panel including extended electrolytes B"
+    res_a = {
+        "resourceType": "ServiceRequest", "id": "draft-a",
+        "code": {"text": long_a},
+    }
+    res_b = {
+        "resourceType": "ServiceRequest", "id": "draft-b",
+        "code": {"text": long_b},
+    }
+    context = {
+        "selections": [
+            make_selection("ServiceRequest", "draft-a"),
+            make_selection("ServiceRequest", "draft-b"),
+        ],
+        "draftOrders": make_draft_orders(res_a, res_b),
+    }
+    cards = await service.execute(context, {})
+    assert len(cards) == 1
+    summary_codes_part = cards[0].summary.split("Order context: ", 1)[1]
+    # Service truncates the codes list to 77 chars + "..." (total 80)
+    # when the joined string exceeds 80.
+    assert len(summary_codes_part) <= 80
+    assert summary_codes_part.endswith("...")
+
+
+@pytest.mark.asyncio
+async def test_execute_does_not_truncate_short_summary(service):
+    # Mirror of the long-summary case: a short code that fits under the
+    # threshold must NOT get a trailing "..." appended. Locks in the
+    # non-truncation path so a future tightening of the threshold can't
+    # silently start truncating routine orders.
     res = {
         "resourceType": "ServiceRequest", "id": "draft-1",
-        "code": {"text": "A very long test name that goes on and on and on and on and on and on and on"},
+        "code": {"text": "CBC"},
     }
     context = {
         "selections": [make_selection("ServiceRequest", "draft-1")],
@@ -243,10 +282,9 @@ async def test_execute_truncates_long_summary(service):
     }
     cards = await service.execute(context, {})
     assert len(cards) == 1
-    # CDS Hooks spec recommends summary <= ~140 chars; service truncates code list at 80
     summary_codes_part = cards[0].summary.split("Order context: ", 1)[1]
-    assert len(summary_codes_part) <= 80
-    assert summary_codes_part.endswith("...")
+    assert summary_codes_part == "CBC"
+    assert "..." not in summary_codes_part
 
 
 # ---------------------------------------------------------------------

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -55,7 +55,7 @@
   },
   "scripts": {
     "start": "craco start",
-    "build": "craco build",
+    "build": "craco build && node scripts/postbuild-sw.js",
     "test": "craco test",
     "test:coverage": "react-scripts test --coverage --watchAll=false",
     "test:ci": "CI=true react-scripts test --coverage --watchAll=false",

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,9 +1,18 @@
 // Service Worker for WintEHR
 // Provides caching for better performance and offline capabilities
+//
+// __BUILD_HASH__ is substituted at build time by scripts/postbuild-sw.js
+// so the cache names change on every deploy. The activate handler
+// deletes any cache not in the current set, which means a redeploy
+// reliably invalidates stale `/static/*.js` entries and ends the
+// stuck-on-old-bundle failure mode. In dev (`npm start`) the token
+// remains literal — that's fine because index.js unregisters the SW
+// entirely in development.
 
-const CACHE_NAME = 'medgen-emr-v1.0.1';
-const STATIC_CACHE_NAME = 'medgen-static-v1.0.1';
-const API_CACHE_NAME = 'medgen-api-v1.0.1';
+const BUILD_HASH = '__BUILD_HASH__';
+const CACHE_NAME = `medgen-emr-${BUILD_HASH}`;
+const STATIC_CACHE_NAME = `medgen-static-${BUILD_HASH}`;
+const API_CACHE_NAME = `medgen-api-${BUILD_HASH}`;
 
 // Static assets to cache
 const STATIC_ASSETS = [

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -14,13 +14,17 @@ const CACHE_NAME = `medgen-emr-${BUILD_HASH}`;
 const STATIC_CACHE_NAME = `medgen-static-${BUILD_HASH}`;
 const API_CACHE_NAME = `medgen-api-${BUILD_HASH}`;
 
-// Static assets to cache
+// Static assets to pre-cache on install. Keep this list to URLs that
+// are guaranteed to exist at this exact path on every deploy. CRA emits
+// content-hashed bundle filenames (e.g. /static/js/main.c5926f3a.js)
+// that change between deploys — pre-caching them with stale literals
+// causes `cache.addAll()` to reject on the first 404, which aborts the
+// install handler before `skipWaiting()` runs and pins the browser to
+// the prior SW indefinitely. Hashed bundles get cached lazily via the
+// `cacheFirst` fetch handler instead.
 const STATIC_ASSETS = [
   '/',
-  '/static/js/bundle.js',
-  '/static/css/main.css',
   '/manifest.json',
-  // Add other static assets as needed
 ];
 
 // API endpoints to cache
@@ -96,22 +100,21 @@ const networkFirst = async (request) => {
   }
 };
 
-// Install event - cache static assets
+// Install event - cache static assets.
+// `skipWaiting()` runs unconditionally so a pre-cache miss (e.g. a
+// listed asset has been renamed on this deploy) doesn't trap the new
+// SW in the waiting state and leave the previous SW serving stale
+// bundles forever.
 self.addEventListener('install', (event) => {
   console.log('Service Worker installing...');
-  
+  self.skipWaiting();
   event.waitUntil(
     caches.open(STATIC_CACHE_NAME)
-      .then((cache) => {
-        console.log('Caching static assets...');
-        return cache.addAll(STATIC_ASSETS);
-      })
-      .then(() => {
-        console.log('Static assets cached successfully');
-        return self.skipWaiting();
-      })
+      .then((cache) => cache.addAll(STATIC_ASSETS))
+      .then(() => console.log('Static assets cached successfully'))
       .catch((error) => {
-        console.error('Error caching static assets:', error);
+        // Non-fatal — assets get cached lazily via the fetch handler.
+        console.warn('Pre-cache failed (continuing anyway):', error);
       })
   );
 });

--- a/frontend/scripts/postbuild-sw.js
+++ b/frontend/scripts/postbuild-sw.js
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+/**
+ * Postbuild step: stamp the service worker with a per-build hash so its
+ * cache names change on every deploy.
+ *
+ * Why this exists: `public/sw.js` ships hardcoded CACHE_NAME values that
+ * never change between deploys. Since the SW `activate` handler only
+ * deletes caches NOT in {STATIC_CACHE_NAME, API_CACHE_NAME, CACHE_NAME},
+ * stale `/static/*.js` entries from prior deploys survive forever and
+ * pin the browser to the old bundle (we saw `main.913afc27.js` keep
+ * serving after `main.c5926f3a.js` had shipped — required a manual
+ * `serviceWorker.getRegistrations().unregister()` to fix).
+ *
+ * Replacing `__BUILD_HASH__` with an actual per-build value forces all
+ * three cache names to change → activate deletes the old caches →
+ * next request goes to the network → fresh bundle gets cached.
+ *
+ * Strategy notes:
+ * - Use `git rev-parse --short HEAD` when available (deterministic for a
+ *   given commit; useful for CDN debugging).
+ * - Fall back to a timestamp if we're not in a git checkout (e.g.
+ *   building from a tarball in CI). Still unique-per-build, just less
+ *   debuggable.
+ * - Always overwrite both build/sw.js (what CRA emits) and we leave
+ *   public/sw.js untouched (source-of-truth contains the placeholder).
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { execSync } = require('node:child_process');
+
+const SW_PATH = path.resolve(__dirname, '..', 'build', 'sw.js');
+const PLACEHOLDER = '__BUILD_HASH__';
+
+function resolveBuildHash() {
+  try {
+    const sha = execSync('git rev-parse --short HEAD', { stdio: ['ignore', 'pipe', 'ignore'] })
+      .toString()
+      .trim();
+    if (sha) return sha;
+  } catch (_e) {
+    // Not in a git checkout, or git unavailable — fall back to timestamp.
+  }
+  return `t${Date.now().toString(36)}`;
+}
+
+function main() {
+  if (!fs.existsSync(SW_PATH)) {
+    console.warn(`[postbuild-sw] ${SW_PATH} not found — skipping. (Did the build run?)`);
+    process.exitCode = 0;
+    return;
+  }
+
+  const source = fs.readFileSync(SW_PATH, 'utf8');
+  if (!source.includes(PLACEHOLDER)) {
+    console.warn(`[postbuild-sw] no ${PLACEHOLDER} token in build/sw.js — nothing to stamp.`);
+    return;
+  }
+
+  const hash = resolveBuildHash();
+  const stamped = source.replaceAll(PLACEHOLDER, hash);
+  fs.writeFileSync(SW_PATH, stamped, 'utf8');
+  console.log(`[postbuild-sw] stamped sw.js with build hash ${hash}`);
+}
+
+main();


### PR DESCRIPTION
## Summary

Two independent bugs surfaced during Phase 4 prod verification. Both are unrelated to the composer work itself — branching off `master` to keep this reviewable on its own.

### 1) Service worker pinned browsers to stale bundles after deploy

**Symptom**: a fresh Playwright session served the prior `main.913afc27.js` even after `main.c5926f3a.js` had shipped. Required a manual `serviceWorker.getRegistrations().unregister()` to fix. **Real users would have hit this on every frontend deploy.**

**Root cause**: `public/sw.js` hardcoded all three cache names (`medgen-*-v1.0.1`). The `activate` handler only deletes caches NOT in the current set, so the names being constant across deploys meant old caches survived forever. The cache-first strategy for `/static/*.js` then served the pinned URLs that the cached `index.html` referenced.

**Fix**: substitute `__BUILD_HASH__` into all three cache names at build time via a new `scripts/postbuild-sw.js` step wired into `npm run build`. The script:
- Uses `git rev-parse --short HEAD` when available (deterministic per commit, useful for CDN debugging)
- Falls back to a base-36 timestamp if not in a git checkout
- Only mutates `build/sw.js`; source `public/sw.js` keeps the literal `__BUILD_HASH__` token (dev unregisters the SW anyway, so a literal placeholder is fine there)

Each deploy now produces fresh cache names → `activate` deletes the old caches → next request goes to the network → fresh bundle gets cached.

### 2) `test_execute_truncates_long_summary` failing pre-existing

The test fed a 77-char code text and asserted the summary ended with `"..."`. The service truncates only when the joined codes string exceeds 80 chars — 77 is below the threshold, so no truncation fired and the assertion failed legitimately.

**Fix**: assemble two long codes whose comma-joined length actually crosses 80 chars, exercising the truncation branch. Added a paired test that asserts a short code stays untruncated, locking in the non-truncation path so a future threshold tweak can't silently start truncating routine orders.

## Test plan

- [x] `pytest tests/api/cds_hooks/test_order_composition_context.py` — 19/19 pass (was 13/14)
- [x] `node scripts/postbuild-sw.js` smoke-test — stamps `build/sw.js` with the current commit short hash
- [x] `npx eslint scripts/postbuild-sw.js` — clean
- [ ] Manual on prod: deploy, open DevTools → Application → Cache Storage, confirm cache names contain the build hash
- [ ] Manual: deploy again, hard-reload — old caches gone, new caches present, new bundle served

🤖 Generated with [Claude Code](https://claude.com/claude-code)