### PR TITLE
feat(mar): Tasks pane for non-medication recording (#116 Phase 5.2)

### DIFF
--- a/backend/api/clinical/administration/router.py
+++ b/backend/api/clinical/administration/router.py
@@ -37,6 +37,7 @@ from services.hapi_fhir_client import HAPIFHIRClient
 
 from .service import (
     ADMINISTRABLE_STATUSES,
+    IMMUNIZATION_ORDER_EXTENSION,
     get_administration_tasks,
     get_scheduled_tasks,
 )
@@ -428,7 +429,11 @@ async def record_immunization_endpoint(body: RecordImmunizationRequest) -> Recor
         "patient": service_request.get("subject") or {},
         "occurrenceDateTime": occurrence.isoformat(),
         "recorded": datetime.now(timezone.utc).isoformat(),
-        "basedOn": [{"reference": f"ServiceRequest/{body.service_request_id}"}],
+        # R4 Immunization has no `basedOn`; carry the order link on an extension.
+        "extension": [{
+            "url": IMMUNIZATION_ORDER_EXTENSION,
+            "valueReference": {"reference": f"ServiceRequest/{body.service_request_id}"},
+        }],
     }
     if service_request.get("encounter"):
         immunization["encounter"] = service_request["encounter"]

--- a/backend/api/clinical/administration/router.py
+++ b/backend/api/clinical/administration/router.py
@@ -1,17 +1,26 @@
 """
-Administration Record (MAR) router — #116 Phase 5.1.
+Administration Record (MAR) router — #116 Phase 5.1 + 5.2.
 
-Two endpoints:
+Endpoints (all under `/api/clinical/administration`):
 
-- `GET /api/clinical/administration/scheduled-tasks?patient_id=...&window_start=...&window_end=...`
-  Returns the MAR payload: scheduled doses (with admin matches), PRN orders,
-  unscheduled admins. Pure read, no DB writes.
+- `GET /scheduled-tasks?patient_id=...&window_start=...&window_end=...`
+  MAR grid payload: scheduled doses (with admin matches), PRN orders,
+  unscheduled admins. Pure read.
 
-- `POST /api/clinical/administration/record`
-  Creates a MedicationAdministration resource in HAPI. Refuses orders where
-  `status` is not in `ADMINISTRABLE_STATUSES` (mirrors the pharmacy dispense
-  gate from PR #139 — same philosophy: a draft order is not yet a real
-  instruction and must not produce a recorded administration).
+- `GET /tasks?patient_id=...`  (Phase 5.2)
+  Tasks-pane payload: pending non-medication recording tasks, bucketed into
+  immunization / specimen / procedure ServiceRequest orders.
+
+- `POST /record`
+  Creates a MedicationAdministration against a signed MedicationRequest.
+
+- `POST /record/immunization`, `/record/specimen`, `/record/procedure`  (Phase 5.2)
+  Records a non-medication clinical event (Immunization / Specimen /
+  Procedure) against its signed ServiceRequest order.
+
+Every record endpoint refuses orders whose `status` is not in
+`ADMINISTRABLE_STATUSES` (mirrors the pharmacy dispense gate from PR #139 —
+a draft order is not yet a real instruction and must not produce a record).
 """
 
 from __future__ import annotations
@@ -26,7 +35,11 @@ from pydantic import BaseModel, Field
 
 from services.hapi_fhir_client import HAPIFHIRClient
 
-from .service import ADMINISTRABLE_STATUSES, get_scheduled_tasks
+from .service import (
+    ADMINISTRABLE_STATUSES,
+    get_administration_tasks,
+    get_scheduled_tasks,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -124,6 +137,25 @@ async def scheduled_tasks_endpoint(
         "scheduled": bundle.scheduled,
         "prn_orders": bundle.prn_orders,
         "unscheduled_admins": bundle.unscheduled_admins,
+    }
+
+
+@router.get("/tasks")
+async def administration_tasks_endpoint(
+    patient_id: str = Query(..., description="Bare patient FHIR id (no 'Patient/' prefix)"),
+) -> dict[str, Any]:
+    """Tasks-pane payload: pending non-medication recording tasks (#116 Phase 5.2).
+
+    Returns active ServiceRequest orders bucketed into immunization /
+    specimen / procedure tasks, each flagged `fulfilled` when a recording
+    resource already links back to the order.
+    """
+    bundle = await get_administration_tasks(patient_id)
+    return {
+        "patient_id": bundle.patient_id,
+        "immunizations": bundle.immunizations,
+        "specimens": bundle.specimens,
+        "procedures": bundle.procedures,
     }
 
 
@@ -269,3 +301,260 @@ async def record_administration_endpoint(body: RecordAdministrationRequest) -> R
         status=fhir_status,
         effective_datetime=effective,
     )
+
+
+# =====================================================================
+# Phase 5.2 — non-medication recording (Immunization / Specimen / Procedure)
+# =====================================================================
+
+
+class RecordImmunizationRequest(BaseModel):
+    """Body for POST /record/immunization."""
+
+    service_request_id: str = Field(..., description="The signed ServiceRequest immunization order")
+    status: Literal["completed", "not-done", "entered-in-error"] = "completed"
+    occurrence_datetime: Optional[datetime] = Field(None, description="When given; defaults to now")
+    lot_number: Optional[str] = None
+    expiration_date: Optional[str] = Field(None, description="Vaccine lot expiration (FHIR date)")
+    route: Optional[str] = Field(None, description="Route, e.g. IM/SC/IN")
+    site: Optional[str] = Field(None, description="Body site, e.g. left deltoid")
+    dose_value: Optional[float] = Field(None, description="Dose quantity")
+    dose_unit: Optional[str] = Field(None, description="Dose unit, e.g. mL")
+    performer_reference: Optional[str] = Field(None, description="Practitioner/{id}; defaults to current user")
+    reaction: Optional[str] = Field(None, description="Free-text adverse reaction, if any")
+    status_reason: Optional[str] = Field(None, description="Required when status='not-done'")
+    notes: Optional[str] = None
+
+
+class RecordSpecimenRequest(BaseModel):
+    """Body for POST /record/specimen."""
+
+    service_request_id: str = Field(..., description="The signed ServiceRequest lab order")
+    specimen_type: Optional[str] = Field(None, description="Specimen type text; defaults to the order's code")
+    collected_datetime: Optional[datetime] = Field(None, description="When collected; defaults to now")
+    collector_reference: Optional[str] = Field(None, description="Practitioner/{id}; defaults to current user")
+    body_site: Optional[str] = Field(None, description="Collection body site")
+    container: Optional[str] = Field(None, description="Container type, e.g. EDTA tube")
+    quantity_value: Optional[float] = Field(None, description="Collected quantity")
+    quantity_unit: Optional[str] = Field(None, description="Quantity unit, e.g. mL")
+    notes: Optional[str] = None
+
+
+class RecordProcedureRequest(BaseModel):
+    """Body for POST /record/procedure."""
+
+    service_request_id: str = Field(..., description="The signed ServiceRequest procedure order")
+    status: Literal["completed", "in-progress", "not-done"] = "completed"
+    performed_datetime: Optional[datetime] = Field(None, description="When performed; defaults to now")
+    performer_reference: Optional[str] = Field(None, description="Practitioner/{id}; defaults to current user")
+    outcome: Optional[str] = Field(None, description="Procedure outcome, e.g. successful")
+    complication: Optional[str] = Field(None, description="Free-text complication, if any")
+    status_reason: Optional[str] = Field(None, description="Required when status='not-done'")
+    notes: Optional[str] = None
+
+
+class RecordTaskResponse(BaseModel):
+    """Shared response for the three Phase 5.2 record endpoints."""
+
+    resource_id: str
+    resource_type: str
+    status: str
+
+
+async def _read_administrable_service_request(
+    hapi: HAPIFHIRClient,
+    service_request_id: str,
+) -> dict[str, Any]:
+    """Read a ServiceRequest and enforce the administrability status gate.
+
+    Mirrors the MedicationRequest gate in `record_administration_endpoint`:
+    a draft (unsigned) or revoked order must not produce a recorded event.
+    """
+    service_request = await hapi.read("ServiceRequest", service_request_id)
+    if not service_request:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail=f"ServiceRequest/{service_request_id} not found",
+        )
+    order_status = service_request.get("status")
+    if order_status not in ADMINISTRABLE_STATUSES:
+        raise HTTPException(
+            status_code=http_status.HTTP_409_CONFLICT,
+            detail=(
+                f"Cannot record against ServiceRequest in status '{order_status}'. "
+                f"The order must be signed (status='active') before recording."
+            ),
+        )
+    return service_request
+
+
+async def _create_or_500(hapi: HAPIFHIRClient, resource_type: str, resource: dict[str, Any]) -> dict[str, Any]:
+    """Write a resource to HAPI, mapping any failure to a 500 (logged)."""
+    try:
+        return await hapi.create(resource_type, resource)
+    except Exception as exc:
+        logger.error("Failed to create %s: %s", resource_type, exc, exc_info=True)
+        raise HTTPException(
+            status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to record {resource_type}: {exc}",
+        ) from exc
+
+
+@router.post(
+    "/record/immunization",
+    response_model=RecordTaskResponse,
+    status_code=http_status.HTTP_201_CREATED,
+)
+async def record_immunization_endpoint(body: RecordImmunizationRequest) -> RecordTaskResponse:
+    """Record an `Immunization` against a signed immunization ServiceRequest."""
+    hapi = HAPIFHIRClient()
+    service_request = await _read_administrable_service_request(hapi, body.service_request_id)
+
+    if body.status == "not-done" and not body.status_reason:
+        raise HTTPException(
+            status_code=http_status.HTTP_400_BAD_REQUEST,
+            detail="A status_reason is required when status='not-done'.",
+        )
+
+    occurrence = body.occurrence_datetime or datetime.now(timezone.utc)
+    if occurrence.tzinfo is None:
+        occurrence = occurrence.replace(tzinfo=timezone.utc)
+
+    immunization: dict[str, Any] = {
+        "resourceType": "Immunization",
+        "status": body.status,
+        # The order's `code` carries the CVX coding the prescriber chose.
+        "vaccineCode": service_request.get("code") or {"text": "Unspecified vaccine"},
+        "patient": service_request.get("subject") or {},
+        "occurrenceDateTime": occurrence.isoformat(),
+        "recorded": datetime.now(timezone.utc).isoformat(),
+        "basedOn": [{"reference": f"ServiceRequest/{body.service_request_id}"}],
+    }
+    if service_request.get("encounter"):
+        immunization["encounter"] = service_request["encounter"]
+    if body.lot_number:
+        immunization["lotNumber"] = body.lot_number
+    if body.expiration_date:
+        immunization["expirationDate"] = body.expiration_date
+    if body.route:
+        immunization["route"] = {"text": body.route}
+    if body.site:
+        immunization["site"] = {"text": body.site}
+    if body.dose_value is not None and body.dose_unit:
+        immunization["doseQuantity"] = {
+            "value": body.dose_value,
+            "unit": body.dose_unit,
+            "system": "http://unitsofmeasure.org",
+            "code": body.dose_unit,
+        }
+    immunization["performer"] = [{
+        "actor": {"reference": body.performer_reference or "Practitioner/demo-physician"},
+    }]
+    if body.status == "not-done":
+        immunization["statusReason"] = {"text": body.status_reason}
+
+    # FHIR R4 Immunization.reaction.detail references an Observation; for the
+    # educational use case a free-text reaction is recorded as a note rather
+    # than spawning a dangling Observation reference.
+    notes: list[dict[str, Any]] = []
+    if body.reaction:
+        notes.append({"text": f"Reaction: {body.reaction}"})
+    if body.notes:
+        notes.append({"text": body.notes})
+    if notes:
+        immunization["note"] = notes
+
+    created = await _create_or_500(hapi, "Immunization", immunization)
+    new_id = created.get("id")
+    logger.info("Recorded Immunization/%s for ServiceRequest/%s", new_id, body.service_request_id)
+    return RecordTaskResponse(resource_id=new_id, resource_type="Immunization", status=body.status)
+
+
+@router.post(
+    "/record/specimen",
+    response_model=RecordTaskResponse,
+    status_code=http_status.HTTP_201_CREATED,
+)
+async def record_specimen_endpoint(body: RecordSpecimenRequest) -> RecordTaskResponse:
+    """Record a `Specimen` collection against a signed lab ServiceRequest."""
+    hapi = HAPIFHIRClient()
+    service_request = await _read_administrable_service_request(hapi, body.service_request_id)
+
+    collected = body.collected_datetime or datetime.now(timezone.utc)
+    if collected.tzinfo is None:
+        collected = collected.replace(tzinfo=timezone.utc)
+
+    specimen: dict[str, Any] = {
+        "resourceType": "Specimen",
+        "status": "available",
+        "type": {"text": body.specimen_type} if body.specimen_type else (service_request.get("code") or {}),
+        "subject": service_request.get("subject") or {},
+        "receivedTime": datetime.now(timezone.utc).isoformat(),
+        "request": [{"reference": f"ServiceRequest/{body.service_request_id}"}],
+    }
+    collection: dict[str, Any] = {"collectedDateTime": collected.isoformat()}
+    collection["collector"] = {
+        "reference": body.collector_reference or "Practitioner/demo-physician",
+    }
+    if body.body_site:
+        collection["bodySite"] = {"text": body.body_site}
+    if body.quantity_value is not None and body.quantity_unit:
+        collection["quantity"] = {"value": body.quantity_value, "unit": body.quantity_unit}
+    specimen["collection"] = collection
+    if body.container:
+        specimen["container"] = [{"type": {"text": body.container}}]
+    if body.notes:
+        specimen["note"] = [{"text": body.notes}]
+
+    created = await _create_or_500(hapi, "Specimen", specimen)
+    new_id = created.get("id")
+    logger.info("Recorded Specimen/%s for ServiceRequest/%s", new_id, body.service_request_id)
+    return RecordTaskResponse(resource_id=new_id, resource_type="Specimen", status="available")
+
+
+@router.post(
+    "/record/procedure",
+    response_model=RecordTaskResponse,
+    status_code=http_status.HTTP_201_CREATED,
+)
+async def record_procedure_endpoint(body: RecordProcedureRequest) -> RecordTaskResponse:
+    """Record a `Procedure` against a signed procedure ServiceRequest."""
+    hapi = HAPIFHIRClient()
+    service_request = await _read_administrable_service_request(hapi, body.service_request_id)
+
+    if body.status == "not-done" and not body.status_reason:
+        raise HTTPException(
+            status_code=http_status.HTTP_400_BAD_REQUEST,
+            detail="A status_reason is required when status='not-done'.",
+        )
+
+    performed = body.performed_datetime or datetime.now(timezone.utc)
+    if performed.tzinfo is None:
+        performed = performed.replace(tzinfo=timezone.utc)
+
+    procedure: dict[str, Any] = {
+        "resourceType": "Procedure",
+        "status": body.status,
+        "code": service_request.get("code") or {"text": "Unspecified procedure"},
+        "subject": service_request.get("subject") or {},
+        "performedDateTime": performed.isoformat(),
+        "basedOn": [{"reference": f"ServiceRequest/{body.service_request_id}"}],
+    }
+    if service_request.get("encounter"):
+        procedure["encounter"] = service_request["encounter"]
+    procedure["performer"] = [{
+        "actor": {"reference": body.performer_reference or "Practitioner/demo-physician"},
+    }]
+    if body.outcome:
+        procedure["outcome"] = {"text": body.outcome}
+    if body.complication:
+        procedure["complication"] = [{"text": body.complication}]
+    if body.status == "not-done":
+        procedure["statusReason"] = {"text": body.status_reason}
+    if body.notes:
+        procedure["note"] = [{"text": body.notes}]
+
+    created = await _create_or_500(hapi, "Procedure", procedure)
+    new_id = created.get("id")
+    logger.info("Recorded Procedure/%s for ServiceRequest/%s", new_id, body.service_request_id)
+    return RecordTaskResponse(resource_id=new_id, resource_type="Procedure", status=body.status)

