### PR TITLE
feat(dicom): render + play color/multi-frame instances (echo) via WADO-RS

### DIFF
--- a/backend/api/dicom/dicom_service.py
+++ b/backend/api/dicom/dicom_service.py
@@ -384,7 +384,45 @@ class DICOMService:
             
         except Exception as e:
             raise HTTPException(status_code=400, detail=f"Failed to extract pixel data: {e}")
-    
+
+    @staticmethod
+    def fetch_wado_rendered(
+        study_instance_uid: str,
+        series_instance_uid: str,
+        sop_instance_uid: str,
+        frame: int = 1,
+        qido_url: Optional[str] = None,
+    ) -> dict:
+        """Fetch a PACS-rendered frame for an instance via WADO-RS `rendered`.
+
+        dcm4chee decodes the pixel data server-side — including JPEG, color
+        (YBR/RGB), and multi-frame — and returns a browser-displayable still.
+        Used as a fallback when local grayscale windowing can't handle the
+        instance (e.g. color/multi-frame ultrasound). We render a single frame
+        (default frame 1) rather than the whole multi-frame object: the
+        instance-level `rendered` returns the full cine as one large animated
+        GIF (seconds, multi-MB), whereas a single frame is a fast ~50 KB JPEG.
+        Returns {"content": bytes, "content_type": str}.
+        """
+        if qido_url is None:
+            qido_url = _get_qido_url()
+        rendered_url = urljoin(
+            qido_url.rstrip("/") + "/",
+            f"studies/{study_instance_uid}/series/{series_instance_uid}"
+            f"/instances/{sop_instance_uid}/frames/{frame}/rendered",
+        )
+        resp = requests.get(
+            rendered_url,
+            headers={"Accept": "image/*"},
+            verify=False,
+            timeout=120,
+        )
+        resp.raise_for_status()
+        return {
+            "content": resp.content,
+            "content_type": resp.headers.get("Content-Type", "image/jpeg"),
+        }
+
     @staticmethod
     def convert_to_png(pixel_array: np.ndarray, window_center: int = 128, window_width: int = 256) -> bytes:
         """Convert DICOM pixel array to PNG image."""
