### PR TITLE
fix(frontend): repoint fhirClient imports to the canonical client

### DIFF
--- a/frontend/src/components/clinical/trends/TrendsTab.js
+++ b/frontend/src/components/clinical/trends/TrendsTab.js
@@ -22,7 +22,7 @@ import { useClinical } from '../../../contexts/ClinicalContext';
 import VitalSignsTrends from '../../VitalSignsTrends';
 import LabTrends from '../charts/LabTrends';
 import VitalsOverview from '../charts/VitalsOverview';
-import { fhirClient } from '../../../services/fhirClient';
+import { fhirClient } from '../../../core/fhir/services/fhirClient';
 
 const TabPanel = ({ children, value, index, ...other }) => {
   return (

--- a/frontend/src/components/clinical/workspace/cds/CDSHooksVerifier.js
+++ b/frontend/src/components/clinical/workspace/cds/CDSHooksVerifier.js
@@ -60,7 +60,7 @@ import {
 } from '@mui/icons-material';
 import { format } from 'date-fns';
 import { cdsHooksClient } from '../../../../services/cdsHooksClient';
-import { fhirClient } from '../../../../services/fhirClient';
+import { fhirClient } from '../../../../core/fhir/services/fhirClient';
 import { useFHIRResource } from '../../../../contexts/FHIRResourceContext';
 import { cdsHooksTester } from '../../../../core/cds/cdsHooksTester';
 

--- a/frontend/src/modules/ui-composer/services/FHIRDataOrchestrator.js
+++ b/frontend/src/modules/ui-composer/services/FHIRDataOrchestrator.js
@@ -3,7 +3,7 @@
  * Handles FHIR data fetching and aggregation for UI Composer
  */
 
-import { fhirClient } from '../../../services/fhirClient';
+import { fhirClient } from '../../../core/fhir/services/fhirClient';
 import { 
   extractPatientDemographics,
   extractConditionInfo,


### PR DESCRIPTION
## Summary

Three files imported `fhirClient` from `services/fhirClient` — deleted in the HAPI FHIR migration. Repointed to the canonical `core/fhir/services/fhirClient` (the named `fhirClient` singleton imported the same way by ~100 other modules):

- `components/clinical/trends/TrendsTab.js`
- `components/clinical/workspace/cds/CDSHooksVerifier.js`
- `modules/ui-composer/services/FHIRDataOrchestrator.js`

The other six files carrying the same broken import were orphaned and removed in #155.

## Verification

Clean production build (`npm run build`, exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)