### PR TITLE
fix(timeline): use correct per-resource FHIR date search params

### DIFF
--- a/frontend/src/components/clinical/workspace/tabs/TimelineTabModern.js
+++ b/frontend/src/components/clinical/workspace/tabs/TimelineTabModern.js
@@ -890,8 +890,10 @@ const TimelineTabModern = ({ patientId, patient, onNavigateToTab }) => {
         setLoadingError(null);
         
         const promises = Array.from(selectedTypes).map(async (resourceType) => {
-          // Get the correct HAPI FHIR search parameter name for date filtering and sorting
-          // Each resource type has specific valid search parameters
+          // Each FHIR resource type names its date search parameter differently;
+          // sending the wrong one makes HAPI reject the whole query (HAPI-0524).
+          // A few types (e.g. Coverage) have no date parameter at all — `null`
+          // means "skip date filtering and date sorting for this type".
           const dateParam = (() => {
             switch (resourceType) {
               case 'Condition': return 'recorded-date';
@@ -903,7 +905,11 @@ const TimelineTabModern = ({ patientId, patient, onNavigateToTab }) => {
               case 'Immunization': return 'date';
               case 'DocumentReference': return 'date';
               case 'DiagnosticReport': return 'date';
-              case 'AllergyIntolerance': return 'recorded-date';
+              case 'CarePlan': return 'date';
+              case 'AllergyIntolerance': return 'date';
+              case 'ImagingStudy': return 'started';
+              case 'Goal': return 'start-date';
+              case 'Coverage': return null; // no date search parameter
               default: return 'date';
             }
           })();
@@ -911,10 +917,10 @@ const TimelineTabModern = ({ patientId, patient, onNavigateToTab }) => {
           const params = {
             patient: patientId,
             _count: 100, // Load more resources for better timeline
-            _sort: `-${dateParam}` // Use the same valid parameter for sorting (descending)
+            ...(dateParam ? { _sort: `-${dateParam}` } : {})
           };
 
-          if (dateRange.start && dateRange.end) {
+          if (dateParam && dateRange.start && dateRange.end) {
             // Use array for proper FHIR query encoding (avoids URL-encoding & in values)
             params[dateParam] = [
               `ge${dateRange.start.toISOString().split('T')[0]}`,


### PR DESCRIPTION
## Summary
- Timeline tab queried `AllergyIntolerance` with `recorded-date` and let `ImagingStudy`, `Goal`, and `Coverage` fall through to a generic `date` search parameter. HAPI rejected all four with `HAPI-0524: Unknown search parameter`, so those resource types silently failed to load on the Timeline.
- Map each resource type to its real FHIR date parameter: `AllergyIntolerance`→`date`, `ImagingStudy`→`started`, `Goal`→`start-date`, `CarePlan`→`date`.
- `Coverage` has no date search parameter at all — return `null` and skip both the date filter and the `_sort` for such types instead of sending an invalid param.

## Test plan
- [ ] Open a patient with allergies/imaging/goals/coverage, go to the Timeline tab
- [ ] Confirm no `HAPI-0524` 400 errors in the console
- [ ] Confirm AllergyIntolerance, ImagingStudy, Goal, Coverage events appear on the timeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)