@@ -689,24 +727,32 @@ async def get_instance_image(
         
         # Parse DICOM data
         ds = pydicom.dcmread(io.BytesIO(dicom_data), force=True)
-        
-        if not hasattr(ds, 'pixel_array'):
-            raise HTTPException(
-                status_code=400,
-                detail="DICOM instance has no pixel data"
-            )
-        
-        pixel_array = ds.pixel_array
-        
-        # Apply rescaling if needed
-        if hasattr(ds, 'RescaleSlope') and hasattr(ds, 'RescaleIntercept'):
-            pixel_array = pixel_array * float(ds.RescaleSlope) + float(ds.RescaleIntercept)
-        
-        # Convert to PNG
-        image_data = DICOMService.convert_to_png(pixel_array, window_center, window_width)
-        
-        logger.info(f"Successfully retrieved image for instance {sop_instance_uid}")
-        return Response(content=image_data, media_type="image/png")
+
+        samples = int(getattr(ds, "SamplesPerPixel", 1) or 1)
+        frames = int(getattr(ds, "NumberOfFrames", 1) or 1)
+
+        # Grayscale single-frame (e.g. CT): window/level locally so the viewer's
+        # window_center/width controls stay interactive. Color or multi-frame
+        # instances (e.g. ultrasound/echo cine loops) can't be windowed as
+        # grayscale — defer to the PACS renderer below, which decodes JPEG/color
+        # and returns an animated GIF for cine.
+        if samples == 1 and frames == 1 and hasattr(ds, "pixel_array"):
+            try:
+                pixel_array = ds.pixel_array
+                if hasattr(ds, 'RescaleSlope') and hasattr(ds, 'RescaleIntercept'):
+                    pixel_array = pixel_array * float(ds.RescaleSlope) + float(ds.RescaleIntercept)
+                image_data = DICOMService.convert_to_png(pixel_array, window_center, window_width)
+                logger.info(f"Successfully retrieved image for instance {sop_instance_uid}")
+                return Response(content=image_data, media_type="image/png")
+            except Exception as conv_err:
+                logger.info(
+                    f"Local windowing unavailable for {sop_instance_uid} ({conv_err}); "
+                    f"falling back to WADO-RS rendered"
+                )
+
+        rendered = DICOMService.fetch_wado_rendered(study_uid, series_uid, sop_instance_uid)
+        logger.info(f"Returned PACS-rendered image for instance {sop_instance_uid}")
+        return Response(content=rendered["content"], media_type=rendered["content_type"])
         
     except HTTPException:
         raise

--- a/backend/api/dicom/dicom_service.py
+++ b/backend/api/dicom/dicom_service.py
@@ -673,12 +673,21 @@ async def get_study_metadata(
             # Skip if filtering by series UID and this isn't it
             if series_uid and series_uid_value != series_uid:
                 continue
+            try:
+                number_of_frames = int(
+                    DICOMService._get_dicom_json_value(instance, "00280008", "NumberOfFrames", 1) or 1
+                )
+            except (TypeError, ValueError):
+                number_of_frames = 1
             metadata = {
                 "studyInstanceUID": study_uid,
                 "seriesInstanceUID": series_uid_value,
                 "sopInstanceUID": DICOMService._get_dicom_json_value(instance, "00080018", "SOPInstanceUID", ""),
                 "instanceNumber": DICOMService._get_dicom_json_value(instance, "00200013", "InstanceNumber", "1"),
                 "modality": DICOMService._get_dicom_json_value(instance, "00080060", "Modality", ""),
+                # Number of frames in this instance (e.g. ultrasound/echo cine
+                # loops have many); 1 for single-frame. Drives frame playback.
+                "numberOfFrames": number_of_frames,
             }
             instances.append(metadata)
     
@@ -701,11 +710,13 @@ async def get_instance_image(
     series_uid: str,
     sop_instance_uid: str,
     window_center: int = Query(128, description="Window center for display"),
-    window_width: int = Query(256, description="Window width for display")
+    window_width: int = Query(256, description="Window width for display"),
+    frame: int = Query(1, ge=1, description="1-based frame number for multi-frame instances")
 ):
     """
     Get image data for a specific DICOM instance via WADO.
-    Returns PNG image with applied windowing.
+    Returns PNG image with applied windowing (grayscale single-frame), or a
+    PACS-rendered JPEG of the requested frame (color / multi-frame, e.g. echo).
     """
     try:
         study_uid = validate_uid(study_uid, "study")
@@ -750,8 +761,8 @@ async def get_instance_image(
                     f"falling back to WADO-RS rendered"
                 )
 
-        rendered = DICOMService.fetch_wado_rendered(study_uid, series_uid, sop_instance_uid)
-        logger.info(f"Returned PACS-rendered image for instance {sop_instance_uid}")
+        rendered = DICOMService.fetch_wado_rendered(study_uid, series_uid, sop_instance_uid, frame=frame)
+        logger.info(f"Returned PACS-rendered image for instance {sop_instance_uid} frame {frame}")
         return Response(content=rendered["content"], media_type=rendered["content_type"])
         
     except HTTPException:

--- a/frontend/src/components/clinical/imaging/DICOMViewer.js
+++ b/frontend/src/components/clinical/imaging/DICOMViewer.js
@@ -45,6 +45,9 @@ const DICOMViewer = ({ study, onClose }) => {
   const [error, setError] = useState(null);
   const [instances, setInstances] = useState([]);
   const [currentInstanceIndex, setCurrentInstanceIndex] = useState(0);
+  // 1-based frame within the current (possibly multi-frame) instance. Echo/US
+  // clips have many frames; CT slices are single-frame (frame always 1).
+  const [currentFrame, setCurrentFrame] = useState(1);
   const [currentImage, setCurrentImage] = useState(null);
   const [, setViewerConfig] = useState(null);
   
@@ -63,6 +66,9 @@ const DICOMViewer = ({ study, onClose }) => {
   const lastPanRef = useRef({ x: 0, y: 0 });
   const isDragging = useRef(false);
 
+  // Frames in the current instance (≥1). >1 means a cine clip (e.g. echo).
+  const frameCount = instances[currentInstanceIndex]?.numberOfFrames || 1;
+
   const resolveDicomEndpoints = useCallback(() => {
     return {
       qido: study?.dicomEndpoints?.qido || getDicomQidoUrl(),
@@ -77,17 +83,22 @@ const DICOMViewer = ({ study, onClose }) => {
     }
   }, [study]); // Remove loadStudyData from dependencies to prevent infinite loops
 
-  // Auto-play animation
+  // Auto-play animation. For a multi-frame instance (cine clip, e.g. echo) we
+  // loop its frames; otherwise we advance through instances (e.g. CT slices).
   useEffect(() => {
-    if (isPlaying && instances.length > 1) {
+    const frames = instances[currentInstanceIndex]?.numberOfFrames || 1;
+    const canPlay = isPlaying && (frames > 1 || instances.length > 1);
+    if (canPlay) {
       animationRef.current = setInterval(() => {
-        setCurrentInstanceIndex(prev => (prev + 1) % instances.length);
+        if (frames > 1) {
+          setCurrentFrame(prev => (prev % frames) + 1);
+        } else {
+          setCurrentInstanceIndex(prev => (prev + 1) % instances.length);
+        }
       }, playSpeed);
-    } else {
-      if (animationRef.current) {
-        clearInterval(animationRef.current);
-        animationRef.current = null;
-      }
+    } else if (animationRef.current) {
+      clearInterval(animationRef.current);
+      animationRef.current = null;
     }
 
     return () => {
@@ -95,7 +106,12 @@ const DICOMViewer = ({ study, onClose }) => {
         clearInterval(animationRef.current);
       }
     };
-  }, [isPlaying, instances.length, playSpeed]);
+  }, [isPlaying, instances, currentInstanceIndex, playSpeed]);
+
+  // Reset to the first frame whenever the selected instance changes.
+  useEffect(() => {
+    setCurrentFrame(1);
+  }, [currentInstanceIndex]);
 
   // Load current instance image. `instances` is read inside the effect so it
   // MUST be in the deps — without it, this only fires when windowCenter/Width
@@ -106,7 +122,7 @@ const DICOMViewer = ({ study, onClose }) => {
     if (instances.length > 0 && currentInstanceIndex < instances.length && !error) {
       loadInstanceImage(instances[currentInstanceIndex]);
     }
-  }, [instances, currentInstanceIndex, windowCenter, windowWidth, error]);
+  }, [instances, currentInstanceIndex, currentFrame, windowCenter, windowWidth, error]);
 
   // Render current image
   useEffect(() => {
@@ -203,7 +219,8 @@ const DICOMViewer = ({ study, onClose }) => {
         throw new Error('Instance is missing seriesInstanceUID or sopInstanceUID');
       }
 
-      const url = `/dicom/studies/${studyDir}/series/${seriesUid}/instances/${sopUid}/image?window_center=${windowCenter}&window_width=${windowWidth}`;
+      const frameParam = (instance?.numberOfFrames > 1) ? currentFrame : 1;
+      const url = `/dicom/studies/${studyDir}/series/${seriesUid}/instances/${sopUid}/image?window_center=${windowCenter}&window_width=${windowWidth}&frame=${frameParam}`;
       const dicomEndpoints = resolveDicomEndpoints();
 
       const response = await apiClient.get(url, {
@@ -469,7 +486,7 @@ const DICOMViewer = ({ study, onClose }) => {
               </Tooltip>
               <Tooltip title="Play/Pause (Space)">
                 <span>
-                  <IconButton onClick={handlePlayPause} disabled={instances.length <= 1}>
+                  <IconButton onClick={handlePlayPause} disabled={instances.length <= 1 && frameCount <= 1}>
                     {isPlaying ? <PauseIcon /> : <PlayIcon />}
                   </IconButton>
                 </span>
@@ -484,10 +501,11 @@ const DICOMViewer = ({ study, onClose }) => {
             </ButtonGroup>
           </Grid>
 
-          {/* Instance Counter */}
+          {/* Instance / frame counter */}
           <Grid item>
             <Typography variant="body2">
-              {currentInstanceIndex + 1} / {instances.length}
+              {instances.length > 1 ? `Clip ${currentInstanceIndex + 1}/${instances.length}` : `${currentInstanceIndex + 1} / ${instances.length}`}
+              {frameCount > 1 ? ` · Frame ${currentFrame}/${frameCount}` : ''}
             </Typography>
           </Grid>
 
@@ -543,7 +561,7 @@ const DICOMViewer = ({ study, onClose }) => {
           </Grid>
 
           {/* Play Speed */}
-          {instances.length > 1 && (
+          {(instances.length > 1 || frameCount > 1) && (
             <Grid item>
               <FormControl size="small" sx={{ minWidth: 80 }}>
                 <InputLabel>Speed</InputLabel>
@@ -600,8 +618,9 @@ const DICOMViewer = ({ study, onClose }) => {
           onMouseLeave={handleMouseUp}
         />
 
-        {/* Instance slider overlay */}
-        {instances.length > 1 && (
+        {/* Bottom slider overlay: scrubs frames for a cine clip, otherwise
+            scrubs through instances (e.g. CT slices). */}
+        {(instances.length > 1 || frameCount > 1) && (
           <Box sx={{
             position: 'absolute',
             bottom: 20,
@@ -612,16 +631,28 @@ const DICOMViewer = ({ study, onClose }) => {
             p: 2,
             minWidth: 200
           }}>
-            <Slider
-              value={currentInstanceIndex}
-              onChange={(e, value) => setCurrentInstanceIndex(value)}
-              min={0}
-              max={instances.length - 1}
-              step={1}
-              marks
-              valueLabelDisplay="auto"
-              sx={{ color: 'white' }}
-            />
+            {frameCount > 1 ? (
+              <Slider
+                value={currentFrame}
+                onChange={(e, value) => setCurrentFrame(value)}
+                min={1}
+                max={frameCount}
+                step={1}
+                valueLabelDisplay="auto"
+                sx={{ color: 'white' }}
+              />
+            ) : (
+              <Slider
+                value={currentInstanceIndex}
+                onChange={(e, value) => setCurrentInstanceIndex(value)}
+                min={0}
+                max={instances.length - 1}
+                step={1}
+                marks
+                valueLabelDisplay="auto"
+                sx={{ color: 'white' }}
+              />
+            )}
           </Box>
         )}
       </Box>


### PR DESCRIPTION
## Problem

The imaging viewer couldn't display **color / multi-frame / JPEG-compressed** instances (e.g. ultrasound/echo). The image endpoint decoded pixels and applied **grayscale window/level**, returning `500 "Cannot handle this data type ... |u1"` — and even when displayed, multi-frame cine loops were stuck on a single still.

## Changes

**Rendering (color/multi-frame):**
- `get_instance_image` keeps local window/level for **grayscale single-frame** (CT — interactive window/level preserved).
- For **color or multi-frame** instances (or any local-conversion failure), it falls back to the PACS renderer via **WADO-RS `.../frames/{n}/rendered`** (dcm4chee decodes JPEG/color/multi-frame). New helper `DICOMService.fetch_wado_rendered(...)`. A single frame is requested (fast ~46 KB JPEG) rather than the instance-level rendered (a multi-MB, multi-second animated GIF).

**Playback (cine):**
- `get_study_metadata` now reports `numberOfFrames` per instance (tag `00280008`).
- `get_instance_image` accepts a 1-based `frame` query param.
- `DICOMViewer` animates **frames within a multi-frame clip** (the canvas can't animate a GIF, so cine is per-frame fetch): play/pause, speed, and a frame scrubber drive frames; prev/next move between clips; single-frame CT keeps slice-stepping. Counter shows "Clip X/N · Frame Y/F".

## Verification

- Echo (US, JPEG Baseline, YBR_FULL_422, 67 clips × 77 frames): image endpoint was `500` → now `200`; distinct frames render in ~0.15–0.26 s; the viewer plays the cine loop.
- Synthea CT (grayscale): unchanged — `200` `image/png` via local windowing, slice-stepping. No regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)