--- a/backend/api/clinical/administration/service.py
+++ b/backend/api/clinical/administration/service.py
@@ -47,6 +47,12 @@ TASK_CATEGORY_IMMUNIZATION = frozenset({"33879002", "immunization"})
 TASK_CATEGORY_SPECIMEN = frozenset({"108252007", "laboratory", "laboratory-procedure"})
 TASK_CATEGORY_PROCEDURE = frozenset({"387713003", "procedure"})
 
+# FHIR R4 `Immunization` has no `basedOn` element (it was added in R5).
+# To still link a recorded Immunization back to its ordering ServiceRequest
+# we carry the reference on this custom extension. Procedure (`basedOn`) and
+# Specimen (`request`) use their native R4 elements — no extension needed.
+IMMUNIZATION_ORDER_EXTENSION = "http://wintehr.local/fhir/StructureDefinition/immunization-order"
+
 
 @dataclass(frozen=True)
 class AdminRecord:
@@ -181,8 +187,10 @@ async def get_administration_tasks(patient_id: str) -> AdministrationTasksBundle
     )
 
     # ServiceRequest id -> id of the recording resource that fulfils it.
-    # Immunization/Procedure link via `basedOn`, Specimen via `request`.
-    imm_by_order = _fulfillment_map(imm_bundle, "basedOn")
+    # Procedure links via `basedOn`, Specimen via `request` (both native R4
+    # elements); Immunization has no R4 order element so it links via the
+    # `IMMUNIZATION_ORDER_EXTENSION` extension.
+    imm_by_order = _immunization_fulfillment_map(imm_bundle)
     spec_by_order = _fulfillment_map(spec_bundle, "request")
     proc_by_order = _fulfillment_map(proc_bundle, "basedOn")
 
@@ -428,6 +436,27 @@ def _fulfillment_map(bundle: dict[str, Any], ref_field: str) -> dict[str, str]:
             if target.startswith("ServiceRequest/"):
                 # First fulfilment wins — a re-recorded order is rare and the
                 # pane only needs *a* link to flip the card to "done".
+                out.setdefault(target.split("/", 1)[1], res_id)
+    return out
+
+
+def _immunization_fulfillment_map(bundle: dict[str, Any]) -> dict[str, str]:
+    """Map ServiceRequest id -> Immunization id via `IMMUNIZATION_ORDER_EXTENSION`.
+
+    Separate from `_fulfillment_map` because R4 Immunization carries the order
+    link on an extension rather than a `basedOn`/`request` element.
+    """
+    out: dict[str, str] = {}
+    for entry in _entries(bundle):
+        res = entry.get("resource") or {}
+        res_id = res.get("id")
+        if not res_id:
+            continue
+        for ext in res.get("extension") or []:
+            if ext.get("url") != IMMUNIZATION_ORDER_EXTENSION:
+                continue
+            target = (ext.get("valueReference") or {}).get("reference") or ""
+            if target.startswith("ServiceRequest/"):
                 out.setdefault(target.split("/", 1)[1], res_id)
     return out
 

--- a/backend/api/clinical/administration/service.py
+++ b/backend/api/clinical/administration/service.py
@@ -38,6 +38,15 @@ ADMINISTRABLE_STATUSES = frozenset({"active", "completed"})
 # scheduled time. Adjust later if a specific facility policy demands tighter.
 ADMIN_MATCH_WINDOW = timedelta(minutes=60)
 
+# ServiceRequest.category codings the Order Composer emits for the three
+# non-medication task types the MAR Tasks pane (#116 Phase 5.2) records
+# against. Matching is tolerant: a code OR a lower-cased category text.
+# Immunization orders use SNOMED 33879002 (ImmunizationOrderTab); lab
+# orders SNOMED 108252007; procedure orders SNOMED 387713003.
+TASK_CATEGORY_IMMUNIZATION = frozenset({"33879002", "immunization"})
+TASK_CATEGORY_SPECIMEN = frozenset({"108252007", "laboratory", "laboratory-procedure"})
+TASK_CATEGORY_PROCEDURE = frozenset({"387713003", "procedure"})
+
 
 @dataclass(frozen=True)
 class AdminRecord:
