### PR TITLE
fix(dicom): load generated DICOM into dcm4chee so the imaging viewer renders

### DIFF
--- a/backend/api/dicom/dicom_service.py
+++ b/backend/api/dicom/dicom_service.py
@@ -585,6 +585,12 @@ def validate_uid(uid: str, uid_type: str = "study") -> str:
     
     uid = unquote(uid).strip()
 
+    # FHIR ImagingStudy identifiers carry the DICOM UID as urn:oid:<oid>, but
+    # dcm4chee stores and is queried by the bare OID. Normalize so proxied
+    # QIDO/WADO calls match what was stored (Synthea -> dcm4chee imaging).
+    if uid.startswith("urn:oid:"):
+        uid = uid[len("urn:oid:"):]
+
     # Basic UID format validation (should be numeric with dots)
     if not all(c.isdigit() or c == '.' or c == ":" or c.isalpha() for c in uid):
         raise HTTPException(

--- a/backend/api/dicom/dicom_service.py
+++ b/backend/api/dicom/dicom_service.py
@@ -25,6 +25,7 @@ import logging
 
 from database import get_db_session
 from services.dicom_mapping_service import DICOMToImagingStudyMapper, DICOMImagingStudyService
+from api.dicom.uid_utils import dicom_uid_from_fhir_identifier
 
 logger = logging.getLogger(__name__)
 
@@ -585,11 +586,11 @@ def validate_uid(uid: str, uid_type: str = "study") -> str:
     
     uid = unquote(uid).strip()
 
-    # FHIR ImagingStudy identifiers carry the DICOM UID as urn:oid:<oid>, but
-    # dcm4chee stores and is queried by the bare OID. Normalize so proxied
-    # QIDO/WADO calls match what was stored (Synthea -> dcm4chee imaging).
-    if uid.startswith("urn:oid:"):
-        uid = uid[len("urn:oid:"):]
+    # Callers that read the UID from a FHIR ImagingStudy identifier may pass
+    # FHIR's URN encoding (urn:oid:<uid>). Recover the bare UID — the only
+    # form the DICOM UI VR permits in DICOMweb requests. The UID itself is
+    # never altered; see api/dicom/uid_utils.py for the full rationale.
+    uid = dicom_uid_from_fhir_identifier(uid)
 
     # Basic UID format validation (should be numeric with dots)
     if not all(c.isdigit() or c == '.' or c == ":" or c.isalpha() for c in uid):

--- a/backend/api/dicom/uid_utils.py
+++ b/backend/api/dicom/uid_utils.py
@@ -1,0 +1,33 @@
+"""
+UID representation helpers for the FHIR <-> DICOM boundary.
+
+A DICOM Study/Series/SOP Instance UID is a bare OID (e.g. "1.2.840.99999...").
+The HL7 DICOM-to-FHIR mapping expresses the *same* UID as a URN,
+``urn:oid:<uid>``, in ``ImagingStudy.identifier``. These are two encodings of
+the identical identifier — converting between them never alters the UID.
+
+Inside DICOM files and DICOMweb (QIDO/WADO/STOW) requests only the bare form
+is legal: the UI VR (DICOM PS3.5) permits digits and periods only, so a
+``urn:oid:``-prefixed value is non-conformant and is rejected by a strict PACS.
+
+Use this helper at every FHIR -> DICOM handoff instead of stripping the prefix
+ad hoc, so the conversion happens in exactly one place.
+
+This module is intentionally dependency-free: it is imported both by the
+FastAPI DICOM proxy and by the standalone generation/STOW scripts.
+"""
+
+
+FHIR_OID_URN_PREFIX = "urn:oid:"
+
+
+def dicom_uid_from_fhir_identifier(value) -> str:
+    """Return the bare DICOM UID for a FHIR identifier value.
+
+    Strips FHIR's ``urn:oid:`` URN encoding when present; the underlying UID
+    is returned unchanged. Values already in bare form pass through untouched.
+    """
+    value = str(value or "").strip()
+    if value.startswith(FHIR_OID_URN_PREFIX):
+        return value[len(FHIR_OID_URN_PREFIX):]
+    return value

--- a/backend/scripts/CLAUDE.md
+++ b/backend/scripts/CLAUDE.md
@@ -63,7 +63,8 @@ Exception — terminology load: `download_umls.py`, `extract_vocabularies.py`,
 | Script | Purpose | In `deploy.sh`? |
 |---|---|---|
 | `load_cds_services_to_hapi.py` | Converts built-in CDS services to FHIR `PlanDefinition`s, posts to HAPI | yes |
-| `generate_dicom_from_hapi.py` | Fetches `ImagingStudy` from HAPI, generates multi-slice DICOM into `/app/data/generated_dicoms/` | yes |
+| `generate_dicom_from_hapi.py` | Fetches `ImagingStudy` from HAPI (paginated), generates multi-slice DICOM into `/app/data/generated_dicoms/` | yes |
+| `stow_dicom_to_dcm4chee.py` | STOWs generated DICOM into the dcm4chee VNA (normalizes `urn:oid:` study UID); the viewer proxies to dcm4chee, so without this the Imaging tab shows no images | yes |
 | `create_dicom_endpoints.py` | Scans generated DICOM dirs, creates FHIR `Endpoint`s, links `ImagingStudy` | yes |
 | `create_demo_practitioners.py` | Creates `Practitioner` resources for demo/nurse/pharmacist/admin | yes |
 | `build_terminology_index.py` | Builds local SQLite terminology index for `/api/catalogs/*` autocomplete | yes (terminology phase) |
@@ -97,8 +98,10 @@ Exception — terminology load: `download_umls.py`, `extract_vocabularies.py`,
   and reference links. No script touches `hfj_*` directly.
 - **DICOM ordering dependency:** `generate_dicom_from_hapi.py` needs
   `ImagingStudy` resources to already exist (loaded by the Synthea pipeline);
-  `create_dicom_endpoints.py` needs the DICOM files to already exist. Run them
-  in pipeline order.
+  `stow_dicom_to_dcm4chee.py` and `create_dicom_endpoints.py` need the DICOM
+  files to already exist. Pipeline order: generate → STOW → endpoints. The
+  viewer (`api/dicom/dicom_service.py`) is a read-only proxy to dcm4chee, so the
+  STOW step is what makes images actually render.
 - **`cql_bridge_poc.py` has a hard-coded host** — the one place in this tree
   that violates env-driven URLs. It is a POC, not deploy code; leave it or pass
   a patient id, but do not copy its URL pattern.
@@ -126,7 +129,7 @@ Exception — terminology load: `download_umls.py`, `extract_vocabularies.py`,
 |---|---|
 | Patient load fails | `docker compose logs emr-backend`; re-run `synthea_to_hapi_pipeline.py <count> <state>` manually |
 | Synthea bundle rejected by HAPI | Pipeline rewrites `collection`→`transaction` and fixes `ifNoneExist`; check that conversion step |
-| Imaging tab shows no images | `ImagingStudy` exists but no DICOM/`Endpoint` — run `generate_dicom_from_hapi.py` then `create_dicom_endpoints.py` |
+| Imaging tab shows no images | DICOM not in dcm4chee — run `generate_dicom_from_hapi.py` → `stow_dicom_to_dcm4chee.py` → `create_dicom_endpoints.py`. The viewer proxies to dcm4chee; local files alone don't render. |
 | CDS service missing from CDS Studio | `load_cds_services_to_hapi.py` did not run / failed (non-critical in `deploy.sh`) |
 | Catalog autocomplete falls back / sparse | Terminology index not built — `build_terminology_index.py` needs vocab files in `/tmp`; restart `emr-backend` after build |
 | Same CDS card appears N times | Orphan visual-builder `PlanDefinition`s — `expunge_orphan_visual_plan_definitions.py` |

--- a/backend/scripts/CLAUDE.md
+++ b/backend/scripts/CLAUDE.md
@@ -64,7 +64,7 @@ Exception — terminology load: `download_umls.py`, `extract_vocabularies.py`,
 |---|---|---|
 | `load_cds_services_to_hapi.py` | Converts built-in CDS services to FHIR `PlanDefinition`s, posts to HAPI | yes |
 | `generate_dicom_from_hapi.py` | Fetches `ImagingStudy` from HAPI (paginated), generates multi-slice DICOM into `/app/data/generated_dicoms/` | yes |
-| `stow_dicom_to_dcm4chee.py` | STOWs generated DICOM into the dcm4chee VNA (normalizes `urn:oid:` study UID); the viewer proxies to dcm4chee, so without this the Imaging tab shows no images | yes |
+| `stow_dicom_to_dcm4chee.py` | STOWs generated DICOM into the dcm4chee VNA byte-identical (repairs, with a logged warning, legacy files whose StudyInstanceUID still carries FHIR's `urn:oid:` encoding — see `api/dicom/uid_utils.py`); the viewer proxies to dcm4chee, so without this the Imaging tab shows no images | yes |
 | `create_dicom_endpoints.py` | Scans generated DICOM dirs, creates FHIR `Endpoint`s, links `ImagingStudy` | yes |
 | `create_demo_practitioners.py` | Creates `Practitioner` resources for demo/nurse/pharmacist/admin | yes |
 | `build_terminology_index.py` | Builds local SQLite terminology index for `/api/catalogs/*` autocomplete | yes (terminology phase) |

--- a/backend/scripts/active/generate_dicom_from_hapi.py
+++ b/backend/scripts/active/generate_dicom_from_hapi.py
@@ -64,31 +64,51 @@ class HAPIFHIRDicomGenerator:
         }
 
     def fetch_imaging_studies(self, max_count=None, patient_id=None):
-        """Fetch ImagingStudy resources from HAPI FHIR"""
+        """Fetch ImagingStudy resources from HAPI FHIR.
+
+        Follows Bundle `next` links so that every ImagingStudy is processed,
+        not just the first page. Without pagination a default `_count` (200)
+        silently caps generation, leaving later studies with no pixel data.
+        `max_count`, when given, is an upper bound on the number returned.
+        """
         logger.info("📡 Fetching ImagingStudy resources from HAPI FHIR...")
 
-        params = {'_count': max_count or 100}
+        # Page size: large but bounded; HAPI caps the effective page size itself.
+        page_size = min(max_count, 200) if max_count else 200
+        params = {'_count': page_size}
         if patient_id:
             params['patient'] = patient_id
 
+        studies = []
+        url = '/ImagingStudy'
         try:
-            response = self.client.get('/ImagingStudy', params=params)
-            response.raise_for_status()
-            bundle = response.json()
+            while url:
+                response = self.client.get(url, params=params)
+                response.raise_for_status()
+                bundle = response.json()
 
-            if bundle.get('resourceType') != 'Bundle':
-                logger.error("Invalid response from HAPI FHIR")
-                return []
+                if bundle.get('resourceType') != 'Bundle':
+                    logger.error("Invalid response from HAPI FHIR")
+                    return studies
 
-            entries = bundle.get('entry', [])
-            studies = [entry['resource'] for entry in entries if 'resource' in entry]
+                entries = bundle.get('entry', [])
+                studies.extend(e['resource'] for e in entries if 'resource' in e)
+
+                if max_count and len(studies) >= max_count:
+                    studies = studies[:max_count]
+                    break
+
+                # Follow the absolute `next` link; params are already encoded in it.
+                url = next((l['url'] for l in bundle.get('link', [])
+                            if l.get('relation') == 'next'), None)
+                params = None
 
             logger.info(f"✅ Found {len(studies)} ImagingStudy resources")
             return studies
 
         except httpx.HTTPError as e:
             logger.error(f"❌ Failed to fetch ImagingStudy resources: {e}")
-            return []
+            return studies
 
     def get_patient_name(self, patient_ref):
         """Get patient name from HAPI FHIR"""
@@ -127,8 +147,14 @@ class HAPIFHIRDicomGenerator:
         patient_name = self.get_patient_name(patient_ref)
         patient_id = patient_ref.replace('Patient/', '').split('?')[0]
 
-        # Get study metadata
-        study_uid = study.get('identifier', [{}])[0].get('value', generate_uid())
+        # Get study metadata. FHIR ImagingStudy identifiers express the DICOM
+        # StudyInstanceUID as urn:oid:<oid>; strip the prefix so the DICOM tag
+        # holds a valid bare OID (a urn:oid: value violates the UI VR and is
+        # rejected on STOW into a PACS such as dcm4chee).
+        raw_study_uid = study.get('identifier', [{}])[0].get('value', '') or ''
+        if raw_study_uid.startswith('urn:oid:'):
+            raw_study_uid = raw_study_uid[len('urn:oid:'):]
+        study_uid = raw_study_uid or generate_uid()
         study_date = study.get('started', datetime.now().isoformat())[:10].replace('-', '')
         study_time = datetime.now().strftime('%H%M%S')
         description = study.get('description', 'Medical Imaging Study')

--- a/backend/scripts/active/generate_dicom_from_hapi.py
+++ b/backend/scripts/active/generate_dicom_from_hapi.py
@@ -24,6 +24,11 @@ import httpx
 import numpy as np
 from PIL import Image, ImageDraw, ImageFont
 
+# Make the backend package importable when run as a script (scripts/active/ ->
+# backend/) so the FHIR<->DICOM UID conversion is shared, not copy-pasted.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from api.dicom.uid_utils import dicom_uid_from_fhir_identifier  # noqa: E402
+
 # Configure logging
 logging.basicConfig(
     level=logging.INFO,
@@ -147,14 +152,18 @@ class HAPIFHIRDicomGenerator:
         patient_name = self.get_patient_name(patient_ref)
         patient_id = patient_ref.replace('Patient/', '').split('?')[0]
 
-        # Get study metadata. FHIR ImagingStudy identifiers express the DICOM
-        # StudyInstanceUID as urn:oid:<oid>; strip the prefix so the DICOM tag
-        # holds a valid bare OID (a urn:oid: value violates the UI VR and is
-        # rejected on STOW into a PACS such as dcm4chee).
-        raw_study_uid = study.get('identifier', [{}])[0].get('value', '') or ''
-        if raw_study_uid.startswith('urn:oid:'):
-            raw_study_uid = raw_study_uid[len('urn:oid:'):]
-        study_uid = raw_study_uid or generate_uid()
+        # Get study metadata. The HL7 DICOM<->FHIR mapping expresses the
+        # StudyInstanceUID as urn:oid:<uid> in ImagingStudy.identifier; recover
+        # the bare UID for the DICOM tag (the UI VR forbids the urn: prefix).
+        # The UID itself is unchanged — see api/dicom/uid_utils.py.
+        study_uid = dicom_uid_from_fhir_identifier(
+            study.get('identifier', [{}])[0].get('value', ''))
+        if not study_uid:
+            study_uid = generate_uid()
+            logger.warning(
+                "ImagingStudy %s has no DICOM UID identifier — minting new "
+                "StudyInstanceUID %s (it will not match the FHIR resource)",
+                study.get('id', '?'), study_uid)
         study_date = study.get('started', datetime.now().isoformat())[:10].replace('-', '')
         study_time = datetime.now().strftime('%H%M%S')
         description = study.get('description', 'Medical Imaging Study')

--- a/backend/scripts/active/stow_dicom_to_dcm4chee.py
+++ b/backend/scripts/active/stow_dicom_to_dcm4chee.py
@@ -7,9 +7,13 @@ a DICOMweb server (QIDO/WADO). `generate_dicom_from_hapi.py` only writes .dcm
 files to /app/data/generated_dicoms/ — it does not load them into the PACS, so
 without this step the Imaging tab lists studies but renders no images.
 
-This script uploads every generated study into dcm4chee via STOW-RS, normalizing
-the StudyInstanceUID to a bare OID (FHIR ImagingStudy identifiers carry it as
-urn:oid:<oid>, which is not a valid DICOM UI value). STOW is idempotent — dcm4chee
+This script uploads every generated study into dcm4chee via STOW-RS. Files are
+uploaded byte-identical, with one exception: files written by the pre-fix
+generator carry FHIR's urn:oid: URN encoding inside the StudyInstanceUID tag,
+which the DICOM UI VR forbids. Those legacy files are repaired in flight —
+same UID, minus the URN prefix — and each repair is logged so the mutation is
+visible (see api/dicom/uid_utils.py for the encoding rationale). Freshly
+generated files are never modified. STOW is idempotent — dcm4chee
 de-duplicates by SOPInstanceUID — so re-running is safe.
 
 Usage:
@@ -28,8 +32,14 @@ import sys
 import uuid
 import warnings
 from io import BytesIO
+from pathlib import Path
 
 import requests
+
+# Make the backend package importable when run as a script (scripts/active/ ->
+# backend/) so the FHIR<->DICOM UID conversion is shared, not copy-pasted.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from api.dicom.uid_utils import dicom_uid_from_fhir_identifier  # noqa: E402
 
 warnings.filterwarnings("ignore")
 
@@ -44,31 +54,44 @@ except ImportError:
     DICOM_AVAILABLE = False
 
 
-def normalize_uid(value):
-    """Strip a urn:oid: prefix so the value is a bare DICOM OID."""
-    value = str(value or "").strip()
-    return value[len("urn:oid:"):] if value.startswith("urn:oid:") else value
-
-
 def stow_url_from_qido(qido_url):
     """Derive the STOW-RS studies endpoint from the configured QIDO base."""
     return qido_url.rstrip("/") + "/studies"
 
 
 def stow_study(study_dir, stow_url, timeout=120):
-    """STOW every instance in a study directory as one multipart/related POST."""
+    """STOW every instance in a study directory as one multipart/related POST.
+
+    Files upload byte-identical. The sole exception is the legacy repair: a
+    StudyInstanceUID tag still carrying FHIR's urn:oid: prefix (written by the
+    pre-fix generator, invalid per the UI VR) is rewritten to the bare UID —
+    the identical identifier without the URN encoding — and the repair is
+    logged per study.
+    """
     files = sorted(glob.glob(os.path.join(study_dir, "*", "*.dcm")))
     if not files:
         return None, 0, "no .dcm files"
 
-    parts, study_uid = [], None
+    parts, study_uid, repaired = [], None, 0
     for path in files:
-        ds = pydicom.dcmread(path, force=True)
-        ds.StudyInstanceUID = normalize_uid(ds.StudyInstanceUID)
-        study_uid = ds.StudyInstanceUID
-        buf = BytesIO()
-        ds.save_as(buf, write_like_original=False)
-        parts.append(buf.getvalue())
+        with open(path, "rb") as f:
+            raw = f.read()
+        ds = pydicom.dcmread(BytesIO(raw), force=True)
+        bare_uid = dicom_uid_from_fhir_identifier(ds.StudyInstanceUID)
+        if bare_uid != str(ds.StudyInstanceUID):
+            ds.StudyInstanceUID = bare_uid
+            buf = BytesIO()
+            ds.save_as(buf, write_like_original=False)
+            raw = buf.getvalue()
+            repaired += 1
+        study_uid = bare_uid
+        parts.append(raw)
+
+    if repaired:
+        logger.warning(
+            "Repaired legacy urn:oid:-prefixed StudyInstanceUID in %d/%d "
+            "files under %s (UID value unchanged: %s)",
+            repaired, len(files), os.path.basename(study_dir), study_uid)
 
     boundary = "DCMBOUND" + uuid.uuid4().hex
     body = b""

--- a/backend/scripts/active/stow_dicom_to_dcm4chee.py
+++ b/backend/scripts/active/stow_dicom_to_dcm4chee.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""
+STOW generated DICOM files into the dcm4chee VNA.
+
+The imaging viewer (backend/api/dicom/dicom_service.py) is a read-only proxy to
+a DICOMweb server (QIDO/WADO). `generate_dicom_from_hapi.py` only writes .dcm
+files to /app/data/generated_dicoms/ — it does not load them into the PACS, so
+without this step the Imaging tab lists studies but renders no images.
+
+This script uploads every generated study into dcm4chee via STOW-RS, normalizing
+the StudyInstanceUID to a bare OID (FHIR ImagingStudy identifiers carry it as
+urn:oid:<oid>, which is not a valid DICOM UI value). STOW is idempotent — dcm4chee
+de-duplicates by SOPInstanceUID — so re-running is safe.
+
+Usage:
+    # Inside the backend container (deploy.sh style)
+    python scripts/active/stow_dicom_to_dcm4chee.py
+
+    # Limit how many studies to upload (smoke test)
+    python scripts/active/stow_dicom_to_dcm4chee.py --max-studies 1
+"""
+
+import argparse
+import glob
+import logging
+import os
+import sys
+import uuid
+import warnings
+from io import BytesIO
+
+import requests
+
+warnings.filterwarnings("ignore")
+
+logging.basicConfig(level=logging.INFO,
+                    format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+try:
+    import pydicom
+    DICOM_AVAILABLE = True
+except ImportError:
+    DICOM_AVAILABLE = False
+
+
+def normalize_uid(value):
+    """Strip a urn:oid: prefix so the value is a bare DICOM OID."""
+    value = str(value or "").strip()
+    return value[len("urn:oid:"):] if value.startswith("urn:oid:") else value
+
+
+def stow_url_from_qido(qido_url):
+    """Derive the STOW-RS studies endpoint from the configured QIDO base."""
+    return qido_url.rstrip("/") + "/studies"
+
+
+def stow_study(study_dir, stow_url, timeout=120):
+    """STOW every instance in a study directory as one multipart/related POST."""
+    files = sorted(glob.glob(os.path.join(study_dir, "*", "*.dcm")))
+    if not files:
+        return None, 0, "no .dcm files"
+
+    parts, study_uid = [], None
+    for path in files:
+        ds = pydicom.dcmread(path, force=True)
+        ds.StudyInstanceUID = normalize_uid(ds.StudyInstanceUID)
+        study_uid = ds.StudyInstanceUID
+        buf = BytesIO()
+        ds.save_as(buf, write_like_original=False)
+        parts.append(buf.getvalue())
+
+    boundary = "DCMBOUND" + uuid.uuid4().hex
+    body = b""
+    for data in parts:
+        body += ("--" + boundary + "\r\n").encode()
+        body += b"Content-Type: application/dicom\r\n\r\n"
+        body += data + b"\r\n"
+    body += ("--" + boundary + "--\r\n").encode()
+
+    headers = {
+        "Content-Type": 'multipart/related; type="application/dicom"; boundary=' + boundary,
+        "Accept": "application/dicom+json",
+    }
+    resp = requests.post(stow_url, data=body, headers=headers, timeout=timeout)
+    return study_uid, len(parts), "%d" % resp.status_code
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="STOW generated DICOM files into the dcm4chee VNA")
+    parser.add_argument("--dicom-dir", default="/app/data/generated_dicoms",
+                        help="Directory of generated study_* dirs")
+    parser.add_argument("--qido-url",
+                        default=os.getenv("DICOM_QIDO_URL",
+                                          "http://arc:8080/dcm4chee-arc/aets/DCM4CHEE/rs/"),
+                        help="QIDO-RS base URL (STOW is {base}/studies)")
+    parser.add_argument("--max-studies", type=int,
+                        help="Upload at most N studies")
+    args = parser.parse_args()
+
+    if not DICOM_AVAILABLE:
+        logger.error("❌ pydicom is not installed - cannot STOW DICOM")
+        return 1
+
+    stow_url = stow_url_from_qido(args.qido_url)
+    dirs = sorted(d for d in glob.glob(os.path.join(args.dicom_dir, "study_*"))
+                  if os.path.isdir(d))
+    if args.max_studies:
+        dirs = dirs[:args.max_studies]
+
+    logger.info("STOW target: %s", stow_url)
+    logger.info("Studies to upload: %d", len(dirs))
+
+    ok = fail = 0
+    for i, d in enumerate(dirs, 1):
+        try:
+            study_uid, n, status = stow_study(d, stow_url)
+            good = status.startswith(("200", "202"))
+            ok += good
+            fail += not good
+            if not good:
+                logger.warning("[%d/%d] %s -> HTTP %s", i, len(dirs),
+                               os.path.basename(d), status)
+            elif i == 1 or i == len(dirs):
+                logger.info("[%d/%d] %s files=%d suid=%s -> %s", i, len(dirs),
+                            os.path.basename(d), n, study_uid, status)
+        except Exception as e:  # noqa: BLE001 - keep going, report at end
+            fail += 1
+            logger.warning("[%d/%d] %s ERROR %s", i, len(dirs),
+                           os.path.basename(d), e)
+
+    logger.info("✅ STOW complete: ok=%d fail=%d", ok, fail)
+    return 0 if fail == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/deploy.sh
+++ b/deploy.sh
@@ -571,6 +571,18 @@ if [ "$SKIP_DATA" = false ]; then
         echo "   Imaging studies will be available without DICOM files"
     fi
 
+    # Load the generated DICOM into the dcm4chee VNA via STOW-RS. The imaging
+    # viewer proxies to dcm4chee's DICOMweb endpoints, so without this step the
+    # Imaging tab lists studies but renders no images.
+    echo -e "${BLUE}🏥 Uploading DICOM studies to dcm4chee (STOW-RS)...${NC}"
+    if docker exec emr-backend \
+        python scripts/active/stow_dicom_to_dcm4chee.py; then
+        echo -e "${GREEN}✅ DICOM studies uploaded to dcm4chee${NC}"
+    else
+        echo -e "${YELLOW}⚠️  DICOM STOW had issues (non-critical)${NC}"
+        echo "   Imaging studies may list without viewable images"
+    fi
+
     # Create DICOM Endpoint resources and link to ImagingStudy resources.
     # The FHIR Endpoint.address must be an absolute URL that the browser can
     # resolve — not the container-internal http://localhost:8000. Derive from


### PR DESCRIPTION
## Problem

The imaging viewer (`backend/api/dicom/dicom_service.py`) is a **read-only proxy** to the dcm4chee VNA added in #179, but **nothing in the deploy pipeline ever loads studies into dcm4chee**. `generate_dicom_from_hapi.py` only writes local `.dcm` files to `/app/data/generated_dicoms/`. As a result, after a normal deploy the Imaging tab **lists ImagingStudy resources but every study renders zero instances** (`GET /dicom/studies/{uid}/metadata` → `{"instances": []}`).

Two latent bugs compound it:
- The generator stamps `StudyInstanceUID = "urn:oid:1.2.840…"` — a `urn:oid:` value violates the DICOM `UI` VR and is rejected on STOW.
- `fetch_imaging_studies` reads a single `_count` page (default 100, no pagination), so only the first N studies ever get DICOM.

## Changes

- **New `scripts/active/stow_dicom_to_dcm4chee.py`** — STOW-RS uploader that pushes generated studies into dcm4chee, normalizing the `urn:oid:` study UID to a bare OID. Idempotent (dcm4chee de-dupes by SOPInstanceUID).
- **`deploy.sh`** — run the STOW step between DICOM generation and Endpoint creation (`generate → STOW → endpoints`).
- **`generate_dicom_from_hapi.py`** — strip `urn:oid:` before setting `StudyInstanceUID`; paginate the `ImagingStudy` fetch (follow Bundle `next`) so all studies are processed.
- **`dicom_service.py`** — normalize a leading `urn:oid:` in `validate_uid` so the frontend's FHIR-identifier-based queries match the bare-OID studies stored in dcm4chee.
- **`backend/scripts/CLAUDE.md`** — document the `generate → STOW → endpoints` order and that the viewer proxies to dcm4chee.

## Verification

Deployed to a production VM and confirmed end-to-end via the exact frontend path (`urn:oid:` UID through nginx): all 159 studies STOW into dcm4chee, `/metadata` returns instances, and `/series/{s}/instances/{i}/image` returns rendered 512×512 PNGs. Sampled 16 studies, all returned images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)