### PR TITLE
fix(dashboard): drop invalid `code` search param on Flag query

### DIFF
--- a/frontend/src/services/dashboard/dashboardDataService.js
+++ b/frontend/src/services/dashboard/dashboardDataService.js
@@ -302,12 +302,21 @@ class DashboardDataService {
         _count: 100
       });
 
-      // Get fall incidents from AdverseEvent or Flag resources
-      const falls = await fhirClient.search('Flag', {
-        code: 'fall-risk,patient-fall',
+      // Get fall incidents from Flag resources. Flag has no `code` search
+      // parameter in FHIR R4, so fetch by date and filter on code client-side.
+      const flagsForFalls = await fhirClient.search('Flag', {
         date: `ge${thirtyDaysAgo.toISOString()}`,
         _count: 100
       });
+      const isFallFlag = (flag) => {
+        const codeText = flag.code?.text?.toLowerCase() || '';
+        const codings = flag.code?.coding || [];
+        return codeText.includes('fall') ||
+               codings.some(c =>
+                 (c.code || '').toLowerCase().includes('fall') ||
+                 (c.display || '').toLowerCase().includes('fall'));
+      };
+      const fallFlags = (flagsForFalls.resources || []).filter(isFallFlag);
 
       // Get medication errors from AdverseEvent
       const medErrors = await fhirClient.search('AdverseEvent', {
@@ -325,7 +334,7 @@ class DashboardDataService {
 
       // Calculate rates
       const haiCount = infections.total || 0;
-      const fallCount = falls.total || 0;
+      const fallCount = fallFlags.length;
       const medErrorCount = medErrors.total || 0;
       const pressureInjuryCount = pressureInjuries.total || 0;
 


### PR DESCRIPTION
## Summary
- The quality-metrics dashboard fetch searched `Flag` with `code=fall-risk,patient-fall`. FHIR R4 `Flag` has no `code` search parameter, so HAPI rejected the query with `HAPI-0524: Unknown search parameter "code"` and fall-incident metrics silently failed.
- Fetch `Flag` resources by `date` only and filter for fall-related codes client-side — the same pattern already used for the drug/allergy flag queries later in the same function.
- Count from the filtered list rather than `Bundle.total` (which would have counted every flag in the window).

## Test plan
- [ ] Load the quality-metrics dashboard
- [ ] Confirm no `HAPI-0524` 400 error for `Flag` in the console
- [ ] Confirm the fall-rate metric renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)