@@ -67,6 +76,22 @@ class ScheduledTaskBundle:
     prn_orders: list[dict[str, Any]]
     # Admins that didn't match any scheduled time (late-charted unsolicited doses)
     unscheduled_admins: list[dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class AdministrationTasksBundle:
+    """Non-medication recording tasks for the MAR Tasks pane (#116 Phase 5.2).
+
+    Each list holds the active ServiceRequest orders of one task type, with a
+    `fulfilled` flag set when a recording resource already references the
+    order. The frontend renders pending tasks as actionable cards and
+    fulfilled ones as a muted "done" row.
+    """
+
+    patient_id: str
+    immunizations: list[dict[str, Any]]
+    specimens: list[dict[str, Any]]
+    procedures: list[dict[str, Any]]
 
 
 async def get_scheduled_tasks(
@@ -134,6 +159,55 @@ async def get_scheduled_tasks(
         scheduled=sorted(scheduled, key=lambda s: (s["scheduled_time"], s["medication_request_id"])),
         prn_orders=prn_orders,
         unscheduled_admins=unscheduled_admins,
+    )
+
+
+async def get_administration_tasks(patient_id: str) -> AdministrationTasksBundle:
+    """Build the Tasks-pane payload: pending non-medication recording tasks.
+
+    Parallel-queries the patient's ServiceRequests and the three recording
+    resource types (Immunization / Specimen / Procedure), buckets the
+    ServiceRequests by category coding, and marks each order fulfilled when a
+    recording resource already links back to it. Pure read — no DB writes.
+    """
+    hapi = HAPIFHIRClient()
+
+    sr_bundle, imm_bundle, spec_bundle, proc_bundle = await _parallel_search(
+        hapi,
+        ("ServiceRequest", {"patient": f"Patient/{patient_id}", "_count": 200}),
+        ("Immunization", {"patient": f"Patient/{patient_id}", "_count": 200}),
+        ("Specimen", {"patient": f"Patient/{patient_id}", "_count": 200}),
+        ("Procedure", {"patient": f"Patient/{patient_id}", "_count": 200}),
+    )
+
+    # ServiceRequest id -> id of the recording resource that fulfils it.
+    # Immunization/Procedure link via `basedOn`, Specimen via `request`.
+    imm_by_order = _fulfillment_map(imm_bundle, "basedOn")
+    spec_by_order = _fulfillment_map(spec_bundle, "request")
+    proc_by_order = _fulfillment_map(proc_bundle, "basedOn")
+
+    immunizations: list[dict[str, Any]] = []
+    specimens: list[dict[str, Any]] = []
+    procedures: list[dict[str, Any]] = []
+
+    for entry in _entries(sr_bundle):
+        sr = entry.get("resource") or {}
+        if sr.get("status") not in ADMINISTRABLE_STATUSES:
+            # Unsigned (draft) or revoked orders are not actionable tasks.
+            continue
+        codes = _sr_category_codes(sr)
+        if codes & TASK_CATEGORY_IMMUNIZATION:
+            immunizations.append(_render_task(sr, imm_by_order, "immunization"))
+        elif codes & TASK_CATEGORY_SPECIMEN:
+            specimens.append(_render_task(sr, spec_by_order, "specimen"))
+        elif codes & TASK_CATEGORY_PROCEDURE:
+            procedures.append(_render_task(sr, proc_by_order, "procedure"))
+
+    return AdministrationTasksBundle(
+        patient_id=patient_id,
+        immunizations=_sort_tasks(immunizations),
+        specimens=_sort_tasks(specimens),
+        procedures=_sort_tasks(procedures),
     )
 
 
@@ -321,3 +395,76 @@ def _indication_text(med_request: dict[str, Any]) -> Optional[str]:
     reason_code = (med_request.get("reasonCode") or [{}])[0]
     text = reason_code.get("text") or (reason_code.get("coding") or [{}])[0].get("display")
     return text or None
+
+
+def _sr_category_codes(sr: dict[str, Any]) -> set[str]:
+    """Collect every category coding `code` plus lower-cased category `text`."""
+    codes: set[str] = set()
+    for cat in sr.get("category") or []:
+        for coding in cat.get("coding") or []:
+            code = coding.get("code")
+            if code:
+                codes.add(code)
+        text = cat.get("text")
+        if text:
+            codes.add(text.strip().lower())
+    return codes
+
+
+def _fulfillment_map(bundle: dict[str, Any], ref_field: str) -> dict[str, str]:
+    """Map ServiceRequest id -> id of a resource whose `ref_field` points at it.
+
+    `ref_field` is `basedOn` (Immunization/Procedure) or `request` (Specimen);
+    both are lists of FHIR References.
+    """
+    out: dict[str, str] = {}
+    for entry in _entries(bundle):
+        res = entry.get("resource") or {}
+        res_id = res.get("id")
+        if not res_id:
+            continue
+        for ref in res.get(ref_field) or []:
+            target = (ref or {}).get("reference") or ""
+            if target.startswith("ServiceRequest/"):
+                # First fulfilment wins — a re-recorded order is rare and the
+                # pane only needs *a* link to flip the card to "done".
+                out.setdefault(target.split("/", 1)[1], res_id)
+    return out
+
+
+def _render_task(
+    sr: dict[str, Any],
+    fulfillment_map: dict[str, str],
+    task_type: str,
+) -> dict[str, Any]:
+    sr_id = sr.get("id")
+    code = sr.get("code") or {}
+    first_coding = (code.get("coding") or [{}])[0]
+    code_display = (
+        code.get("text")
+        or first_coding.get("display")
+        or "(unspecified)"
+    )
+    fulfillment_id = fulfillment_map.get(sr_id)
+    return {
+        "service_request_id": sr_id,
+        "task_type": task_type,
+        "code": first_coding.get("code"),
+        "code_system": first_coding.get("system"),
+        "code_display": code_display,
+        "ordered_datetime": sr.get("authoredOn"),
+        "priority": sr.get("priority"),
+        "order_status": sr.get("status"),
+        "fulfilled": fulfillment_id is not None,
+        "fulfillment_id": fulfillment_id,
+    }
+
+
+def _sort_tasks(tasks: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Pending tasks first, each group most-recently-ordered first."""
+    def _ordered(t: dict[str, Any]) -> str:
+        return t.get("ordered_datetime") or ""
+
+    pending = sorted((t for t in tasks if not t["fulfilled"]), key=_ordered, reverse=True)
+    done = sorted((t for t in tasks if t["fulfilled"]), key=_ordered, reverse=True)
+    return pending + done

--- a/backend/tests/api/clinical/administration/test_tasks_router.py
+++ b/backend/tests/api/clinical/administration/test_tasks_router.py
@@ -1,0 +1,296 @@
+"""
+Tests for the Administration Tasks-pane endpoints (#116 Phase 5.2).
+
+Covers:
+- GET  /api/clinical/administration/tasks
+- POST /api/clinical/administration/record/immunization
+- POST /api/clinical/administration/record/specimen
+- POST /api/clinical/administration/record/procedure
+
+The router is the system boundary; the HAPI client is mocked so these run
+without a live FHIR server. The GET endpoint exercises the service-layer
+bucketing/fulfilment logic; the POST endpoints exercise the status gate and
+the FHIR resource shape written to HAPI.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.clinical.administration.router import router
+
+
+@pytest.fixture
+def client():
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------
+
+# SNOMED category codings the Order Composer emits per task type.
+_CATEGORY = {
+    "immunization": "33879002",
+    "specimen": "108252007",
+    "procedure": "387713003",
+}
+
+
+def service_request(
+    sr_id: str = "sr-1",
+    task: str = "immunization",
+    status: str = "active",
+    authored_on: str = "2026-05-14T08:00:00+00:00",
+    code_display: str = "Influenza vaccine",
+    code_value: str = "140",
+) -> dict:
+    return {
+        "resourceType": "ServiceRequest",
+        "id": sr_id,
+        "status": status,
+        "intent": "order",
+        "authoredOn": authored_on,
+        "priority": "routine",
+        "subject": {"reference": "Patient/123"},
+        "category": [{"coding": [{"system": "http://snomed.info/sct", "code": _CATEGORY[task]}]}],
+        "code": {"coding": [{"system": "http://hl7.org/fhir/sid/cvx", "code": code_value, "display": code_display}]},
+        "encounter": {"reference": "Encounter/enc-1"},
+    }
+
+
+def bundle(*resources: dict) -> dict:
+    return {"resourceType": "Bundle", "entry": [{"resource": r} for r in resources]}
+
+
+# ---------------------------------------------------------------------
+# GET /tasks
+# ---------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_tasks_buckets_by_category(client):
+    """One order of each type → one task in each bucket, all pending."""
+    with patch("api.clinical.administration.service.HAPIFHIRClient") as MockHapi:
+        instance = MockHapi.return_value
+        instance.search = AsyncMock(side_effect=[
+            bundle(  # ServiceRequest
+                service_request("sr-imm", "immunization"),
+                service_request("sr-spec", "specimen"),
+                service_request("sr-proc", "procedure"),
+            ),
+            bundle(),  # Immunization
+            bundle(),  # Specimen
+            bundle(),  # Procedure
+        ])
+        resp = client.get("/api/clinical/administration/tasks", params={"patient_id": "123"})
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["patient_id"] == "123"
+    assert len(payload["immunizations"]) == 1
+    assert len(payload["specimens"]) == 1
+    assert len(payload["procedures"]) == 1
+    assert payload["immunizations"][0]["service_request_id"] == "sr-imm"
+    assert payload["immunizations"][0]["fulfilled"] is False
+    assert payload["immunizations"][0]["code_display"] == "Influenza vaccine"
+
+
+@pytest.mark.asyncio
+async def test_tasks_marks_fulfilled_orders(client):
+    """An Immunization whose basedOn points at the order → that task is fulfilled."""
+    with patch("api.clinical.administration.service.HAPIFHIRClient") as MockHapi:
+        instance = MockHapi.return_value
+        instance.search = AsyncMock(side_effect=[
+            bundle(service_request("sr-imm", "immunization")),
+            bundle({
+                "resourceType": "Immunization", "id": "imm-99",
+                "basedOn": [{"reference": "ServiceRequest/sr-imm"}],
+            }),
+            bundle(),
+            bundle(),
+        ])
+        resp = client.get("/api/clinical/administration/tasks", params={"patient_id": "123"})
+
+    assert resp.status_code == 200
+    task = resp.json()["immunizations"][0]
+    assert task["fulfilled"] is True
+    assert task["fulfillment_id"] == "imm-99"
+
+
+@pytest.mark.asyncio
+async def test_tasks_skips_draft_orders(client):
+    """A draft (unsigned) ServiceRequest is not yet an actionable task."""
+    with patch("api.clinical.administration.service.HAPIFHIRClient") as MockHapi:
+        instance = MockHapi.return_value
+        instance.search = AsyncMock(side_effect=[
+            bundle(service_request("sr-draft", "procedure", status="draft")),
+            bundle(), bundle(), bundle(),
+        ])
+        resp = client.get("/api/clinical/administration/tasks", params={"patient_id": "123"})
+
+    assert resp.status_code == 200
+    assert resp.json()["procedures"] == []
+
+
+# ---------------------------------------------------------------------
+# POST /record/immunization
+# ---------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_record_immunization_creates_resource_with_basedon(client):
+    with patch("api.clinical.administration.router.HAPIFHIRClient") as MockHapi:
+        instance = MockHapi.return_value
+        instance.read = AsyncMock(return_value=service_request("sr-imm", "immunization"))
+        instance.create = AsyncMock(return_value={"id": "imm-1", "resourceType": "Immunization"})
+        resp = client.post(
+            "/api/clinical/administration/record/immunization",
+            json={
+                "service_request_id": "sr-imm",
+                "lot_number": "LOT-42",
+                "route": "IM",
+                "site": "left deltoid",
+                "dose_value": 0.5,
+                "dose_unit": "mL",
+            },
+        )
+
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["resource_id"] == "imm-1"
+    assert body["resource_type"] == "Immunization"
+
+    sent = instance.create.call_args.args[1]
+    assert instance.create.call_args.args[0] == "Immunization"
+    assert sent["status"] == "completed"
+    assert sent["basedOn"][0]["reference"] == "ServiceRequest/sr-imm"
+    assert sent["vaccineCode"]["coding"][0]["code"] == "140"
+    assert sent["lotNumber"] == "LOT-42"
+    assert sent["doseQuantity"]["value"] == 0.5
+    assert sent["encounter"]["reference"] == "Encounter/enc-1"
+
+
+@pytest.mark.asyncio
+async def test_record_immunization_not_done_requires_reason(client):
+    with patch("api.clinical.administration.router.HAPIFHIRClient") as MockHapi:
+        instance = MockHapi.return_value
+        instance.read = AsyncMock(return_value=service_request("sr-imm", "immunization"))
+        resp = client.post(
+            "/api/clinical/administration/record/immunization",
+            json={"service_request_id": "sr-imm", "status": "not-done"},
+        )
+    assert resp.status_code == 400
+    assert "status_reason" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_record_immunization_against_draft_order_409s(client):
+    with patch("api.clinical.administration.router.HAPIFHIRClient") as MockHapi:
+        instance = MockHapi.return_value
+        instance.read = AsyncMock(return_value=service_request("sr-imm", "immunization", status="draft"))
+        resp = client.post(
+            "/api/clinical/administration/record/immunization",
+            json={"service_request_id": "sr-imm"},
+        )
+    assert resp.status_code == 409
+    assert "draft" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_record_immunization_missing_order_404s(client):
+    with patch("api.clinical.administration.router.HAPIFHIRClient") as MockHapi:
+        instance = MockHapi.return_value
+        instance.read = AsyncMock(return_value=None)
+        resp = client.post(
+            "/api/clinical/administration/record/immunization",
+            json={"service_request_id": "sr-nope"},
+        )
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------
+# POST /record/specimen
+# ---------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_record_specimen_creates_resource_with_request_link(client):
+    with patch("api.clinical.administration.router.HAPIFHIRClient") as MockHapi:
+        instance = MockHapi.return_value
+        instance.read = AsyncMock(return_value=service_request("sr-spec", "specimen"))
+        instance.create = AsyncMock(return_value={"id": "spec-1", "resourceType": "Specimen"})
+        resp = client.post(
+            "/api/clinical/administration/record/specimen",
+            json={
+                "service_request_id": "sr-spec",
+                "specimen_type": "Whole blood",
+                "container": "EDTA tube",
+                "body_site": "left antecubital",
+            },
+        )
+
+    assert resp.status_code == 201
+    sent = instance.create.call_args.args[1]
+    assert instance.create.call_args.args[0] == "Specimen"
+    assert sent["status"] == "available"
+    assert sent["request"][0]["reference"] == "ServiceRequest/sr-spec"
+    assert sent["type"]["text"] == "Whole blood"
+    assert sent["collection"]["bodySite"]["text"] == "left antecubital"
+    assert sent["container"][0]["type"]["text"] == "EDTA tube"
+
+
+@pytest.mark.asyncio
+async def test_record_specimen_against_draft_order_409s(client):
+    with patch("api.clinical.administration.router.HAPIFHIRClient") as MockHapi:
+        instance = MockHapi.return_value
+        instance.read = AsyncMock(return_value=service_request("sr-spec", "specimen", status="draft"))
+        resp = client.post(
+            "/api/clinical/administration/record/specimen",
+            json={"service_request_id": "sr-spec"},
+        )
+    assert resp.status_code == 409
+
+
+# ---------------------------------------------------------------------
+# POST /record/procedure
+# ---------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_record_procedure_creates_resource_with_basedon(client):
+    with patch("api.clinical.administration.router.HAPIFHIRClient") as MockHapi:
+        instance = MockHapi.return_value
+        instance.read = AsyncMock(return_value=service_request("sr-proc", "procedure"))
+        instance.create = AsyncMock(return_value={"id": "proc-1", "resourceType": "Procedure"})
+        resp = client.post(
+            "/api/clinical/administration/record/procedure",
+            json={
+                "service_request_id": "sr-proc",
+                "outcome": "successful",
+                "notes": "No complications.",
+            },
+        )
+
+    assert resp.status_code == 201
+    sent = instance.create.call_args.args[1]
+    assert instance.create.call_args.args[0] == "Procedure"
+    assert sent["status"] == "completed"
+    assert sent["basedOn"][0]["reference"] == "ServiceRequest/sr-proc"
+    assert sent["outcome"]["text"] == "successful"
+    assert sent["note"][0]["text"] == "No complications."
+
+
+@pytest.mark.asyncio
+async def test_record_procedure_not_done_requires_reason(client):
+    with patch("api.clinical.administration.router.HAPIFHIRClient") as MockHapi:
+        instance = MockHapi.return_value
+        instance.read = AsyncMock(return_value=service_request("sr-proc", "procedure"))
+        resp = client.post(
+            "/api/clinical/administration/record/procedure",
+            json={"service_request_id": "sr-proc", "status": "not-done"},
+        )
+    assert resp.status_code == 400
+    assert "status_reason" in resp.json()["detail"]

--- a/backend/tests/api/clinical/administration/test_tasks_router.py
+++ b/backend/tests/api/clinical/administration/test_tasks_router.py
@@ -103,14 +103,23 @@ async def test_tasks_buckets_by_category(client):
 
 @pytest.mark.asyncio
 async def test_tasks_marks_fulfilled_orders(client):
-    """An Immunization whose basedOn points at the order → that task is fulfilled."""
+    """An Immunization whose order extension points at the order → fulfilled.
+
+    R4 Immunization has no `basedOn`; the order link rides on a custom
+    extension, so fulfilment detection reads that.
+    """
+    from api.clinical.administration.service import IMMUNIZATION_ORDER_EXTENSION
+
     with patch("api.clinical.administration.service.HAPIFHIRClient") as MockHapi:
         instance = MockHapi.return_value
         instance.search = AsyncMock(side_effect=[
             bundle(service_request("sr-imm", "immunization")),
             bundle({
                 "resourceType": "Immunization", "id": "imm-99",
-                "basedOn": [{"reference": "ServiceRequest/sr-imm"}],
+                "extension": [{
+                    "url": IMMUNIZATION_ORDER_EXTENSION,
+                    "valueReference": {"reference": "ServiceRequest/sr-imm"},
+                }],
             }),
             bundle(),
             bundle(),
@@ -121,6 +130,34 @@ async def test_tasks_marks_fulfilled_orders(client):
     task = resp.json()["immunizations"][0]
     assert task["fulfilled"] is True
     assert task["fulfillment_id"] == "imm-99"
+
+
+@pytest.mark.asyncio
+async def test_procedure_and_specimen_fulfilment_use_native_elements(client):
+    """Procedure links via basedOn, Specimen via request — both native R4."""
+    with patch("api.clinical.administration.service.HAPIFHIRClient") as MockHapi:
+        instance = MockHapi.return_value
+        instance.search = AsyncMock(side_effect=[
+            bundle(
+                service_request("sr-spec", "specimen"),
+                service_request("sr-proc", "procedure"),
+            ),
+            bundle(),
+            bundle({
+                "resourceType": "Specimen", "id": "spec-1",
+                "request": [{"reference": "ServiceRequest/sr-spec"}],
+            }),
+            bundle({
+                "resourceType": "Procedure", "id": "proc-1",
+                "basedOn": [{"reference": "ServiceRequest/sr-proc"}],
+            }),
+        ])
+        resp = client.get("/api/clinical/administration/tasks", params={"patient_id": "123"})
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["specimens"][0]["fulfilled"] is True
+    assert payload["procedures"][0]["fulfilled"] is True
 
 
 @pytest.mark.asyncio
@@ -143,7 +180,10 @@ async def test_tasks_skips_draft_orders(client):
 # ---------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_record_immunization_creates_resource_with_basedon(client):
+async def test_record_immunization_creates_resource_with_order_extension(client):
+    """R4 Immunization links to its order via an extension, not `basedOn`."""
+    from api.clinical.administration.service import IMMUNIZATION_ORDER_EXTENSION
+
     with patch("api.clinical.administration.router.HAPIFHIRClient") as MockHapi:
         instance = MockHapi.return_value
         instance.read = AsyncMock(return_value=service_request("sr-imm", "immunization"))
@@ -168,7 +208,9 @@ async def test_record_immunization_creates_resource_with_basedon(client):
     sent = instance.create.call_args.args[1]
     assert instance.create.call_args.args[0] == "Immunization"
     assert sent["status"] == "completed"
-    assert sent["basedOn"][0]["reference"] == "ServiceRequest/sr-imm"
+    assert "basedOn" not in sent  # not a valid R4 Immunization element
+    order_ext = [e for e in sent["extension"] if e["url"] == IMMUNIZATION_ORDER_EXTENSION]
+    assert order_ext[0]["valueReference"]["reference"] == "ServiceRequest/sr-imm"
     assert sent["vaccineCode"]["coding"][0]["code"] == "140"
     assert sent["lotNumber"] == "LOT-42"
     assert sent["doseQuantity"]["value"] == 0.5

--- a/frontend/src/components/clinical/trends/TrendsTab.js
+++ b/frontend/src/components/clinical/trends/TrendsTab.js
@@ -22,7 +22,7 @@ import { useClinical } from '../../../contexts/ClinicalContext';
 import VitalSignsTrends from '../../VitalSignsTrends';
 import LabTrends from '../charts/LabTrends';
 import VitalsOverview from '../charts/VitalsOverview';
-import { fhirClient } from '../../../services/fhirClient';
+import { fhirClient } from '../../../core/fhir/services/fhirClient';
 
 const TabPanel = ({ children, value, index, ...other }) => {
   return (

--- a/frontend/src/components/clinical/workspace/AdministrationRecord/AdministrationRecord.jsx
+++ b/frontend/src/components/clinical/workspace/AdministrationRecord/AdministrationRecord.jsx
@@ -27,6 +27,7 @@ import FilterBar, { WINDOW_PRESETS } from './FilterBar';
 import MARGrid from './MARGrid';
 import PRNPane from './PRNPane';
 import QuickAdminPopover from './QuickAdminPopover';
+import TaskPane from './TaskPane';
 import { classifyCell } from './MARCell';
 import { useScheduledTasks } from './useScheduledTasks';
 
@@ -137,42 +138,54 @@ const AdministrationRecord = ({ patientId, currentPatient }) => {
         </Alert>
       )}
 
-      {error && (
-        <Alert severity="error" sx={{ m: 2 }}>
-          Failed to load administration data: {error.message}
-        </Alert>
-      )}
+      {effectivePatientId && (
+        <Box sx={{ display: 'flex', alignItems: 'flex-start' }}>
+          {/* Left column — medication time grid + PRN pane. */}
+          <Box sx={{ flex: 1, minWidth: 0 }}>
+            {error && (
+              <Alert severity="error" sx={{ m: 2 }}>
+                Failed to load administration data: {error.message}
+              </Alert>
+            )}
 
-      {loading && !data && (
-        <Stack direction="row" alignItems="center" justifyContent="center" sx={{ py: 6, gap: 1 }}>
-          <CircularProgress size={20} />
-          <Typography variant="body2" color="text.secondary">Loading administration record…</Typography>
-        </Stack>
-      )}
+            {loading && !data && (
+              <Stack direction="row" alignItems="center" justifyContent="center" sx={{ py: 6, gap: 1 }}>
+                <CircularProgress size={20} />
+                <Typography variant="body2" color="text.secondary">Loading administration record…</Typography>
+              </Stack>
+            )}
 
-      {data && (
-        <>
-          <MARGrid
-            scheduledRows={filteredScheduled}
-            windowStart={windowStart}
-            windowEnd={windowEnd}
-            density={density}
-            onCellClick={handleCellClick}
-            pendingRequestIds={pendingRequestIds}
-            tick={tick}
-            /* When the status filter hid everything but the window does
-               have doses, MARGrid should say "filter hides them", not
-               "none scheduled" — pass the hint so its empty state is
-               accurate. */
-            filterHidEverything={
-              statusFilter !== 'all'
-              && (data.scheduled || []).length > 0
-              && filteredScheduled.length === 0
-            }
-            activeFilterLabel={statusFilter}
-          />
-          <PRNPane prnOrders={data.prn_orders || []} onGiveNow={handlePrnGive} />
-        </>
+            {data && (
+              <>
+                <MARGrid
+                  scheduledRows={filteredScheduled}
+                  windowStart={windowStart}
+                  windowEnd={windowEnd}
+                  density={density}
+                  onCellClick={handleCellClick}
+                  pendingRequestIds={pendingRequestIds}
+                  tick={tick}
+                  /* When the status filter hid everything but the window does
+                     have doses, MARGrid should say "filter hides them", not
+                     "none scheduled" — pass the hint so its empty state is
+                     accurate. */
+                  filterHidEverything={
+                    statusFilter !== 'all'
+                    && (data.scheduled || []).length > 0
+                    && filteredScheduled.length === 0
+                  }
+                  activeFilterLabel={statusFilter}
+                />
+                <PRNPane prnOrders={data.prn_orders || []} onGiveNow={handlePrnGive} />
+              </>
+            )}
+          </Box>
+
+          {/* Right column — non-medication recording tasks (Phase 5.2). */}
+          <Box sx={{ width: 320, flexShrink: 0, borderLeft: 1, borderColor: 'divider', alignSelf: 'stretch' }}>
+            <TaskPane patientId={effectivePatientId} />
+          </Box>
+        </Box>
       )}
 
       <QuickAdminPopover

--- a/frontend/src/components/clinical/workspace/AdministrationRecord/CLAUDE.md
+++ b/frontend/src/components/clinical/workspace/AdministrationRecord/CLAUDE.md
@@ -2,7 +2,7 @@
 
 The Medication Administration Record. Nurse-side surface for charting
 "I gave the 0800 metformin", complementing the Order Composer's CPOE
-side. #116 Phase 5.1.
+side. #116 Phase 5.1 (medication grid) + 5.2 (non-medication Tasks pane).
 
 **Inherits** root + `frontend/CLAUDE.md` + `frontend/src/CLAUDE.md` patterns.
 
@@ -10,16 +10,37 @@ side. #116 Phase 5.1.
 
 ```
 AdministrationRecord.jsx  ──┐    (tab shell — wires data + UI)
-                            │
+                            │    2-column: grid (left) + Tasks pane (right)
                             ├─ FilterBar.jsx       (status / window / density)
                             ├─ MARGrid.jsx         (time-axis CSS grid)
                             │   ├─ MedRowHeader.jsx   (left rail, 200px)
                             │   └─ MARCell.jsx        (per-cell state machine)
                             ├─ PRNPane.jsx         (PRN cards below grid)
-                            └─ QuickAdminPopover.jsx (click-to-document)
+                            ├─ QuickAdminPopover.jsx (click-to-document)
+                            └─ TaskPane.jsx        (Phase 5.2 — right column)
+                                └─ dialogs/        (Immunization / Specimen /
+                                                    Procedure recording dialogs)
 
-useScheduledTasks.js  ──── data hook (fetch, WebSocket live updates, tick)
+useScheduledTasks.js     ── grid data hook (fetch, WebSocket updates, tick)
+useAdministrationTasks.js ─ Tasks-pane data hook (fetch + WebSocket refresh)
 ```
+
+## Tasks pane — non-medication recording (Phase 5.2)
+
+Where the grid charts medication doses, `TaskPane` charts the other
+shift work: immunizations, specimen collections, procedures. It reads
+`GET /api/clinical/administration/tasks`, which returns active
+ServiceRequest orders bucketed by category coding (immunization
+`33879002`, lab `108252007`, procedure `387713003`), each flagged
+`fulfilled` when a recording resource (`Immunization`/`Specimen`/
+`Procedure`) already links back to the order.
+
+Each pending order is a tappable card → a recording dialog under
+`dialogs/`. The dialog POSTs to `POST .../administration/record/{type}`,
+which builds the FHIR resource with `basedOn` (Immunization/Procedure)
+or `request` (Specimen) → the order, and enforces the same
+`ADMINISTRABLE_STATUSES` gate. These dialogs are deliberately lean — the
+full `ImmunizationDialogEnhanced` stepper is retired in Phase 5.3.
 
 ## Cell state grammar (the visual language)
 
@@ -77,10 +98,12 @@ Action types and the FHIR statuses they map to:
 | `held` | `on-hold` | `statusReason` (required) |
 | `refused` | `not-done` | `statusReason` (required) |
 
-## What's deliberately out of scope for 5.1
+## What's deliberately out of scope
 
-- **Non-medication tasks** (immunization recording, specimen collection,
-  procedure performance) — Phase 5.2.
+- **Retiring `ImmunizationDialogEnhanced`** (the 3-step stepper still used
+  by Chart Review's edit path) — Phase 5.3.
+- **Ad-hoc recording with no order** — every Tasks-pane card has a
+  ServiceRequest; orderless recording stays on the legacy dialog.
 - **Drag-to-reschedule** — out of scope, app is modal-first.
 - **Advanced `Timing.repeat` shapes**: `dayOfWeek`, `timeOfDay`,
   `when` event-coded timing (mealtime-relative), taper schedules across

--- a/frontend/src/components/clinical/workspace/AdministrationRecord/TaskPane.jsx
+++ b/frontend/src/components/clinical/workspace/AdministrationRecord/TaskPane.jsx
@@ -1,0 +1,187 @@
+/**
+ * TaskPane — non-medication recording tasks for the MAR (#116 Phase 5.2).
+ *
+ * Right-side pane on the Administration tab. Where the MAR grid charts
+ * medication doses, this pane charts the other things a nurse records
+ * during a shift: immunizations, specimen collections, procedures.
+ *
+ * Data comes from `GET /api/clinical/administration/tasks` via
+ * `useAdministrationTasks` — each pending order is a tappable card that
+ * opens the matching recording dialog; fulfilled orders show muted with a
+ * check. The three dialogs each POST to a `/record/{type}` endpoint.
+ */
+
+import React, { useState } from 'react';
+import {
+  Alert,
+  Box,
+  Chip,
+  CircularProgress,
+  Paper,
+  Stack,
+  Typography,
+} from '@mui/material';
+import {
+  Vaccines as ImmunizationIcon,
+  Biotech as SpecimenIcon,
+  MedicalServices as ProcedureIcon,
+  CheckCircle as DoneIcon,
+} from '@mui/icons-material';
+
+import { useAdministrationTasks } from './useAdministrationTasks';
+import ImmunizationAdminDialog from './dialogs/ImmunizationAdminDialog';
+import SpecimenCollectionDialog from './dialogs/SpecimenCollectionDialog';
+import ProcedurePerformanceDialog from './dialogs/ProcedurePerformanceDialog';
+
+const SECTIONS = [
+  { type: 'immunization', key: 'immunizations', label: 'Immunizations', Icon: ImmunizationIcon },
+  { type: 'specimen', key: 'specimens', label: 'Specimen collection', Icon: SpecimenIcon },
+  { type: 'procedure', key: 'procedures', label: 'Procedures', Icon: ProcedureIcon },
+];
+
+const formatOrdered = (iso) => {
+  if (!iso) return null;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toLocaleDateString([], { month: 'short', day: 'numeric' });
+};
+
+const TaskCard = ({ task, onClick }) => {
+  const ordered = formatOrdered(task.ordered_datetime);
+  return (
+    <Paper
+      variant="outlined"
+      onClick={task.fulfilled ? undefined : onClick}
+      role={task.fulfilled ? undefined : 'button'}
+      tabIndex={task.fulfilled ? undefined : 0}
+      onKeyDown={(e) => {
+        if (!task.fulfilled && (e.key === 'Enter' || e.key === ' ')) {
+          e.preventDefault();
+          onClick();
+        }
+      }}
+      sx={{
+        p: 1,
+        cursor: task.fulfilled ? 'default' : 'pointer',
+        opacity: task.fulfilled ? 0.6 : 1,
+        transition: 'background-color 0.15s, border-color 0.15s',
+        '&:hover': task.fulfilled ? {} : { borderColor: 'primary.main', bgcolor: 'action.hover' },
+      }}
+    >
+      <Stack direction="row" alignItems="flex-start" spacing={1}>
+        <Box sx={{ flex: 1, minWidth: 0 }}>
+          <Typography variant="body2" sx={{ fontWeight: 600 }} noWrap>
+            {task.code_display}
+          </Typography>
+          <Stack direction="row" spacing={0.5} sx={{ mt: 0.5 }} alignItems="center">
+            {ordered && (
+              <Typography variant="caption" color="text.secondary">
+                Ordered {ordered}
+              </Typography>
+            )}
+            {task.priority && task.priority !== 'routine' && (
+              <Chip label={task.priority} size="small" color="warning" sx={{ height: 18 }} />
+            )}
+          </Stack>
+        </Box>
+        {task.fulfilled && <DoneIcon fontSize="small" color="success" />}
+      </Stack>
+    </Paper>
+  );
+};
+
+/**
+ * @param {object} props
+ * @param {string} props.patientId — bare FHIR id
+ */
+const TaskPane = ({ patientId }) => {
+  const { data, loading, error, refetch } = useAdministrationTasks({ patientId });
+  const [active, setActive] = useState({ type: null, task: null });
+
+  const closeDialog = () => setActive({ type: null, task: null });
+
+  const totalPending = SECTIONS.reduce(
+    (sum, s) => sum + ((data?.[s.key] || []).filter((t) => !t.fulfilled).length),
+    0,
+  );
+
+  return (
+    <Box sx={{ p: 1.5 }}>
+      <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 1 }}>
+        <Typography variant="overline" color="text.secondary">Tasks</Typography>
+        {totalPending > 0 && (
+          <Chip label={`${totalPending} pending`} size="small" color="primary" />
+        )}
+      </Stack>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 1 }}>
+          Failed to load tasks: {error.message}
+        </Alert>
+      )}
+
+      {loading && !data && (
+        <Stack direction="row" alignItems="center" spacing={1} sx={{ py: 2 }}>
+          <CircularProgress size={16} />
+          <Typography variant="caption" color="text.secondary">Loading tasks…</Typography>
+        </Stack>
+      )}
+
+      {data && (
+        <Stack spacing={1.5}>
+          {SECTIONS.map(({ type, key, label, Icon }) => {
+            const tasks = data[key] || [];
+            return (
+              <Box key={type}>
+                <Stack direction="row" alignItems="center" spacing={0.5} sx={{ mb: 0.5 }}>
+                  <Icon fontSize="small" color="action" />
+                  <Typography variant="subtitle2">{label}</Typography>
+                  <Typography variant="caption" color="text.secondary">({tasks.length})</Typography>
+                </Stack>
+                {tasks.length === 0 ? (
+                  <Typography variant="caption" color="text.secondary" sx={{ pl: 1 }}>
+                    No orders.
+                  </Typography>
+                ) : (
+                  <Stack spacing={0.75}>
+                    {tasks.map((task) => (
+                      <TaskCard
+                        key={task.service_request_id}
+                        task={task}
+                        onClick={() => setActive({ type, task })}
+                      />
+                    ))}
+                  </Stack>
+                )}
+              </Box>
+            );
+          })}
+        </Stack>
+      )}
+
+      <ImmunizationAdminDialog
+        open={active.type === 'immunization'}
+        task={active.task}
+        patientId={patientId}
+        onClose={closeDialog}
+        onRecorded={refetch}
+      />
+      <SpecimenCollectionDialog
+        open={active.type === 'specimen'}
+        task={active.task}
+        patientId={patientId}
+        onClose={closeDialog}
+        onRecorded={refetch}
+      />
+      <ProcedurePerformanceDialog
+        open={active.type === 'procedure'}
+        task={active.task}
+        patientId={patientId}
+        onClose={closeDialog}
+        onRecorded={refetch}
+      />
+    </Box>
+  );
+};
+
+export default TaskPane;

--- a/frontend/src/components/clinical/workspace/AdministrationRecord/__tests__/TaskPane.test.jsx
+++ b/frontend/src/components/clinical/workspace/AdministrationRecord/__tests__/TaskPane.test.jsx
@@ -1,0 +1,58 @@
+/**
+ * Tests for TaskPane — the MAR non-medication recording pane (#116 Phase 5.2).
+ *
+ * Mocks the `/tasks` fetch and confirms the pane renders pending vs.
+ * fulfilled task cards and opens the matching recording dialog on click.
+ */
+
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '../../../../../test-utils/test-utils';
+import TaskPane from '../TaskPane';
+
+const tasksPayload = {
+  patient_id: 'p1',
+  immunizations: [{
+    service_request_id: 'sr-imm',
+    task_type: 'immunization',
+    code_display: 'Influenza vaccine',
+    ordered_datetime: '2026-05-10T08:00:00Z',
+    priority: 'routine',
+    fulfilled: false,
+  }],
+  specimens: [],
+  procedures: [{
+    service_request_id: 'sr-proc',
+    task_type: 'procedure',
+    code_display: 'Appendectomy',
+    ordered_datetime: '2026-05-09T08:00:00Z',
+    priority: 'routine',
+    fulfilled: true,
+    fulfillment_id: 'proc-9',
+  }],
+};
+
+beforeEach(() => {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({ ok: true, json: () => Promise.resolve(tasksPayload) }),
+  );
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+test('renders pending and fulfilled task cards', async () => {
+  render(<TaskPane patientId="p1" />);
+  await waitFor(() => expect(screen.getByText('Influenza vaccine')).toBeInTheDocument());
+  // One pending task across all sections (the procedure is fulfilled).
+  expect(screen.getByText('1 pending')).toBeInTheDocument();
+  // Fulfilled procedure still renders (muted).
+  expect(screen.getByText('Appendectomy')).toBeInTheDocument();
+});
+
+test('clicking a pending task card opens its recording dialog', async () => {
+  render(<TaskPane patientId="p1" />);
+  await waitFor(() => expect(screen.getByText('Influenza vaccine')).toBeInTheDocument());
+  fireEvent.click(screen.getByText('Influenza vaccine'));
+  await waitFor(() => expect(screen.getByText('Record immunization')).toBeInTheDocument());
+});

--- a/frontend/src/components/clinical/workspace/AdministrationRecord/dialogs/ImmunizationAdminDialog.jsx
+++ b/frontend/src/components/clinical/workspace/AdministrationRecord/dialogs/ImmunizationAdminDialog.jsx
@@ -1,0 +1,269 @@
+/**
+ * ImmunizationAdminDialog — record an Immunization against its order (#116 Phase 5.2).
+ *
+ * The lean nurse-side recording dialog for the MAR Tasks pane. The vaccine
+ * is fixed by the ordering ServiceRequest (shown read-only); this dialog
+ * only captures the administration facts — lot, route, site, dose, performer,
+ * reaction. Posts to `POST /api/clinical/administration/record/immunization`,
+ * which creates an `Immunization` with `basedOn` → the order and refuses
+ * unsigned (draft) orders.
+ *
+ * This is NOT the full ImmunizationDialogEnhanced (the 3-step stepper used
+ * for standalone/historical immunization editing) — Phase 5.3 retires that.
+ */
+
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  FormControlLabel,
+  InputLabel,
+  MenuItem,
+  Radio,
+  RadioGroup,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+
+import { buildUrl } from '../../../../../config/apiConfig';
+import { useClinicalWorkflow } from '../../../../../contexts/ClinicalWorkflowContext';
+import { CLINICAL_EVENTS } from '../../../../../constants/clinicalEvents';
+
+const ROUTES = ['IM', 'SC', 'ID', 'IN', 'PO'];
+const SITES = [
+  'Left deltoid', 'Right deltoid',
+  'Left thigh', 'Right thigh',
+  'Left gluteus', 'Right gluteus',
+];
+
+/** Format a Date as the value a `datetime-local` input expects (local time). */
+const toLocalInput = (date) => {
+  const pad = (n) => String(n).padStart(2, '0');
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`
+    + `T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+};
+
+/**
+ * @param {object} props
+ * @param {boolean} props.open
+ * @param {object|null} props.task — the immunization task (service_request_id, code_display, ...)
+ * @param {string} [props.patientId]
+ * @param {() => void} props.onClose
+ * @param {() => void} props.onRecorded — fired after a successful save
+ */
+const ImmunizationAdminDialog = ({ open, task, patientId, onClose, onRecorded }) => {
+  const { publish } = useClinicalWorkflow();
+
+  const [status, setStatus] = useState('completed');
+  const [occurrence, setOccurrence] = useState(() => toLocalInput(new Date()));
+  const [lotNumber, setLotNumber] = useState('');
+  const [expiration, setExpiration] = useState('');
+  const [route, setRoute] = useState('IM');
+  const [site, setSite] = useState('Left deltoid');
+  const [doseValue, setDoseValue] = useState('0.5');
+  const [doseUnit, setDoseUnit] = useState('mL');
+  const [reaction, setReaction] = useState('');
+  const [statusReason, setStatusReason] = useState('');
+  const [notes, setNotes] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setStatus('completed');
+    setOccurrence(toLocalInput(new Date()));
+    setLotNumber('');
+    setExpiration('');
+    setRoute('IM');
+    setSite('Left deltoid');
+    setDoseValue('0.5');
+    setDoseUnit('mL');
+    setReaction('');
+    setStatusReason('');
+    setNotes('');
+    setError(null);
+  }, [open, task]);
+
+  const notDone = status === 'not-done';
+  const vaccineName = useMemo(() => task?.code_display || 'Vaccine', [task]);
+
+  const handleSubmit = async () => {
+    if (!task) return;
+    if (notDone && !statusReason.trim()) {
+      setError('A reason is required when the vaccine was not given.');
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const body = {
+        service_request_id: task.service_request_id,
+        status,
+        occurrence_datetime: new Date(occurrence).toISOString(),
+        ...(lotNumber ? { lot_number: lotNumber } : {}),
+        ...(expiration ? { expiration_date: expiration } : {}),
+        ...(!notDone && route ? { route } : {}),
+        ...(!notDone && site ? { site } : {}),
+        ...(!notDone && doseValue ? { dose_value: parseFloat(doseValue), dose_unit: doseUnit } : {}),
+        ...(reaction ? { reaction } : {}),
+        ...(notDone ? { status_reason: statusReason } : {}),
+        ...(notes ? { notes } : {}),
+      };
+      const res = await fetch(
+        buildUrl('backend', '/api/clinical/administration/record/immunization'),
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        },
+      );
+      if (!res.ok) {
+        const payload = await res.json().catch(() => ({}));
+        throw new Error(payload.detail || `Server returned ${res.status}`);
+      }
+      const created = await res.json().catch(() => ({}));
+      publish?.(CLINICAL_EVENTS.IMMUNIZATION_ADMINISTERED, {
+        patientId,
+        immunizationId: created.resource_id,
+        serviceRequestId: task.service_request_id,
+      });
+      onRecorded?.();
+      onClose?.();
+    } catch (err) {
+      console.error('ImmunizationAdminDialog: submit failed', err);
+      setError(err.message || String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={submitting ? undefined : onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Record immunization</DialogTitle>
+      <DialogContent dividers>
+        <Stack spacing={2}>
+          <Box>
+            <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>{vaccineName}</Typography>
+            <Typography variant="caption" color="text.secondary">
+              Recording against the signed immunization order.
+            </Typography>
+          </Box>
+
+          {error && <Alert severity="error">{error}</Alert>}
+
+          <RadioGroup row value={status} onChange={(e) => setStatus(e.target.value)}>
+            <FormControlLabel value="completed" control={<Radio size="small" />} label="Given" />
+            <FormControlLabel value="not-done" control={<Radio size="small" />} label="Not given" />
+          </RadioGroup>
+
+          <TextField
+            label="Occurrence"
+            type="datetime-local"
+            value={occurrence}
+            onChange={(e) => setOccurrence(e.target.value)}
+            size="small"
+            InputLabelProps={{ shrink: true }}
+          />
+
+          {notDone ? (
+            <TextField
+              label="Reason not given"
+              value={statusReason}
+              onChange={(e) => setStatusReason(e.target.value)}
+              size="small"
+              required
+            />
+          ) : (
+            <>
+              <Stack direction="row" spacing={1}>
+                <TextField
+                  label="Lot number"
+                  value={lotNumber}
+                  onChange={(e) => setLotNumber(e.target.value)}
+                  size="small"
+                  sx={{ flex: 1 }}
+                />
+                <TextField
+                  label="Lot expiration"
+                  type="date"
+                  value={expiration}
+                  onChange={(e) => setExpiration(e.target.value)}
+                  size="small"
+                  sx={{ flex: 1 }}
+                  InputLabelProps={{ shrink: true }}
+                />
+              </Stack>
+              <Stack direction="row" spacing={1}>
+                <FormControl size="small" sx={{ flex: 1 }}>
+                  <InputLabel>Route</InputLabel>
+                  <Select value={route} label="Route" onChange={(e) => setRoute(e.target.value)}>
+                    {ROUTES.map((r) => <MenuItem key={r} value={r}>{r}</MenuItem>)}
+                  </Select>
+                </FormControl>
+                <FormControl size="small" sx={{ flex: 2 }}>
+                  <InputLabel>Site</InputLabel>
+                  <Select value={site} label="Site" onChange={(e) => setSite(e.target.value)}>
+                    {SITES.map((s) => <MenuItem key={s} value={s}>{s}</MenuItem>)}
+                  </Select>
+                </FormControl>
+              </Stack>
+              <Stack direction="row" spacing={1}>
+                <TextField
+                  label="Dose"
+                  value={doseValue}
+                  onChange={(e) => setDoseValue(e.target.value)}
+                  size="small"
+                  sx={{ flex: 1 }}
+                />
+                <TextField
+                  label="Unit"
+                  value={doseUnit}
+                  onChange={(e) => setDoseUnit(e.target.value)}
+                  size="small"
+                  sx={{ flex: 1 }}
+                />
+              </Stack>
+              <TextField
+                label="Adverse reaction (if any)"
+                value={reaction}
+                onChange={(e) => setReaction(e.target.value)}
+                size="small"
+              />
+            </>
+          )}
+
+          <TextField
+            label="Notes"
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            multiline
+            minRows={2}
+            size="small"
+          />
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={submitting}>Cancel</Button>
+        <Button
+          variant="contained"
+          onClick={handleSubmit}
+          disabled={submitting}
+          startIcon={submitting ? <CircularProgress size={14} color="inherit" /> : null}
+        >
+          Record
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default ImmunizationAdminDialog;

--- a/frontend/src/components/clinical/workspace/AdministrationRecord/dialogs/ProcedurePerformanceDialog.jsx
+++ b/frontend/src/components/clinical/workspace/AdministrationRecord/dialogs/ProcedurePerformanceDialog.jsx
@@ -1,0 +1,217 @@
+/**
+ * ProcedurePerformanceDialog — record a Procedure against its order (#116 Phase 5.2).
+ *
+ * Nurse/clinician-side dialog for the MAR Tasks pane: documents that a
+ * procedure was performed for a signed procedure ServiceRequest. Posts to
+ * `POST /api/clinical/administration/record/procedure`, which creates a
+ * `Procedure` with `basedOn` → the order and refuses unsigned (draft) orders.
+ */
+
+import React, { useEffect, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+
+import { buildUrl } from '../../../../../config/apiConfig';
+import { useClinicalWorkflow } from '../../../../../contexts/ClinicalWorkflowContext';
+import { CLINICAL_EVENTS } from '../../../../../constants/clinicalEvents';
+
+const STATUSES = [
+  { value: 'completed', label: 'Completed' },
+  { value: 'in-progress', label: 'In progress' },
+  { value: 'not-done', label: 'Not done' },
+];
+
+const OUTCOMES = ['Successful', 'Partially successful', 'Unsuccessful'];
+
+const toLocalInput = (date) => {
+  const pad = (n) => String(n).padStart(2, '0');
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`
+    + `T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+};
+
+/**
+ * @param {object} props
+ * @param {boolean} props.open
+ * @param {object|null} props.task — the procedure task (service_request_id, code_display, ...)
+ * @param {string} [props.patientId]
+ * @param {() => void} props.onClose
+ * @param {() => void} props.onRecorded
+ */
+const ProcedurePerformanceDialog = ({ open, task, patientId, onClose, onRecorded }) => {
+  const { publish } = useClinicalWorkflow();
+
+  const [status, setStatus] = useState('completed');
+  const [performed, setPerformed] = useState(() => toLocalInput(new Date()));
+  const [performer, setPerformer] = useState('');
+  const [outcome, setOutcome] = useState('Successful');
+  const [complication, setComplication] = useState('');
+  const [statusReason, setStatusReason] = useState('');
+  const [notes, setNotes] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setStatus('completed');
+    setPerformed(toLocalInput(new Date()));
+    setPerformer('');
+    setOutcome('Successful');
+    setComplication('');
+    setStatusReason('');
+    setNotes('');
+    setError(null);
+  }, [open, task]);
+
+  const notDone = status === 'not-done';
+
+  const handleSubmit = async () => {
+    if (!task) return;
+    if (notDone && !statusReason.trim()) {
+      setError('A reason is required when the procedure was not done.');
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const body = {
+        service_request_id: task.service_request_id,
+        status,
+        performed_datetime: new Date(performed).toISOString(),
+        ...(performer ? { performer_reference: `Practitioner/${performer}` } : {}),
+        ...(!notDone && outcome ? { outcome } : {}),
+        ...(complication ? { complication } : {}),
+        ...(notDone ? { status_reason: statusReason } : {}),
+        ...(notes ? { notes } : {}),
+      };
+      const res = await fetch(
+        buildUrl('backend', '/api/clinical/administration/record/procedure'),
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        },
+      );
+      if (!res.ok) {
+        const payload = await res.json().catch(() => ({}));
+        throw new Error(payload.detail || `Server returned ${res.status}`);
+      }
+      const created = await res.json().catch(() => ({}));
+      publish?.(CLINICAL_EVENTS.PROCEDURE_PERFORMED, {
+        patientId,
+        procedureId: created.resource_id,
+        serviceRequestId: task.service_request_id,
+      });
+      onRecorded?.();
+      onClose?.();
+    } catch (err) {
+      console.error('ProcedurePerformanceDialog: submit failed', err);
+      setError(err.message || String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={submitting ? undefined : onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Record procedure</DialogTitle>
+      <DialogContent dividers>
+        <Stack spacing={2}>
+          <Box>
+            <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+              {task?.code_display || 'Procedure'}
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              Recording performance against the signed procedure order.
+            </Typography>
+          </Box>
+
+          {error && <Alert severity="error">{error}</Alert>}
+
+          <FormControl size="small">
+            <InputLabel>Status</InputLabel>
+            <Select value={status} label="Status" onChange={(e) => setStatus(e.target.value)}>
+              {STATUSES.map((s) => <MenuItem key={s.value} value={s.value}>{s.label}</MenuItem>)}
+            </Select>
+          </FormControl>
+
+          <TextField
+            label="Performed"
+            type="datetime-local"
+            value={performed}
+            onChange={(e) => setPerformed(e.target.value)}
+            size="small"
+            InputLabelProps={{ shrink: true }}
+          />
+
+          <TextField
+            label="Performed by (Practitioner id)"
+            value={performer}
+            onChange={(e) => setPerformer(e.target.value)}
+            size="small"
+            placeholder="Optional — defaults to current user"
+          />
+
+          {notDone ? (
+            <TextField
+              label="Reason not done"
+              value={statusReason}
+              onChange={(e) => setStatusReason(e.target.value)}
+              size="small"
+              required
+            />
+          ) : (
+            <FormControl size="small">
+              <InputLabel>Outcome</InputLabel>
+              <Select value={outcome} label="Outcome" onChange={(e) => setOutcome(e.target.value)}>
+                {OUTCOMES.map((o) => <MenuItem key={o} value={o}>{o}</MenuItem>)}
+              </Select>
+            </FormControl>
+          )}
+
+          <TextField
+            label="Complication (if any)"
+            value={complication}
+            onChange={(e) => setComplication(e.target.value)}
+            size="small"
+          />
+          <TextField
+            label="Notes"
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            multiline
+            minRows={2}
+            size="small"
+          />
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={submitting}>Cancel</Button>
+        <Button
+          variant="contained"
+          onClick={handleSubmit}
+          disabled={submitting}
+          startIcon={submitting ? <CircularProgress size={14} color="inherit" /> : null}
+        >
+          Record
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default ProcedurePerformanceDialog;

--- a/frontend/src/components/clinical/workspace/AdministrationRecord/dialogs/SpecimenCollectionDialog.jsx
+++ b/frontend/src/components/clinical/workspace/AdministrationRecord/dialogs/SpecimenCollectionDialog.jsx
@@ -1,0 +1,208 @@
+/**
+ * SpecimenCollectionDialog — record a Specimen against its lab order (#116 Phase 5.2).
+ *
+ * Nurse/phlebotomist-side dialog for the MAR Tasks pane: documents that a
+ * specimen was collected for a signed laboratory ServiceRequest. Posts to
+ * `POST /api/clinical/administration/record/specimen`, which creates a
+ * `Specimen` with `request` → the order and refuses unsigned (draft) orders.
+ */
+
+import React, { useEffect, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+
+import { buildUrl } from '../../../../../config/apiConfig';
+import { useClinicalWorkflow } from '../../../../../contexts/ClinicalWorkflowContext';
+import { CLINICAL_EVENTS } from '../../../../../constants/clinicalEvents';
+
+const CONTAINERS = [
+  'EDTA tube (lavender)',
+  'Serum separator tube (gold)',
+  'Sodium citrate tube (blue)',
+  'Lithium heparin tube (green)',
+  'Sterile urine cup',
+  'Other (see notes)',
+];
+
+const toLocalInput = (date) => {
+  const pad = (n) => String(n).padStart(2, '0');
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`
+    + `T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+};
+
+/**
+ * @param {object} props
+ * @param {boolean} props.open
+ * @param {object|null} props.task — the specimen task (service_request_id, code_display, ...)
+ * @param {string} [props.patientId]
+ * @param {() => void} props.onClose
+ * @param {() => void} props.onRecorded
+ */
+const SpecimenCollectionDialog = ({ open, task, patientId, onClose, onRecorded }) => {
+  const { publish } = useClinicalWorkflow();
+
+  const [specimenType, setSpecimenType] = useState('');
+  const [collected, setCollected] = useState(() => toLocalInput(new Date()));
+  const [container, setContainer] = useState(CONTAINERS[0]);
+  const [bodySite, setBodySite] = useState('');
+  const [quantityValue, setQuantityValue] = useState('');
+  const [quantityUnit, setQuantityUnit] = useState('mL');
+  const [notes, setNotes] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setSpecimenType(task?.code_display && task.code_display !== '(unspecified)' ? task.code_display : '');
+    setCollected(toLocalInput(new Date()));
+    setContainer(CONTAINERS[0]);
+    setBodySite('');
+    setQuantityValue('');
+    setQuantityUnit('mL');
+    setNotes('');
+    setError(null);
+  }, [open, task]);
+
+  const handleSubmit = async () => {
+    if (!task) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const body = {
+        service_request_id: task.service_request_id,
+        collected_datetime: new Date(collected).toISOString(),
+        ...(specimenType ? { specimen_type: specimenType } : {}),
+        ...(container ? { container } : {}),
+        ...(bodySite ? { body_site: bodySite } : {}),
+        ...(quantityValue ? { quantity_value: parseFloat(quantityValue), quantity_unit: quantityUnit } : {}),
+        ...(notes ? { notes } : {}),
+      };
+      const res = await fetch(
+        buildUrl('backend', '/api/clinical/administration/record/specimen'),
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        },
+      );
+      if (!res.ok) {
+        const payload = await res.json().catch(() => ({}));
+        throw new Error(payload.detail || `Server returned ${res.status}`);
+      }
+      const created = await res.json().catch(() => ({}));
+      publish?.(CLINICAL_EVENTS.SPECIMEN_COLLECTED, {
+        patientId,
+        specimenId: created.resource_id,
+        serviceRequestId: task.service_request_id,
+      });
+      onRecorded?.();
+      onClose?.();
+    } catch (err) {
+      console.error('SpecimenCollectionDialog: submit failed', err);
+      setError(err.message || String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={submitting ? undefined : onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Record specimen collection</DialogTitle>
+      <DialogContent dividers>
+        <Stack spacing={2}>
+          <Box>
+            <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+              {task?.code_display || 'Lab order'}
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              Recording collection against the signed lab order.
+            </Typography>
+          </Box>
+
+          {error && <Alert severity="error">{error}</Alert>}
+
+          <TextField
+            label="Specimen type"
+            value={specimenType}
+            onChange={(e) => setSpecimenType(e.target.value)}
+            size="small"
+            placeholder="e.g. Whole blood, Urine"
+          />
+          <TextField
+            label="Collected"
+            type="datetime-local"
+            value={collected}
+            onChange={(e) => setCollected(e.target.value)}
+            size="small"
+            InputLabelProps={{ shrink: true }}
+          />
+          <FormControl size="small">
+            <InputLabel>Container</InputLabel>
+            <Select value={container} label="Container" onChange={(e) => setContainer(e.target.value)}>
+              {CONTAINERS.map((c) => <MenuItem key={c} value={c}>{c}</MenuItem>)}
+            </Select>
+          </FormControl>
+          <TextField
+            label="Collection body site"
+            value={bodySite}
+            onChange={(e) => setBodySite(e.target.value)}
+            size="small"
+            placeholder="e.g. Left antecubital fossa"
+          />
+          <Stack direction="row" spacing={1}>
+            <TextField
+              label="Quantity"
+              value={quantityValue}
+              onChange={(e) => setQuantityValue(e.target.value)}
+              size="small"
+              sx={{ flex: 1 }}
+            />
+            <TextField
+              label="Unit"
+              value={quantityUnit}
+              onChange={(e) => setQuantityUnit(e.target.value)}
+              size="small"
+              sx={{ flex: 1 }}
+            />
+          </Stack>
+          <TextField
+            label="Notes"
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            multiline
+            minRows={2}
+            size="small"
+          />
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={submitting}>Cancel</Button>
+        <Button
+          variant="contained"
+          onClick={handleSubmit}
+          disabled={submitting}
+          startIcon={submitting ? <CircularProgress size={14} color="inherit" /> : null}
+        >
+          Record
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default SpecimenCollectionDialog;

--- a/frontend/src/components/clinical/workspace/AdministrationRecord/useAdministrationTasks.js
+++ b/frontend/src/components/clinical/workspace/AdministrationRecord/useAdministrationTasks.js
@@ -1,0 +1,94 @@
+/**
+ * useAdministrationTasks — the Tasks-pane data hook (#116 Phase 5.2).
+ *
+ * Wraps `GET /api/clinical/administration/tasks`, which returns the patient's
+ * non-medication recording tasks (immunization / specimen / procedure orders)
+ * bucketed by type and flagged `fulfilled` when a recording resource already
+ * links back to the order.
+ *
+ * Like `useScheduledTasks`, it triggers a quiet refetch on the relevant
+ * WebSocket events so a card flips to "done" when a peer records the task —
+ * the server is the source of truth for fulfilment, so we refetch rather
+ * than mutate local state.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { buildUrl } from '../../../../config/apiConfig';
+import { useClinicalWorkflow } from '../../../../contexts/ClinicalWorkflowContext';
+import { CLINICAL_EVENTS } from '../../../../constants/clinicalEvents';
+
+const REFRESH_EVENTS = [
+  CLINICAL_EVENTS.IMMUNIZATION_ADMINISTERED,
+  CLINICAL_EVENTS.SPECIMEN_COLLECTED,
+  CLINICAL_EVENTS.PROCEDURE_PERFORMED,
+];
+
+/**
+ * @param {object} params
+ * @param {string} params.patientId — bare FHIR id, no "Patient/" prefix
+ * @returns {{
+ *   data: object|null,
+ *   loading: boolean,
+ *   error: Error|null,
+ *   refetch: () => void,
+ * }}
+ */
+export function useAdministrationTasks({ patientId }) {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const { subscribe } = useClinicalWorkflow();
+  const abortRef = useRef(null);
+
+  const fetchTasks = useCallback(async () => {
+    if (!patientId) return;
+    if (abortRef.current) abortRef.current.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setLoading(true);
+    setError(null);
+    try {
+      const url = new URL(
+        buildUrl('backend', '/api/clinical/administration/tasks'),
+        window.location.origin,
+      );
+      url.searchParams.set('patient_id', patientId);
+      const res = await fetch(url.toString(), { signal: controller.signal });
+      if (!res.ok) {
+        throw new Error(`Tasks fetch failed: ${res.status} ${res.statusText}`);
+      }
+      setData(await res.json());
+    } catch (err) {
+      if (err.name === 'AbortError') return;
+      console.error('useAdministrationTasks: fetch failed', err);
+      setError(err);
+    } finally {
+      setLoading(false);
+    }
+  }, [patientId]);
+
+  useEffect(() => {
+    fetchTasks();
+    return () => {
+      if (abortRef.current) abortRef.current.abort();
+    };
+  }, [fetchTasks]);
+
+  // Live updates — refetch when any non-medication recording event lands
+  // for this patient.
+  useEffect(() => {
+    if (!subscribe) return undefined;
+    const unsubs = REFRESH_EVENTS.map((evtName) =>
+      subscribe(evtName, (evt) => {
+        if (!patientId) return;
+        const evtPatient = evt?.patient_id || evt?.patientId;
+        if (evtPatient && evtPatient !== patientId) return;
+        fetchTasks();
+      }),
+    );
+    return () => unsubs.forEach((u) => { if (typeof u === 'function') u(); });
+  }, [subscribe, fetchTasks, patientId]);
+
+  return { data, loading, error, refetch: fetchTasks };
+}

--- a/frontend/src/components/clinical/workspace/cds/CDSHooksVerifier.js
+++ b/frontend/src/components/clinical/workspace/cds/CDSHooksVerifier.js
@@ -60,7 +60,7 @@ import {
 } from '@mui/icons-material';
 import { format } from 'date-fns';
 import { cdsHooksClient } from '../../../../services/cdsHooksClient';
-import { fhirClient } from '../../../../services/fhirClient';
+import { fhirClient } from '../../../../core/fhir/services/fhirClient';
 import { useFHIRResource } from '../../../../contexts/FHIRResourceContext';
 import { cdsHooksTester } from '../../../../core/cds/cdsHooksTester';
 

--- a/frontend/src/constants/clinicalEvents.js
+++ b/frontend/src/constants/clinicalEvents.js
@@ -45,6 +45,10 @@ export const CLINICAL_EVENTS = {
   PROCEDURE_COMPLETED: 'procedure.completed',
   PROCEDURE_CANCELLED: 'procedure.cancelled',
   PROCEDURE_UPDATED: 'procedure.updated',
+  PROCEDURE_PERFORMED: 'procedure.performed',
+
+  // Specimen events
+  SPECIMEN_COLLECTED: 'specimen.collected',
 
   // Observation events
   OBSERVATION_RECORDED: 'observation.recorded',

--- a/frontend/src/modules/ui-composer/services/FHIRDataOrchestrator.js
+++ b/frontend/src/modules/ui-composer/services/FHIRDataOrchestrator.js
@@ -3,7 +3,7 @@
  * Handles FHIR data fetching and aggregation for UI Composer
  */
 
-import { fhirClient } from '../../../services/fhirClient';
+import { fhirClient } from '../../../core/fhir/services/fhirClient';
 import { 
   extractPatientDemographics,
   extractConditionInfo,


### PR DESCRIPTION
## Summary
Adds a right-side **Tasks pane** to the Administration (MAR) tab for recording immunizations, specimen collections, and procedures against their `ServiceRequest` orders — the non-medication counterpart to the Phase 5.1 medication time grid.

### Backend (`api/clinical/administration`)
- `GET /tasks` — buckets active `ServiceRequest`s by category coding (immunization `33879002` / lab `108252007` / procedure `387713003`), marks each `fulfilled` when an `Immunization`/`Specimen`/`Procedure` already links back.
- `POST /record/immunization|specimen|procedure` — each reads the ordering `ServiceRequest`, enforces `ADMINISTRABLE_STATUSES` (409 on a draft order), builds the FHIR resource with `basedOn`/`request` → the order, writes to HAPI.

### Frontend (`AdministrationRecord`)
- `useAdministrationTasks` hook + `TaskPane` (three grouped sections of tappable order cards; fulfilled orders shown muted with a check).
- Lean recording dialogs — `ImmunizationAdminDialog`, `SpecimenCollectionDialog`, `ProcedurePerformanceDialog`.
- 2-column layout wires the pane beside the medication grid.

The full `ImmunizationDialogEnhanced` stepper is retired separately in Phase 5.3.

## Test plan
- [x] 11 backend tests (category bucketing, fulfilled detection, status-gate 409, resource `basedOn`/`request` links) — `pytest tests/api/clinical/administration/` 49 passed
- [x] `TaskPane` render + click test passes
- [ ] Prod: open Administration tab for a patient with active immunization/lab/procedure orders → Tasks pane lists them → record one of each → confirm the FHIR resource exists with the correct `basedOn`/`request` link

🤖 Generated with [Claude Code](https://claude.com/claude-code)