### PR TITLE
refactor(clinical): single tab registry — one source of truth for workspace tabs

### DIFF
--- a/frontend/src/components/clinical/ClinicalWorkspaceEnhanced.js
+++ b/frontend/src/components/clinical/ClinicalWorkspaceEnhanced.js
@@ -15,16 +15,6 @@ import {
   Typography
 } from '@mui/material';
 import {
-  Dashboard as DashboardIcon,
-  FolderOpen as ChartIcon,
-  EventNote as EncountersIcon,
-  Science as ResultsIcon,
-  LocalPharmacy as PharmacyIcon,
-  Description as DocumentationIcon,
-  AccountTree as CarePlanIcon,
-  ListAlt as OrdersIcon,
-  Timeline as TimelineIcon,
-  Image as ImagingIcon,
   ChevronLeft as ChevronLeftIcon
 } from '@mui/icons-material';
 
@@ -37,49 +27,7 @@ import TabErrorBoundary from './workspace/TabErrorBoundary';
 import { useKeyboardNavigation } from '../../hooks/useKeyboardNavigation';
 import KeyboardShortcutsDialog from './shared/dialogs/KeyboardShortcutsDialog';
 import CDSPresentation, { PRESENTATION_MODES } from './cds/CDSPresentation';
-
-// Tab Components - Lazy Loaded for Performance with webpack magic comments
-// Using optimized/enhanced versions where available
-const SummaryTab = React.lazy(() => import(
-  /* webpackChunkName: "clinical-summary" */
-  './workspace/tabs/SummaryTab'
-));
-const ChartReviewTab = React.lazy(() => import(
-  /* webpackChunkName: "clinical-chart-review" */
-  './workspace/tabs/ChartReviewTabOptimized'
-));
-const EncountersTab = React.lazy(() => import(
-  /* webpackChunkName: "clinical-encounters" */
-  './workspace/tabs/EncountersTab'
-));
-const ResultsTab = React.lazy(() => import(
-  /* webpackChunkName: "clinical-results" */
-  './workspace/tabs/ResultsTabOptimized'
-));
-const OrdersTab = React.lazy(() => import(
-  /* webpackChunkName: "clinical-orders" */
-  './workspace/tabs/EnhancedOrdersTab'
-));
-const PharmacyTab = React.lazy(() => import(
-  /* webpackChunkName: "clinical-pharmacy" */
-  './workspace/tabs/PharmacyTab'
-));
-const DocumentationTab = React.lazy(() => import(
-  /* webpackChunkName: "clinical-documentation" */
-  './workspace/tabs/DocumentationTabEnhanced'
-));
-const CarePlanTab = React.lazy(() => import(
-  /* webpackChunkName: "clinical-care-plan" */
-  './workspace/tabs/CarePlanTabEnhanced'
-));
-const TimelineTab = React.lazy(() => import(
-  /* webpackChunkName: "clinical-timeline" */
-  './workspace/tabs/TimelineTabModern'
-));
-const ImagingTab = React.lazy(() => import(
-  /* webpackChunkName: "clinical-imaging" */
-  './workspace/tabs/ImagingTab'
-));
+import { buildTabContentConfig } from './workspace/clinicalTabRegistry';
 
 // Tab Loading Component
 const TabLoadingFallback = () => (
@@ -88,20 +36,10 @@ const TabLoadingFallback = () => (
   </Box>
 );
 
-// Tab Configuration - matching the sidebar navigation
-// Note: Using lazy-loaded optimized components defined above
-const TAB_CONFIG = [
-  { id: 'summary', label: 'Summary', icon: DashboardIcon, component: SummaryTab },
-  { id: 'chart-review', label: 'Chart Review', icon: ChartIcon, component: ChartReviewTab }, // Uses ChartReviewTabOptimized
-  { id: 'encounters', label: 'Encounters', icon: EncountersIcon, component: EncountersTab },
-  { id: 'results', label: 'Results', icon: ResultsIcon, component: ResultsTab }, // Uses ResultsTabOptimized
-  { id: 'orders', label: 'Orders', icon: OrdersIcon, component: OrdersTab }, // Uses EnhancedOrdersTab
-  { id: 'pharmacy', label: 'Pharmacy', icon: PharmacyIcon, component: PharmacyTab },
-  { id: 'imaging', label: 'Imaging', icon: ImagingIcon, component: ImagingTab },
-  { id: 'documentation', label: 'Documentation', icon: DocumentationIcon, component: DocumentationTab }, // Uses DocumentationTabEnhanced
-  { id: 'care-plan', label: 'Care Plan', icon: CarePlanIcon, component: CarePlanTab }, // Uses CarePlanTabEnhanced
-  { id: 'timeline', label: 'Timeline', icon: TimelineIcon, component: TimelineTab } // Uses TimelineTabModern
-];
+// Tab content config — lazy-loaded components, ordered by the single
+// source of truth in `clinicalTabRegistry`. Adding a tab is one entry
+// there; this file picks it up automatically.
+const TAB_CONFIG = buildTabContentConfig();
 
 const ClinicalWorkspaceEnhanced = ({ 
   patient,

--- a/frontend/src/components/clinical/layouts/EnhancedClinicalLayout.js
+++ b/frontend/src/components/clinical/layouts/EnhancedClinicalLayout.js
@@ -21,20 +21,14 @@ import { usePatientData } from '../../../hooks/usePatientData';
 import { useResponsive } from '../../../hooks/useResponsive';
 import { MedicalThemeContext } from '../../../App';
 import { LAYOUT_HEIGHTS, Z_INDEX } from '../theme/clinicalThemeConstants';
+import { CLINICAL_TABS } from '../workspace/clinicalTabRegistry';
 
-// Module configuration
-const MODULES = {
-  summary: { id: 'summary', label: 'Summary', index: 0 },
-  'chart-review': { id: 'chart-review', label: 'Chart Review', index: 1 },
-  encounters: { id: 'encounters', label: 'Encounters', index: 2 },
-  results: { id: 'results', label: 'Results', index: 3 },
-  orders: { id: 'orders', label: 'Orders', index: 4 },
-  pharmacy: { id: 'pharmacy', label: 'Pharmacy', index: 5 },
-  imaging: { id: 'imaging', label: 'Imaging', index: 6 },
-  documentation: { id: 'documentation', label: 'Documentation', index: 7 },
-  'care-plan': { id: 'care-plan', label: 'Care Plan', index: 8 },
-  timeline: { id: 'timeline', label: 'Timeline', index: 9 }
-};
+// Module configuration — id → {id, label, index}, derived from the single
+// tab registry. `index` is the registry's array position, so tab order
+// is owned in one place.
+const MODULES = Object.fromEntries(
+  CLINICAL_TABS.map((t, index) => [t.id, { id: t.id, label: t.label, index }]),
+);
 
 const EnhancedClinicalLayout = ({
   children,

--- a/frontend/src/components/clinical/navigation/ClinicalSidebar.js
+++ b/frontend/src/components/clinical/navigation/ClinicalSidebar.js
@@ -23,16 +23,6 @@ import {
   useMediaQuery
 } from '@mui/material';
 import {
-  Dashboard as SummaryIcon,
-  Assignment as ChartReviewIcon,
-  Event as EncountersIcon,
-  Science as ResultsIcon,
-  LocalPharmacy as OrdersIcon,
-  Medication as PharmacyIcon,
-  CameraAlt as ImagingIcon,
-  Description as DocumentationIcon,
-  AccountTree as CarePlanIcon,
-  Timeline as TimelineIcon,
   ChevronLeft as CollapseIcon,
   ChevronRight as ExpandIcon,
   Notifications as AlertsIcon,
@@ -47,84 +37,24 @@ import {
 import { useClinicalWorkflow } from '../../../contexts/ClinicalWorkflowContext';
 import { useSMART } from '../../../contexts/SMARTContext';
 import SMARTAppLauncher from '../../smart/SMARTAppLauncher';
+import { CLINICAL_TABS } from '../workspace/clinicalTabRegistry';
 
 // Sidebar width constants
 const SIDEBAR_WIDTH = 280;
 const SIDEBAR_COLLAPSED_WIDTH = 72;
 
-// Navigation items configuration
-const NAVIGATION_ITEMS = [
-  {
-    id: 'summary',
-    label: 'Summary',
-    icon: SummaryIcon,
-    badge: null,
-    description: 'Patient overview and key metrics'
-  },
-  {
-    id: 'chart-review',
-    label: 'Chart Review',
-    icon: ChartReviewIcon,
-    badge: null,
-    description: 'Problems, medications, allergies, vitals'
-  },
-  {
-    id: 'encounters',
-    label: 'Encounters',
-    icon: EncountersIcon,
-    badge: null,
-    description: 'Visit history and notes'
-  },
-  {
-    id: 'results',
-    label: 'Results',
-    icon: ResultsIcon,
-    badge: 'new',
-    description: 'Lab results and reports'
-  },
-  {
-    id: 'orders',
-    label: 'Orders',
-    icon: OrdersIcon,
-    badge: 3,
-    description: 'Active and pending orders'
-  },
-  {
-    id: 'pharmacy',
-    label: 'Pharmacy',
-    icon: PharmacyIcon,
-    badge: null,
-    description: 'Medication management'
-  },
-  {
-    id: 'imaging',
-    label: 'Imaging',
-    icon: ImagingIcon,
-    badge: 2,
-    description: 'Radiology and DICOM viewer'
-  },
-  {
-    id: 'documentation',
-    label: 'Documentation',
-    icon: DocumentationIcon,
-    badge: null,
-    description: 'Clinical notes and forms'
-  },
-  {
-    id: 'care-plan',
-    label: 'Care Plan',
-    icon: CarePlanIcon,
-    badge: null,
-    description: 'Treatment plans and goals'
-  },
-  {
-    id: 'timeline',
-    label: 'Timeline',
-    icon: TimelineIcon,
-    badge: null,
-    description: 'Clinical history timeline'
-  }
-];
+// Sidebar nav items — derived from the single tab registry. `badge`
+// starts null; the render path layers dynamic notification counts on.
+// (The previous hardcoded list carried placeholder static badges —
+// results:'new', orders:3, imaging:2 — which were demo cruft, not real
+// counts. Dropped.)
+const NAVIGATION_ITEMS = CLINICAL_TABS.map((t) => ({
+  id: t.id,
+  label: t.label,
+  icon: t.icon,
+  badge: null,
+  description: t.description,
+}));
 
 const ClinicalSidebar = ({
   open,

--- a/frontend/src/components/clinical/navigation/ClinicalTabs.js
+++ b/frontend/src/components/clinical/navigation/ClinicalTabs.js
@@ -14,34 +14,20 @@ import {
   useMediaQuery
 } from '@mui/material';
 import { alpha } from '@mui/material/styles';
-import {
-  Dashboard as SummaryIcon,
-  Assignment as ChartReviewIcon,
-  Event as EncountersIcon,
-  Science as ResultsIcon,
-  LocalPharmacy as OrdersIcon,
-  Medication as PharmacyIcon,
-  CameraAlt as ImagingIcon,
-  Description as DocumentationIcon,
-  AccountTree as CarePlanIcon,
-  Timeline as TimelineIcon
-} from '@mui/icons-material';
 import { useClinicalWorkflow } from '../../../contexts/ClinicalWorkflowContext';
 import { LAYOUT_HEIGHTS, Z_INDEX } from '../theme/clinicalThemeConstants';
+import { CLINICAL_TABS } from '../workspace/clinicalTabRegistry';
 
-// Navigation items configuration
-const NAVIGATION_ITEMS = [
-  { id: 'summary', label: 'Summary', icon: SummaryIcon, badge: null, color: '#6366F1' },
-  { id: 'chart-review', label: 'Chart Review', icon: ChartReviewIcon, badge: null, color: '#10B981' },
-  { id: 'encounters', label: 'Encounters', icon: EncountersIcon, badge: null, color: '#3B82F6' },
-  { id: 'results', label: 'Results', icon: ResultsIcon, badge: null, color: '#F59E0B' },
-  { id: 'orders', label: 'Orders', icon: OrdersIcon, badge: null, color: '#8B5CF6' },
-  { id: 'pharmacy', label: 'Pharmacy', icon: PharmacyIcon, badge: null, color: '#14B8A6' },
-  { id: 'imaging', label: 'Imaging', icon: ImagingIcon, badge: null, color: '#EF4444' },
-  { id: 'documentation', label: 'Documentation', icon: DocumentationIcon, badge: null, color: '#78716C' },
-  { id: 'care-plan', label: 'Care Plan', icon: CarePlanIcon, badge: null, color: '#EC4899' },
-  { id: 'timeline', label: 'Timeline', icon: TimelineIcon, badge: null, color: '#06B6D4' },
-];
+// Horizontal tab strip — derived from the single tab registry. `badge`
+// starts null; dynamic notification counts get layered on at render
+// time below.
+const NAVIGATION_ITEMS = CLINICAL_TABS.map((t) => ({
+  id: t.id,
+  label: t.label,
+  icon: t.icon,
+  color: t.color,
+  badge: null,
+}));
 
 const ClinicalTabs = ({
   activeTab,

--- a/frontend/src/components/clinical/utils/navigationHelper.js
+++ b/frontend/src/components/clinical/utils/navigationHelper.js
@@ -2,21 +2,22 @@
  * Navigation Helper for Clinical Workspace
  * Centralizes navigation logic and tab mappings
  * Part of Phase 3.1 - Fix Navigation Issues
+ *
+ * TAB_IDS / TAB_DISPLAY_NAMES / tab validity are now derived from the
+ * single tab registry (`workspace/clinicalTabRegistry`) — adding a tab
+ * there flows through here automatically. RESOURCE_TYPE_TO_TAB below is
+ * a separate concern (which tab owns a given FHIR resource type) and
+ * stays hand-maintained.
  */
 
-// Standard tab identifiers matching TAB_CONFIG in ClinicalWorkspaceEnhanced
-export const TAB_IDS = {
-  SUMMARY: 'summary',
-  CHART_REVIEW: 'chart-review',
-  ENCOUNTERS: 'encounters',
-  RESULTS: 'results',
-  ORDERS: 'orders',
-  PHARMACY: 'pharmacy',
-  IMAGING: 'imaging',
-  DOCUMENTATION: 'documentation',
-  CARE_PLAN: 'care-plan',
-  TIMELINE: 'timeline'
-};
+import {
+  TAB_IDS,
+  TAB_DISPLAY_NAMES,
+  isKnownTabId,
+} from '../workspace/clinicalTabRegistry';
+
+// Re-export so existing importers of `navigationHelper` keep working.
+export { TAB_IDS, TAB_DISPLAY_NAMES };
 
 // Resource type to tab mapping
 export const RESOURCE_TYPE_TO_TAB = {
@@ -52,20 +53,6 @@ export const RESOURCE_TYPE_TO_TAB = {
   'Procedure': TAB_IDS.CHART_REVIEW,
   'ImagingStudy': TAB_IDS.IMAGING,
   'Media': TAB_IDS.IMAGING
-};
-
-// Tab display names
-export const TAB_DISPLAY_NAMES = {
-  [TAB_IDS.SUMMARY]: 'Summary',
-  [TAB_IDS.CHART_REVIEW]: 'Chart Review',
-  [TAB_IDS.ENCOUNTERS]: 'Encounters',
-  [TAB_IDS.RESULTS]: 'Results',
-  [TAB_IDS.ORDERS]: 'Orders',
-  [TAB_IDS.PHARMACY]: 'Pharmacy',
-  [TAB_IDS.IMAGING]: 'Imaging',
-  [TAB_IDS.DOCUMENTATION]: 'Documentation',
-  [TAB_IDS.CARE_PLAN]: 'Care Plan',
-  [TAB_IDS.TIMELINE]: 'Timeline'
 };
 
 /**
@@ -156,7 +143,7 @@ export const getTabDisplayName = (tabId) => {
  * @returns {boolean} Whether the tab ID is valid
  */
 export const isValidTab = (tabId) => {
-  return Object.values(TAB_IDS).includes(tabId);
+  return isKnownTabId(tabId);
 };
 
 /**

--- a/frontend/src/components/clinical/workspace/clinicalTabRegistry.js
+++ b/frontend/src/components/clinical/workspace/clinicalTabRegistry.js
@@ -1,0 +1,180 @@
+/**
+ * Clinical workspace tab registry — the single source of truth.
+ *
+ * Before this file, adding a workspace tab meant editing FIVE places that
+ * each kept their own hardcoded list:
+ *   - ClinicalWorkspaceEnhanced.TAB_CONFIG   (id, label, icon, component)
+ *   - ClinicalTabs.NAVIGATION_ITEMS          (id, label, icon, color, badge)
+ *   - ClinicalSidebar.NAVIGATION_ITEMS       (id, label, icon, description, badge)
+ *   - EnhancedClinicalLayout.MODULES         (id, label, index)
+ *   - navigationHelper.TAB_IDS / TAB_DISPLAY_NAMES
+ *
+ * Adding the Administration tab (#116 Phase 5.1) tripped over three of
+ * those independently — each miss was a silent bug (tab missing from the
+ * strip; URL fell back to Summary). This registry collapses all five into
+ * one ordered array. Each consumer derives the shape it needs via the
+ * helper selectors below.
+ *
+ * To add a tab now: append one entry here. Nothing else.
+ *
+ * Import-graph note: this module imports React `lazy` and MUI icons.
+ * `lazy(() => import(...))` does NOT eagerly load the tab's code — the
+ * chunk is fetched on first render — so importing the registry stays
+ * cheap, and `navigationHelper` (imported very widely) can pull
+ * `TAB_IDS` from here without dragging in every tab's bundle.
+ */
+
+import { lazy } from 'react';
+import {
+  Dashboard as SummaryIcon,
+  Assignment as ChartReviewIcon,
+  Event as EncountersIcon,
+  Science as ResultsIcon,
+  LocalPharmacy as OrdersIcon,
+  Medication as PharmacyIcon,
+  CameraAlt as ImagingIcon,
+  Description as DocumentationIcon,
+  AccountTree as CarePlanIcon,
+  Timeline as TimelineIcon,
+} from '@mui/icons-material';
+
+/**
+ * The ordered tab list. Array order IS the tab order — `EnhancedClinicalLayout`
+ * derives its numeric index map from array position, so reordering here
+ * reorders the workspace.
+ *
+ * Field reference:
+ *   id          — URL `?tab=` value + internal activeTab key
+ *   label       — display text everywhere
+ *   icon        — MUI icon component (used by the tab strip + sidebar)
+ *   color       — accent color for the horizontal tab strip
+ *   description — sidebar secondary text
+ *   loader      — () => dynamic import of the tab's content component.
+ *                 Kept as a thunk (not a pre-built lazy component) so
+ *                 selectors that don't need the component — the sidebar,
+ *                 the layout — don't construct it.
+ */
+export const CLINICAL_TABS = [
+  {
+    id: 'summary',
+    label: 'Summary',
+    icon: SummaryIcon,
+    color: '#6366F1',
+    description: 'Patient overview and key metrics',
+    loader: () => import(/* webpackChunkName: "clinical-summary" */ './tabs/SummaryTab'),
+  },
+  {
+    id: 'chart-review',
+    label: 'Chart Review',
+    icon: ChartReviewIcon,
+    color: '#10B981',
+    description: 'Problems, medications, allergies, vitals',
+    loader: () => import(/* webpackChunkName: "clinical-chart-review" */ './tabs/ChartReviewTabOptimized'),
+  },
+  {
+    id: 'encounters',
+    label: 'Encounters',
+    icon: EncountersIcon,
+    color: '#3B82F6',
+    description: 'Visit history and notes',
+    loader: () => import(/* webpackChunkName: "clinical-encounters" */ './tabs/EncountersTab'),
+  },
+  {
+    id: 'results',
+    label: 'Results',
+    icon: ResultsIcon,
+    color: '#F59E0B',
+    description: 'Lab results and reports',
+    loader: () => import(/* webpackChunkName: "clinical-results" */ './tabs/ResultsTabOptimized'),
+  },
+  {
+    id: 'orders',
+    label: 'Orders',
+    icon: OrdersIcon,
+    color: '#8B5CF6',
+    description: 'Active and pending orders',
+    loader: () => import(/* webpackChunkName: "clinical-orders" */ './tabs/EnhancedOrdersTab'),
+  },
+  {
+    id: 'pharmacy',
+    label: 'Pharmacy',
+    icon: PharmacyIcon,
+    color: '#14B8A6',
+    description: 'Medication management',
+    loader: () => import(/* webpackChunkName: "clinical-pharmacy" */ './tabs/PharmacyTab'),
+  },
+  {
+    id: 'imaging',
+    label: 'Imaging',
+    icon: ImagingIcon,
+    color: '#EF4444',
+    description: 'Radiology and DICOM viewer',
+    loader: () => import(/* webpackChunkName: "clinical-imaging" */ './tabs/ImagingTab'),
+  },
+  {
+    id: 'documentation',
+    label: 'Documentation',
+    icon: DocumentationIcon,
+    color: '#78716C',
+    description: 'Clinical notes and forms',
+    loader: () => import(/* webpackChunkName: "clinical-documentation" */ './tabs/DocumentationTabEnhanced'),
+  },
+  {
+    id: 'care-plan',
+    label: 'Care Plan',
+    icon: CarePlanIcon,
+    color: '#EC4899',
+    description: 'Treatment plans and goals',
+    loader: () => import(/* webpackChunkName: "clinical-care-plan" */ './tabs/CarePlanTabEnhanced'),
+  },
+  {
+    id: 'timeline',
+    label: 'Timeline',
+    icon: TimelineIcon,
+    color: '#06B6D4',
+    description: 'Clinical history timeline',
+    loader: () => import(/* webpackChunkName: "clinical-timeline" */ './tabs/TimelineTabModern'),
+  },
+];
+
+// ---------------------------------------------------------------------
+// Derived selectors — each consumer takes only what it needs.
+// ---------------------------------------------------------------------
+
+/** Ordered list of tab id strings. */
+export const TAB_ID_LIST = CLINICAL_TABS.map((t) => t.id);
+
+/**
+ * Constant-style id map: `TAB_IDS.CHART_REVIEW === 'chart-review'`.
+ * Keys are the id upper-cased with hyphens → underscores. Preserves the
+ * shape `navigationHelper` exposed before this refactor so its existing
+ * consumers (RESOURCE_TYPE_TO_TAB etc.) don't change.
+ */
+export const TAB_IDS = Object.fromEntries(
+  CLINICAL_TABS.map((t) => [t.id.toUpperCase().replace(/-/g, '_'), t.id]),
+);
+
+/** id → display label. */
+export const TAB_DISPLAY_NAMES = Object.fromEntries(
+  CLINICAL_TABS.map((t) => [t.id, t.label]),
+);
+
+/** Whether a string is a registered tab id. */
+export const isKnownTabId = (id) => TAB_ID_LIST.includes(id);
+
+/** 0-based position of a tab in the workspace order, or -1. */
+export const getTabIndex = (id) => TAB_ID_LIST.indexOf(id);
+
+/**
+ * Build the lazy-loaded content-routing config for ClinicalWorkspaceEnhanced.
+ * Each entry's `component` is a `React.lazy` wrapper around the tab's loader.
+ * Constructed on demand (not at module scope) so consumers that never render
+ * tab content don't pay for it.
+ */
+export const buildTabContentConfig = () =>
+  CLINICAL_TABS.map((t) => ({
+    id: t.id,
+    label: t.label,
+    icon: t.icon,
+    component: lazy(t.loader),
+  }));


### PR DESCRIPTION
## Summary

The clinical workspace tab list was hardcoded in **five** places, each with its own shape. Adding the Administration tab in Phase 5.1 tripped over three of them independently — every miss was a silent bug (tab absent from the strip; URL silently falling back to Summary). A new tab shouldn't need five coordinated edits.

This collapses all five into one ordered registry: **`frontend/src/components/clinical/workspace/clinicalTabRegistry.js`**.

### Before — five hardcoded lists
| File | Shape |
|------|-------|
| `ClinicalWorkspaceEnhanced.TAB_CONFIG` | id, label, icon, lazy component |
| `ClinicalTabs.NAVIGATION_ITEMS` | id, label, icon, color, badge |
| `ClinicalSidebar.NAVIGATION_ITEMS` | id, label, icon, description, badge |
| `EnhancedClinicalLayout.MODULES` | id, label, index |
| `navigationHelper.TAB_IDS` / `TAB_DISPLAY_NAMES` | id constants + id→label |

### After — one registry, five derived consumers
`CLINICAL_TABS` is the ordered array. Selectors: `TAB_IDS`, `TAB_DISPLAY_NAMES`, `TAB_ID_LIST`, `isKnownTabId`, `getTabIndex`, `buildTabContentConfig`.

- **ClinicalWorkspaceEnhanced** — `TAB_CONFIG = buildTabContentConfig()`; deleted 10 hand-written `React.lazy` blocks + 10 dead icon imports.
- **ClinicalTabs / ClinicalSidebar** — `NAVIGATION_ITEMS` is now a `.map()` of the registry; deleted their icon-import blocks.
- **EnhancedClinicalLayout** — `MODULES` derived; `index` = array position.
- **navigationHelper** — `TAB_IDS`/`TAB_DISPLAY_NAMES` re-exported from the registry; `isValidTab` delegates to `isKnownTabId`. `RESOURCE_TYPE_TO_TAB` stays hand-maintained (separate concern).

**Adding a tab is now one `CLINICAL_TABS` entry.**

### Notes for the reviewer
- **webpackChunkName preserved** — local `npm run build` still emits `clinical-summary` / `clinical-orders` / `clinical-timeline` / etc. chunks.
- **No circular import** — the registry's `loader` thunks defer the tab modules, so `navigationHelper → registry` resolves without pulling tab code.
- **Icon reconciliation** — `ClinicalWorkspaceEnhanced` previously used `ListAlt`/`LocalPharmacy` for Orders/Pharmacy while the visible nav used `LocalPharmacy`/`Medication`. The registry standardizes on the visible-nav set (TAB_CONFIG's icons weren't rendered anyway).
- **Dropped placeholder badges** — `ClinicalSidebar`'s static `results:'new' / orders:3 / imaging:2` were demo cruft, not real counts. Dynamic notification badges still layer on at render.

### Sequencing
This PR is 10 tabs (master's current set). It merges **before #149** — afterward #149 gets rebased so its Administration tab collapses from "edit 5 nav files" to **one `CLINICAL_TABS` entry**, which also serves as the proof the registry works.

## Test plan
- [x] `npm run build` compiles clean; chunk names verified in `build/static/js/`
- [x] `npx eslint` over all 6 files — 0 errors
- [ ] Manual on prod: open a patient → all 10 workspace tabs render in the strip, the sidebar, and switch correctly; deep-link `?tab=timeline` lands on Timeline (not Summary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)