### PR TITLE
fix: route frontend API calls through the auth client; env-drive hardcoded backend URLs

### DIFF
--- a/backend/api/cds_hooks/prefetch/engine.py
+++ b/backend/api/cds_hooks/prefetch/engine.py
@@ -12,6 +12,7 @@ Educational Focus:
 
 from typing import Any, Dict, List, Optional, Tuple
 from datetime import datetime, timedelta
+import os
 import re
 import json
 import logging
@@ -400,8 +401,8 @@ class HAPIFHIRPrefetchClient:
         - Production-ready implementation
     """
 
-    def __init__(self, base_url: str = "http://hapi-fhir:8080/fhir"):
-        self.base_url = base_url.rstrip("/")
+    def __init__(self, base_url: Optional[str] = None):
+        self.base_url = (base_url or os.getenv("HAPI_FHIR_URL", "http://hapi-fhir:8080/fhir")).rstrip("/")
 
     async def get_resource(
         self,

--- a/backend/api/smart/authorization_server.py
+++ b/backend/api/smart/authorization_server.py
@@ -230,7 +230,7 @@ class SMARTAuthorizationServer:
         self.register_app(RegisteredApp(
             client_id="demo-patient-viewer",
             name="Patient Summary Viewer",
-            redirect_uris=["http://localhost:3001/callback", f"{frontend_url}/smart-callback"],
+            redirect_uris=[f"{frontend_url}/smart-callback"],
             scopes=[
                 "launch", "launch/patient",
                 "patient/Patient.read",

--- a/backend/api/ui_composer/agents/fhir_http_client.py
+++ b/backend/api/ui_composer/agents/fhir_http_client.py
@@ -3,6 +3,7 @@ FHIR HTTP Client for Agent Pipeline
 Uses the FHIR REST API instead of direct database access
 """
 
+import os
 import httpx
 import logging
 from typing import Dict, Any, Optional
@@ -12,9 +13,9 @@ logger = logging.getLogger(__name__)
 
 class FHIRHTTPClient:
     """HTTP client for FHIR REST API calls"""
-    
-    def __init__(self, base_url: str = "http://localhost:8000/fhir/R4"):
-        self.base_url = base_url
+
+    def __init__(self, base_url: Optional[str] = None):
+        self.base_url = base_url or f"{os.getenv('BACKEND_BASE_URL', 'http://localhost:8000')}/fhir/R4"
         self.client = None
     
     async def __aenter__(self):

--- a/backend/api/ui_composer/agents/query_orchestrator.py
+++ b/backend/api/ui_composer/agents/query_orchestrator.py
@@ -3,6 +3,7 @@ Query Orchestrator
 Executes complex FHIR query plans with dependency resolution and result management
 """
 
+import os
 import logging
 import asyncio
 from typing import Dict, Any, List, Optional, Set
@@ -46,8 +47,8 @@ class QueryResult:
 class QueryOrchestrator:
     """Orchestrates execution of complex FHIR query plans"""
     
-    def __init__(self, base_url: str = "http://localhost:8000/fhir/R4"):
-        self.base_url = base_url
+    def __init__(self, base_url: Optional[str] = None):
+        self.base_url = base_url or f"{os.getenv('BACKEND_BASE_URL', 'http://localhost:8000')}/fhir/R4"
         self.results_cache = {}
         self.execution_stats = {
             "total_queries": 0,

--- a/backend/api/ui_composer/agents/ui_generation_orchestrator.py
+++ b/backend/api/ui_composer/agents/ui_generation_orchestrator.py
@@ -3,6 +3,7 @@ UI Generation Orchestrator
 Main orchestrator that coordinates the entire query-driven UI generation pipeline
 """
 
+import os
 import logging
 import asyncio
 from typing import Dict, Any, Optional
@@ -19,11 +20,11 @@ logger = logging.getLogger(__name__)
 class UIGenerationOrchestrator:
     """Orchestrates the complete UI generation pipeline from query to component"""
     
-    def __init__(self, base_url: str = "http://localhost:8000/fhir/R4"):
-        self.base_url = base_url
+    def __init__(self, base_url: Optional[str] = None):
+        self.base_url = base_url or f"{os.getenv('BACKEND_BASE_URL', 'http://localhost:8000')}/fhir/R4"
         self.query_planner = FHIRQueryPlannerAgent()
         self.query_builder = FHIRQueryBuilder()
-        self.query_orchestrator = QueryOrchestrator(base_url)
+        self.query_orchestrator = QueryOrchestrator(self.base_url)
         self.relationship_mapper = DataRelationshipMapper()
         self.component_generator = QueryDrivenGenerator()
     

--- a/frontend/src/components/clinical/workspace/AdministrationRecord/QuickAdminPopover.jsx
+++ b/frontend/src/components/clinical/workspace/AdministrationRecord/QuickAdminPopover.jsx
@@ -36,6 +36,7 @@ import {
 } from '@mui/material';
 
 import { buildUrl } from '../../../../config/apiConfig';
+import api from '../../../../services/api';
 
 const HOLD_REASONS = [
   'NPO for procedure',
@@ -138,15 +139,9 @@ const QuickAdminPopover = ({
         ...(reason ? { reason } : {}),
         ...(notes ? { notes } : {}),
       };
-      const res = await fetch(url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
+      await api.post(url, body).catch((err) => {
+        throw new Error(err.response?.data?.detail || err.message);
       });
-      if (!res.ok) {
-        const errPayload = await res.json().catch(() => ({}));
-        throw new Error(errPayload.detail || `Server returned ${res.status}`);
-      }
       onSubmitDone?.();
       onClose?.();
     } catch (err) {

--- a/frontend/src/components/clinical/workspace/AdministrationRecord/__tests__/TaskPane.test.jsx
+++ b/frontend/src/components/clinical/workspace/AdministrationRecord/__tests__/TaskPane.test.jsx
@@ -8,6 +8,12 @@
 import React from 'react';
 import { render, screen, waitFor, fireEvent } from '../../../../../test-utils/test-utils';
 import TaskPane from '../TaskPane';
+import api from '../../../../../services/api';
+
+jest.mock('../../../../../services/api', () => ({
+  __esModule: true,
+  default: { get: jest.fn(), post: jest.fn() },
+}));
 
 const tasksPayload = {
   patient_id: 'p1',
@@ -32,9 +38,7 @@ const tasksPayload = {
 };
 
 beforeEach(() => {
-  global.fetch = jest.fn(() =>
-    Promise.resolve({ ok: true, json: () => Promise.resolve(tasksPayload) }),
-  );
+  api.get.mockResolvedValue({ data: tasksPayload });
 });
 
 afterEach(() => {

--- a/frontend/src/components/clinical/workspace/AdministrationRecord/dialogs/ImmunizationAdminDialog.jsx
+++ b/frontend/src/components/clinical/workspace/AdministrationRecord/dialogs/ImmunizationAdminDialog.jsx
@@ -44,6 +44,7 @@ import {
 } from '@mui/material';
 
 import { buildUrl } from '../../../../../config/apiConfig';
+import api from '../../../../../services/api';
 import { useClinicalWorkflow } from '../../../../../contexts/ClinicalWorkflowContext';
 import { CLINICAL_EVENTS } from '../../../../../constants/clinicalEvents';
 
@@ -203,19 +204,12 @@ const ImmunizationAdminDialog = ({
       ...(notDone ? { status_reason: statusReason } : {}),
       ...(notes ? { notes } : {}),
     };
-    const res = await fetch(
-      buildUrl('backend', '/api/clinical/administration/record/immunization'),
-      {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-      },
-    );
-    if (!res.ok) {
-      const payload = await res.json().catch(() => ({}));
-      throw new Error(payload.detail || `Server returned ${res.status}`);
-    }
-    const created = await res.json().catch(() => ({}));
+    const res = await api
+      .post(buildUrl('backend', '/api/clinical/administration/record/immunization'), body)
+      .catch((err) => {
+        throw new Error(err.response?.data?.detail || err.message);
+      });
+    const created = res.data ?? {};
     safePublish(CLINICAL_EVENTS.IMMUNIZATION_ADMINISTERED, {
       patientId,
       immunizationId: created.resource_id,

--- a/frontend/src/components/clinical/workspace/AdministrationRecord/dialogs/ProcedurePerformanceDialog.jsx
+++ b/frontend/src/components/clinical/workspace/AdministrationRecord/dialogs/ProcedurePerformanceDialog.jsx
@@ -27,6 +27,7 @@ import {
 } from '@mui/material';
 
 import { buildUrl } from '../../../../../config/apiConfig';
+import api from '../../../../../services/api';
 import { useClinicalWorkflow } from '../../../../../contexts/ClinicalWorkflowContext';
 import { CLINICAL_EVENTS } from '../../../../../constants/clinicalEvents';
 
@@ -98,19 +99,12 @@ const ProcedurePerformanceDialog = ({ open, task, patientId, onClose, onRecorded
         ...(notDone ? { status_reason: statusReason } : {}),
         ...(notes ? { notes } : {}),
       };
-      const res = await fetch(
-        buildUrl('backend', '/api/clinical/administration/record/procedure'),
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(body),
-        },
-      );
-      if (!res.ok) {
-        const payload = await res.json().catch(() => ({}));
-        throw new Error(payload.detail || `Server returned ${res.status}`);
-      }
-      const created = await res.json().catch(() => ({}));
+      const res = await api
+        .post(buildUrl('backend', '/api/clinical/administration/record/procedure'), body)
+        .catch((err) => {
+          throw new Error(err.response?.data?.detail || err.message);
+        });
+      const created = res.data ?? {};
       publish?.(CLINICAL_EVENTS.PROCEDURE_PERFORMED, {
         patientId,
         procedureId: created.resource_id,

--- a/frontend/src/components/clinical/workspace/AdministrationRecord/dialogs/SpecimenCollectionDialog.jsx
+++ b/frontend/src/components/clinical/workspace/AdministrationRecord/dialogs/SpecimenCollectionDialog.jsx
@@ -27,6 +27,7 @@ import {
 } from '@mui/material';
 
 import { buildUrl } from '../../../../../config/apiConfig';
+import api from '../../../../../services/api';
 import { useClinicalWorkflow } from '../../../../../contexts/ClinicalWorkflowContext';
 import { CLINICAL_EVENTS } from '../../../../../constants/clinicalEvents';
 
@@ -92,19 +93,12 @@ const SpecimenCollectionDialog = ({ open, task, patientId, onClose, onRecorded }
         ...(quantityValue ? { quantity_value: parseFloat(quantityValue), quantity_unit: quantityUnit } : {}),
         ...(notes ? { notes } : {}),
       };
-      const res = await fetch(
-        buildUrl('backend', '/api/clinical/administration/record/specimen'),
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(body),
-        },
-      );
-      if (!res.ok) {
-        const payload = await res.json().catch(() => ({}));
-        throw new Error(payload.detail || `Server returned ${res.status}`);
-      }
-      const created = await res.json().catch(() => ({}));
+      const res = await api
+        .post(buildUrl('backend', '/api/clinical/administration/record/specimen'), body)
+        .catch((err) => {
+          throw new Error(err.response?.data?.detail || err.message);
+        });
+      const created = res.data ?? {};
       publish?.(CLINICAL_EVENTS.SPECIMEN_COLLECTED, {
         patientId,
         specimenId: created.resource_id,

--- a/frontend/src/components/clinical/workspace/AdministrationRecord/useAdministrationTasks.js
+++ b/frontend/src/components/clinical/workspace/AdministrationRecord/useAdministrationTasks.js
@@ -14,6 +14,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { buildUrl } from '../../../../config/apiConfig';
+import api from '../../../../services/api';
 import { useClinicalWorkflow } from '../../../../contexts/ClinicalWorkflowContext';
 import { CLINICAL_EVENTS } from '../../../../constants/clinicalEvents';
 
@@ -49,18 +50,13 @@ export function useAdministrationTasks({ patientId }) {
     setLoading(true);
     setError(null);
     try {
-      const url = new URL(
-        buildUrl('backend', '/api/clinical/administration/tasks'),
-        window.location.origin,
-      );
-      url.searchParams.set('patient_id', patientId);
-      const res = await fetch(url.toString(), { signal: controller.signal });
-      if (!res.ok) {
-        throw new Error(`Tasks fetch failed: ${res.status} ${res.statusText}`);
-      }
-      setData(await res.json());
+      const res = await api.get(buildUrl('backend', '/api/clinical/administration/tasks'), {
+        params: { patient_id: patientId },
+        signal: controller.signal,
+      });
+      setData(res.data);
     } catch (err) {
-      if (err.name === 'AbortError') return;
+      if (err.name === 'AbortError' || err.code === 'ERR_CANCELED') return;
       console.error('useAdministrationTasks: fetch failed', err);
       setError(err);
     } finally {

--- a/frontend/src/components/clinical/workspace/AdministrationRecord/useScheduledTasks.js
+++ b/frontend/src/components/clinical/workspace/AdministrationRecord/useScheduledTasks.js
@@ -25,6 +25,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { buildUrl } from '../../../../config/apiConfig';
+import api from '../../../../services/api';
 import { useClinicalWorkflow } from '../../../../contexts/ClinicalWorkflowContext';
 import { CLINICAL_EVENTS } from '../../../../constants/clinicalEvents';
 
@@ -63,21 +64,17 @@ export function useScheduledTasks({ patientId, windowStart, windowEnd }) {
     setLoading(true);
     setError(null);
     try {
-      const url = new URL(
-        buildUrl('backend', '/api/clinical/administration/scheduled-tasks'),
-        window.location.origin,
-      );
-      url.searchParams.set('patient_id', patientId);
-      url.searchParams.set('window_start', windowStart.toISOString());
-      url.searchParams.set('window_end', windowEnd.toISOString());
-      const res = await fetch(url.toString(), { signal: controller.signal });
-      if (!res.ok) {
-        throw new Error(`MAR fetch failed: ${res.status} ${res.statusText}`);
-      }
-      const payload = await res.json();
-      setData(payload);
+      const res = await api.get(buildUrl('backend', '/api/clinical/administration/scheduled-tasks'), {
+        params: {
+          patient_id: patientId,
+          window_start: windowStart.toISOString(),
+          window_end: windowEnd.toISOString(),
+        },
+        signal: controller.signal,
+      });
+      setData(res.data);
     } catch (err) {
-      if (err.name === 'AbortError') return;
+      if (err.name === 'AbortError' || err.code === 'ERR_CANCELED') return;
       console.error('useScheduledTasks: fetch failed', err);
       setError(err);
     } finally {

--- a/frontend/src/components/clinical/workspace/components/QuestionnairesSection.js
+++ b/frontend/src/components/clinical/workspace/components/QuestionnairesSection.js
@@ -38,6 +38,7 @@ import {
 import { formatDistanceToNow, parseISO } from 'date-fns';
 import { fhirClient } from '../../../../core/fhir/services/fhirClient';
 import QuestionnaireDialog from '../dialogs/QuestionnaireDialog';
+import api from '../../../../services/api';
 
 const QuestionnairesSection = ({ patientId }) => {
   const [questionnaires, setQuestionnaires] = useState([]);
@@ -54,20 +55,13 @@ const QuestionnairesSection = ({ patientId }) => {
 
     try {
       // Fetch questionnaires from backend API
-      const qResponse = await fetch('/api/questionnaires');
-      if (!qResponse.ok) {
-        throw new Error(`Failed to fetch questionnaires: ${qResponse.status}`);
-      }
-      const qData = await qResponse.json();
-      setQuestionnaires(qData.questionnaires || []);
+      const qResponse = await api.get('/api/questionnaires');
+      setQuestionnaires(qResponse.data.questionnaires || []);
 
       // Fetch completed responses for this patient
       if (patientId) {
-        const rResponse = await fetch(`/api/questionnaires/responses?patient=${patientId}`);
-        if (rResponse.ok) {
-          const rData = await rResponse.json();
-          setResponses(rData.responses || []);
-        }
+        const rResponse = await api.get(`/api/questionnaires/responses?patient=${patientId}`);
+        setResponses(rResponse.data.responses || []);
       }
     } catch (err) {
       console.error('Error loading questionnaires:', err);
@@ -84,10 +78,7 @@ const QuestionnairesSection = ({ patientId }) => {
   const handleSeed = async () => {
     setSeeding(true);
     try {
-      const response = await fetch('/api/questionnaires/seed', { method: 'POST' });
-      if (!response.ok) {
-        throw new Error(`Seed failed: ${response.status}`);
-      }
+      await api.post('/api/questionnaires/seed');
       // Reload questionnaires after seeding
       await fetchData();
     } catch (err) {

--- a/frontend/src/components/clinical/workspace/tabs/ImagingTab.js
+++ b/frontend/src/components/clinical/workspace/tabs/ImagingTab.js
@@ -83,6 +83,7 @@ import { useClinicalWorkflow, CLINICAL_EVENTS } from '../../../../contexts/Clini
 import { navigateToTab, TAB_IDS } from '../../utils/navigationHelper';
 import websocketService from '../../../../services/websocket';
 import { getDicomQidoUrl, getDicomWadoUrl } from '../../../../config/apiConfig';
+import api from '../../../../services/api';
 import {
   ClinicalResourceCard,
   ClinicalSummaryCard,
@@ -1015,8 +1016,8 @@ const ImagingTab = ({
       }
 
       // Download study as ZIP
-      const response = await fetch(`/dicom/studies/${studyDir}/download`);
-      const blob = await response.blob();
+      const response = await api.get(`/dicom/studies/${studyDir}/download`, { responseType: 'blob' });
+      const blob = response.data;
 
       // Create download link
       const url = window.URL.createObjectURL(blob);

--- a/frontend/src/components/fhir-explorer-v4/query-building/QueryStudioEnhanced.jsx
+++ b/frontend/src/components/fhir-explorer-v4/query-building/QueryStudioEnhanced.jsx
@@ -134,6 +134,7 @@ import {
 import { FHIR_RESOURCES } from '../constants/fhirResources';
 import { fhirClient } from '../../../core/fhir/services/fhirClient';
 import { cdsClinicalDataService } from '../../../services/cdsClinicalDataService';
+import api from '../../../services/api';
 
 // Monaco Editor for syntax highlighting
 import Editor from '@monaco-editor/react';
@@ -873,29 +874,26 @@ const EnhancedParameterBuilder = ({ resource, parameters, onParametersChange }) 
     
     try {
       // Try to fetch distinct values from the API
-      const response = await fetch(
+      const response = await api.get(
         `/api/fhir/search-values/${resource}/${paramName}?limit=${QUERY_STUDIO_CONFIG.distinctValueLimit}`
       );
-      
-      if (response.ok) {
-        const data = await response.json();
-        const values = data.values?.map(item => ({
-          value: item.value || item.value_string || item.value_reference,
-          label: item.display || item.value || item.value_string,
-          count: item.usage_count,
-          description: `Used in ${item.usage_count} resources`
-        })) || [];
-        
-        // Cache the results
-        if (QUERY_STUDIO_CONFIG.cacheDistinctValues) {
-          distinctValuesCache.current.set(cacheKey, {
-            values,
-            timestamp: Date.now()
-          });
-        }
-        
-        return values;
+
+      const values = response.data.values?.map(item => ({
+        value: item.value || item.value_string || item.value_reference,
+        label: item.display || item.value || item.value_string,
+        count: item.usage_count,
+        description: `Used in ${item.usage_count} resources`
+      })) || [];
+
+      // Cache the results
+      if (QUERY_STUDIO_CONFIG.cacheDistinctValues) {
+        distinctValuesCache.current.set(cacheKey, {
+          values,
+          timestamp: Date.now()
+        });
       }
+
+      return values;
     } catch (error) {
       console.log('Distinct values API not available, using fallback');
     } finally {

--- a/frontend/src/components/fhir-explorer-v4/query-building/__tests__/QueryStudioEnhanced.test.js
+++ b/frontend/src/components/fhir-explorer-v4/query-building/__tests__/QueryStudioEnhanced.test.js
@@ -16,10 +16,15 @@ import { ThemeProvider, createTheme } from '@mui/material/styles';
 import QueryStudioEnhanced from '../QueryStudioEnhanced';
 import { fhirClient } from '../../../../core/fhir/services/fhirClient';
 import { cdsClinicalDataService } from '../../../../services/cdsClinicalDataService';
+import api from '../../../../services/api';
 
 // Mock dependencies
 jest.mock('../../../../core/fhir/services/fhirClient');
 jest.mock('../../../../services/cdsClinicalDataService');
+jest.mock('../../../../services/api', () => ({
+  __esModule: true,
+  default: { get: jest.fn(), post: jest.fn() },
+}));
 jest.mock('@monaco-editor/react', () => ({
   __esModule: true,
   default: ({ value, onChange }) => (
@@ -31,8 +36,6 @@ jest.mock('@monaco-editor/react', () => ({
   ),
 }));
 
-// Mock fetch for distinct values API
-global.fetch = jest.fn();
 
 describe('QueryStudioEnhanced', () => {
   const theme = createTheme();
@@ -119,14 +122,13 @@ describe('QueryStudioEnhanced', () => {
   describe('Distinct Values Integration', () => {
     test('fetches distinct values when parameter is selected', async () => {
       // Mock distinct values API response
-      fetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
+      api.get.mockResolvedValueOnce({
+        data: {
           values: [
             { value: 'male', display: 'Male', usage_count: 100 },
             { value: 'female', display: 'Female', usage_count: 120 }
           ]
-        })
+        }
       });
       
       renderComponent();
@@ -148,14 +150,14 @@ describe('QueryStudioEnhanced', () => {
       fireEvent.change(firstParamInput, { target: { value: 'gender' } });
       
       await waitFor(() => {
-        expect(fetch).toHaveBeenCalledWith(
+        expect(api.get).toHaveBeenCalledWith(
           expect.stringContaining('/api/fhir/search-values/Patient/gender')
         );
       });
     });
     
     test('falls back to catalog when distinct values API fails', async () => {
-      fetch.mockRejectedValueOnce(new Error('API Error'));
+      api.get.mockRejectedValueOnce(new Error('API Error'));
       
       renderComponent();
       

--- a/frontend/src/modules/cds-studio/services/cdsStudioApi.js
+++ b/frontend/src/modules/cds-studio/services/cdsStudioApi.js
@@ -4,7 +4,26 @@
  * Handles all communication with the CDS Studio backend API.
  */
 
+import api from '../../../services/api';
+
 const API_BASE = '/api/cds-studio';
+
+/**
+ * Issue a request through the shared axios client (auth header injected by
+ * its interceptor) and unwrap the JSON body. On failure, surface the
+ * backend's `detail` message when present, else the fallback message with
+ * the HTTP status.
+ */
+async function request(method, url, data, fallbackMessage) {
+  try {
+    const response = await api.request({ method, url, data });
+    return response.data;
+  } catch (error) {
+    const detail = error.response?.data?.detail;
+    const status = error.response?.status;
+    throw new Error(detail || (status ? `${fallbackMessage}: ${status}` : fallbackMessage));
+  }
+}
 
 class CDSStudioAPI {
   /**
@@ -18,39 +37,15 @@ class CDSStudioAPI {
     if (filters.status) params.append('status', filters.status);
     if (filters.search) params.append('search', filters.search);
 
-    const response = await fetch(`${API_BASE}/services?${params}`, {
-      credentials: 'include'
-    });
-
-    if (!response.ok) {
-      throw new Error(`Failed to list services: ${response.statusText}`);
-    }
-
-    return response.json();
+    return request('get', `${API_BASE}/services?${params}`, undefined, 'Failed to list services');
   }
 
   async getServiceConfiguration(serviceId) {
-    const response = await fetch(`${API_BASE}/services/${serviceId}/config`, {
-      credentials: 'include'
-    });
-
-    if (!response.ok) {
-      throw new Error(`Failed to get service configuration: ${response.statusText}`);
-    }
-
-    return response.json();
+    return request('get', `${API_BASE}/services/${serviceId}/config`, undefined, 'Failed to get service configuration');
   }
 
   async getConfigurationView(serviceId) {
-    const response = await fetch(`${API_BASE}/services/${serviceId}/config/view`, {
-      credentials: 'include'
-    });
-
-    if (!response.ok) {
-      throw new Error(`Failed to get configuration view: ${response.statusText}`);
-    }
-
-    return response.json();
+    return request('get', `${API_BASE}/services/${serviceId}/config/view`, undefined, 'Failed to get configuration view');
   }
 
   /**
@@ -58,39 +53,11 @@ class CDSStudioAPI {
    */
 
   async createBuiltInService(serviceData) {
-    const response = await fetch(`${API_BASE}/services/built-in`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      credentials: 'include',
-      body: JSON.stringify(serviceData)
-    });
-
-    if (!response.ok) {
-      const error = await response.json();
-      throw new Error(error.detail || 'Failed to create built-in service');
-    }
-
-    return response.json();
+    return request('post', `${API_BASE}/services/built-in`, serviceData, 'Failed to create built-in service');
   }
 
   async createExternalService(serviceData) {
-    const response = await fetch(`${API_BASE}/services/external`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      credentials: 'include',
-      body: JSON.stringify(serviceData)
-    });
-
-    if (!response.ok) {
-      const error = await response.json();
-      throw new Error(error.detail || 'Failed to create external service');
-    }
-
-    return response.json();
+    return request('post', `${API_BASE}/services/external`, serviceData, 'Failed to create external service');
   }
 
   /**
@@ -98,21 +65,7 @@ class CDSStudioAPI {
    */
 
   async testService(serviceId, testRequest) {
-    const response = await fetch(`${API_BASE}/services/${serviceId}/test`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      credentials: 'include',
-      body: JSON.stringify(testRequest)
-    });
-
-    if (!response.ok) {
-      const error = await response.json();
-      throw new Error(error.detail || 'Failed to test service');
-    }
-
-    return response.json();
+    return request('post', `${API_BASE}/services/${serviceId}/test`, testRequest, 'Failed to test service');
   }
 
   /**
@@ -120,15 +73,7 @@ class CDSStudioAPI {
    */
 
   async getServiceMetrics(serviceId) {
-    const response = await fetch(`${API_BASE}/services/${serviceId}/metrics`, {
-      credentials: 'include'
-    });
-
-    if (!response.ok) {
-      throw new Error(`Failed to get service metrics: ${response.statusText}`);
-    }
-
-    return response.json();
+    return request('get', `${API_BASE}/services/${serviceId}/metrics`, undefined, 'Failed to get service metrics');
   }
 
   /**
@@ -136,38 +81,14 @@ class CDSStudioAPI {
    */
 
   async updateServiceStatus(serviceId, status) {
-    const response = await fetch(`${API_BASE}/services/${serviceId}/status`, {
-      method: 'PUT',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      credentials: 'include',
-      body: JSON.stringify({ status })
-    });
-
-    if (!response.ok) {
-      const error = await response.json();
-      throw new Error(error.detail || 'Failed to update service status');
-    }
-
-    return response.json();
+    return request('put', `${API_BASE}/services/${serviceId}/status`, { status }, 'Failed to update service status');
   }
 
   async deleteService(serviceId, hardDelete = false) {
     const params = new URLSearchParams();
     if (hardDelete) params.append('hard_delete', 'true');
 
-    const response = await fetch(`${API_BASE}/services/${serviceId}?${params}`, {
-      method: 'DELETE',
-      credentials: 'include'
-    });
-
-    if (!response.ok) {
-      const error = await response.json();
-      throw new Error(error.detail || 'Failed to delete service');
-    }
-
-    return response.json();
+    return request('delete', `${API_BASE}/services/${serviceId}?${params}`, undefined, 'Failed to delete service');
   }
 
   /**
@@ -175,36 +96,14 @@ class CDSStudioAPI {
    */
 
   async getVersionHistory(serviceId) {
-    const response = await fetch(`${API_BASE}/services/${serviceId}/versions`, {
-      credentials: 'include'
-    });
-
-    if (!response.ok) {
-      throw new Error(`Failed to get version history: ${response.statusText}`);
-    }
-
-    return response.json();
+    return request('get', `${API_BASE}/services/${serviceId}/versions`, undefined, 'Failed to get version history');
   }
 
   async rollbackService(serviceId, targetVersion, notes = null) {
-    const response = await fetch(`${API_BASE}/services/${serviceId}/rollback`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      credentials: 'include',
-      body: JSON.stringify({
-        target_version: targetVersion,
-        rollback_notes: notes
-      })
-    });
-
-    if (!response.ok) {
-      const error = await response.json();
-      throw new Error(error.detail || 'Failed to rollback service');
-    }
-
-    return response.json();
+    return request('post', `${API_BASE}/services/${serviceId}/rollback`, {
+      target_version: targetVersion,
+      rollback_notes: notes
+    }, 'Failed to rollback service');
   }
 
   /**
@@ -212,77 +111,23 @@ class CDSStudioAPI {
    */
 
   async listCredentials() {
-    const response = await fetch(`${API_BASE}/credentials`, {
-      credentials: 'include'
-    });
-
-    if (!response.ok) {
-      throw new Error(`Failed to list credentials: ${response.statusText}`);
-    }
-
-    return response.json();
+    return request('get', `${API_BASE}/credentials`, undefined, 'Failed to list credentials');
   }
 
   async getCredential(credentialId) {
-    const response = await fetch(`${API_BASE}/credentials/${credentialId}`, {
-      credentials: 'include'
-    });
-
-    if (!response.ok) {
-      throw new Error(`Failed to get credential: ${response.statusText}`);
-    }
-
-    return response.json();
+    return request('get', `${API_BASE}/credentials/${credentialId}`, undefined, 'Failed to get credential');
   }
 
   async createCredential(credentialData) {
-    const response = await fetch(`${API_BASE}/credentials`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      credentials: 'include',
-      body: JSON.stringify(credentialData)
-    });
-
-    if (!response.ok) {
-      const error = await response.json();
-      throw new Error(error.detail || 'Failed to create credential');
-    }
-
-    return response.json();
+    return request('post', `${API_BASE}/credentials`, credentialData, 'Failed to create credential');
   }
 
   async updateCredential(credentialId, credentialData) {
-    const response = await fetch(`${API_BASE}/credentials/${credentialId}`, {
-      method: 'PUT',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      credentials: 'include',
-      body: JSON.stringify(credentialData)
-    });
-
-    if (!response.ok) {
-      const error = await response.json();
-      throw new Error(error.detail || 'Failed to update credential');
-    }
-
-    return response.json();
+    return request('put', `${API_BASE}/credentials/${credentialId}`, credentialData, 'Failed to update credential');
   }
 
   async deleteCredential(credentialId) {
-    const response = await fetch(`${API_BASE}/credentials/${credentialId}`, {
-      method: 'DELETE',
-      credentials: 'include'
-    });
-
-    if (!response.ok) {
-      const error = await response.json();
-      throw new Error(error.detail || 'Failed to delete credential');
-    }
-
-    return response.json();
+    return request('delete', `${API_BASE}/credentials/${credentialId}`, undefined, 'Failed to delete credential');
   }
 
   /**
@@ -290,15 +135,7 @@ class CDSStudioAPI {
    */
 
   async getSystemMetrics(timeRange = '24h') {
-    const response = await fetch(`${API_BASE}/metrics?time_range=${timeRange}`, {
-      credentials: 'include'
-    });
-
-    if (!response.ok) {
-      throw new Error(`Failed to get system metrics: ${response.statusText}`);
-    }
-
-    return response.json();
+    return request('get', `${API_BASE}/metrics?time_range=${timeRange}`, undefined, 'Failed to get system metrics');
   }
 
   /**
@@ -309,46 +146,20 @@ class CDSStudioAPI {
    */
 
   async validateCQL(cqlText, subjectRef = null) {
-    const response = await fetch('/api/cds-visual-builder/cql/validate', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
-      body: JSON.stringify({
-        cql: cqlText,
-        subject_ref: subjectRef,
-      }),
-    });
-    if (!response.ok) {
-      const err = await response.json().catch(() => ({}));
-      throw new Error(err.detail || `CQL validation failed: ${response.status}`);
-    }
-    return response.json();
+    return request('post', '/api/cds-visual-builder/cql/validate', {
+      cql: cqlText,
+      subject_ref: subjectRef,
+    }, 'CQL validation failed');
   }
 
   async deriveDataRequirements(cqlText) {
-    const response = await fetch('/api/cds-visual-builder/cql/data-requirements', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
-      body: JSON.stringify({ cql: cqlText }),
-    });
-    if (!response.ok) {
-      const err = await response.json().catch(() => ({}));
-      throw new Error(err.detail || `data-requirements derivation failed: ${response.status}`);
-    }
-    return response.json();
+    return request('post', '/api/cds-visual-builder/cql/data-requirements', {
+      cql: cqlText,
+    }, 'data-requirements derivation failed');
   }
 
   async getServiceFHIRPreview(serviceId) {
-    const response = await fetch(
-      `/api/cds-visual-builder/services/${serviceId}/fhir-preview`,
-      { credentials: 'include' },
-    );
-    if (!response.ok) {
-      const err = await response.json().catch(() => ({}));
-      throw new Error(err.detail || `FHIR preview unavailable: ${response.status}`);
-    }
-    return response.json();
+    return request('get', `/api/cds-visual-builder/services/${serviceId}/fhir-preview`, undefined, 'FHIR preview unavailable');
   }
 
   /**
@@ -362,57 +173,29 @@ class CDSStudioAPI {
     if (createdBy) params.append('created_by', createdBy);
     params.append('limit', String(limit));
     params.append('skip', String(skip));
-    const response = await fetch(`${API_BASE}/value-sets?${params}`, {
-      credentials: 'include',
-    });
-    if (!response.ok) throw new Error(`Failed to list ValueSets: ${response.status}`);
-    return response.json();
+    return request('get', `${API_BASE}/value-sets?${params}`, undefined, 'Failed to list ValueSets');
   }
 
   async getValueSet(vsId) {
-    const response = await fetch(`${API_BASE}/value-sets/${vsId}`, {
-      credentials: 'include',
-    });
-    if (!response.ok) throw new Error(`Failed to load ValueSet: ${response.status}`);
-    return response.json();
+    return request('get', `${API_BASE}/value-sets/${vsId}`, undefined, 'Failed to load ValueSet');
   }
 
   async createValueSet(payload) {
-    const response = await fetch(`${API_BASE}/value-sets`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
-      body: JSON.stringify(payload),
-    });
-    if (!response.ok) {
-      const err = await response.json().catch(() => ({}));
-      throw new Error(err.detail || `Failed to create ValueSet: ${response.status}`);
-    }
-    return response.json();
+    return request('post', `${API_BASE}/value-sets`, payload, 'Failed to create ValueSet');
   }
 
   async updateValueSet(vsId, payload) {
-    const response = await fetch(`${API_BASE}/value-sets/${vsId}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
-      body: JSON.stringify(payload),
-    });
-    if (!response.ok) {
-      const err = await response.json().catch(() => ({}));
-      throw new Error(err.detail || `Failed to update ValueSet: ${response.status}`);
-    }
-    return response.json();
+    return request('put', `${API_BASE}/value-sets/${vsId}`, payload, 'Failed to update ValueSet');
   }
 
   async deleteValueSet(vsId, { purge = false } = {}) {
     const params = purge ? '?purge=true' : '';
-    const response = await fetch(`${API_BASE}/value-sets/${vsId}${params}`, {
-      method: 'DELETE',
-      credentials: 'include',
-    });
-    if (!response.ok && response.status !== 404) {
-      throw new Error(`Failed to delete ValueSet: ${response.status}`);
+    try {
+      await api.delete(`${API_BASE}/value-sets/${vsId}${params}`);
+    } catch (error) {
+      if (error.response?.status !== 404) {
+        throw new Error(`Failed to delete ValueSet: ${error.response?.status || error.message}`);
+      }
     }
     return true;
   }
@@ -421,12 +204,7 @@ class CDSStudioAPI {
     const params = new URLSearchParams();
     if (filter) params.append('filter_text', filter);
     params.append('count', String(count));
-    const response = await fetch(
-      `${API_BASE}/value-sets/${vsId}/expand?${params}`,
-      { credentials: 'include' },
-    );
-    if (!response.ok) throw new Error(`Failed to expand ValueSet: ${response.status}`);
-    return response.json();
+    return request('get', `${API_BASE}/value-sets/${vsId}/expand?${params}`, undefined, 'Failed to expand ValueSet');
   }
 }
 

--- a/frontend/src/modules/ui-composer/components/CostDisplay.js
+++ b/frontend/src/modules/ui-composer/components/CostDisplay.js
@@ -17,6 +17,7 @@ import {
   Info as InfoIcon 
 } from '@mui/icons-material';
 import { uiComposerService } from '../../../services/uiComposerService';
+import api from '../../../services/api';
 
 const CostDisplay = ({ sessionId, loading, onCostUpdate }) => {
   const [costData, setCostData] = useState(null);
@@ -33,18 +34,10 @@ const CostDisplay = ({ sessionId, loading, onCostUpdate }) => {
     
     setFetchingCost(true);
     try {
-      const response = await fetch(`/api/ui-composer/sessions/${sessionId}/cost`, {
-        headers: {
-          'Authorization': `Bearer ${localStorage.getItem('auth_token')}`
-        }
-      });
-      
-      if (response.ok) {
-        const data = await response.json();
-        setCostData(data);
-        if (onCostUpdate) {
-          onCostUpdate(data);
-        }
+      const response = await api.get(`/api/ui-composer/sessions/${sessionId}/cost`);
+      setCostData(response.data);
+      if (onCostUpdate) {
+        onCostUpdate(response.data);
       }
     } catch (error) {
       // Failed to fetch cost data - error handled silently

--- a/frontend/src/modules/ui-composer/components/ProviderComparison.js
+++ b/frontend/src/modules/ui-composer/components/ProviderComparison.js
@@ -28,6 +28,7 @@ import {
   Error as ErrorIcon,
   Speed as SpeedIcon
 } from '@mui/icons-material';
+import api from '../../../services/api';
 
 const PROVIDERS = {
   anthropic: { name: 'Claude', color: '#8B5CF6' },
@@ -49,9 +50,8 @@ const ProviderComparison = ({ request, context, onProviderSelect }) => {
 
   const checkProviderAvailability = async () => {
     try {
-      const response = await fetch('/api/ui-composer/providers/status');
-      const data = await response.json();
-      setAvailableProviders(data);
+      const response = await api.get('/api/ui-composer/providers/status');
+      setAvailableProviders(response.data);
     } catch (err) {
       setError('Failed to check provider availability');
     }
@@ -70,18 +70,13 @@ const ProviderComparison = ({ request, context, onProviderSelect }) => {
     setError(null);
     
     try {
-      const response = await fetch('/api/ui-composer/compare', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          request,
-          context,
-          providers: selectedProviders
-        })
+      const response = await api.post('/api/ui-composer/compare', {
+        request,
+        context,
+        providers: selectedProviders
       });
-      
-      const data = await response.json();
-      setComparisonResults(data);
+
+      setComparisonResults(response.data);
     } catch (err) {
       setError('Comparison failed: ' + err.message);
     } finally {

--- a/frontend/src/modules/ui-composer/components/ProviderTestHarness.js
+++ b/frontend/src/modules/ui-composer/components/ProviderTestHarness.js
@@ -33,6 +33,7 @@ import {
 import DynamicComponent from './DynamicComponent';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
+import api from '../../../services/api';
 
 // Test scenarios for quick testing
 const TEST_SCENARIOS = [
@@ -85,10 +86,10 @@ const ProviderTestHarness = ({ patientId }) => {
 
   const checkProviderAvailability = async () => {
     try {
-      const response = await fetch('/api/ui-composer/providers/status');
-      const data = await response.json();
+      const response = await api.get('/api/ui-composer/providers/status');
+      const data = response.data;
       setAvailableProviders(data);
-      
+
       // Select first available provider
       const firstAvailable = Object.keys(data).find(p => data[p]?.available);
       if (firstAvailable) {
@@ -110,34 +111,26 @@ const ProviderTestHarness = ({ patientId }) => {
       const context = scenario.context;
       
       // Step 1: Analyze request
-      const analyzeResponse = await fetch('/api/ui-composer/analyze', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          request,
-          context: { ...context, provider: selectedProvider },
-          method: 'development' // Use development mode for testing
-        })
+      const analyzeResponse = await api.post('/api/ui-composer/analyze', {
+        request,
+        context: { ...context, provider: selectedProvider },
+        method: 'development' // Use development mode for testing
       });
-      
-      const analyzeData = await analyzeResponse.json();
+
+      const analyzeData = analyzeResponse.data;
       
       if (!analyzeData.success) {
         throw new Error(analyzeData.error || 'Analysis failed');
       }
       
       // Step 2: Generate component with specific provider
-      const generateResponse = await fetch('/api/ui-composer/generate-with-provider', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          specification: analyzeData.specification,
-          fhir_data: {}, // Empty for testing
-          provider: selectedProvider
-        })
+      const generateResponse = await api.post('/api/ui-composer/generate-with-provider', {
+        specification: analyzeData.specification,
+        fhir_data: {}, // Empty for testing
+        provider: selectedProvider
       });
-      
-      const generateData = await generateResponse.json();
+
+      const generateData = generateResponse.data;
       
       if (!generateData.success) {
         throw new Error(generateData.error || 'Generation failed');
@@ -175,17 +168,13 @@ const ProviderTestHarness = ({ patientId }) => {
         throw new Error('Need at least 2 providers for comparison');
       }
       
-      const response = await fetch('/api/ui-composer/compare', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          request,
-          context: scenario.context,
-          providers: providers.slice(0, 3) // Limit to 3 for UI
-        })
+      const response = await api.post('/api/ui-composer/compare', {
+        request,
+        context: scenario.context,
+        providers: providers.slice(0, 3) // Limit to 3 for UI
       });
-      
-      const data = await response.json();
+
+      const data = response.data;
       
       setResults({
         type: 'comparison',

--- a/frontend/src/pages/CLAUDE.md
+++ b/frontend/src/pages/CLAUDE.md
@@ -86,9 +86,9 @@ Pages reach the backend two ways, and the choice is not arbitrary:
   Used by `Analytics`, `AuditTrailPage`, `Settings`, `Login`.
 
 Do not hit FHIR through `services/api.js` raw `fetch`, and do not invent a third
-client. Raw `fetch` exists in a few pages (`PharmacyPage`, `QualityMeasuresPage`,
-the SMART pages) for non-FHIR backend calls — keep new FHIR access on
-`fhirClient`.
+client. The only deliberate raw `fetch` calls left are in the SMART pages —
+the OAuth token exchange and the external-app simulation must not carry the
+app session header. Everything else goes through `api` / `fhirClient`.
 
 Backend endpoints these pages call resolve under `/api/...` and `/fhir/...` —
 prefixes are inconsistent backend-side, so confirm the resolved path against

--- a/frontend/src/pages/PharmacyPage.js
+++ b/frontend/src/pages/PharmacyPage.js
@@ -74,6 +74,7 @@ import { printBatchLabels } from '../services/prescriptionLabelService';
 import { useFHIRResource } from '../contexts/FHIRResourceContext';
 import { useClinicalWorkflow, CLINICAL_EVENTS } from '../contexts/ClinicalWorkflowContext';
 import websocketService from '../services/websocket';
+import api from '../services/api';
 
 // Queue column configuration (should match PharmacyQueue.js)
 const QUEUE_COLUMNS = {
@@ -410,33 +411,25 @@ const PharmacyPage = () => {
   const handleStatusChange = useCallback(async (medicationRequestId, newStatus, category) => {
     try {
       // Update pharmacy status via API
-      const response = await fetch(`/api/clinical/pharmacy/status/${medicationRequestId}`, {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          status: newStatus,
-          updated_by: 'current-pharmacist', // This would come from auth context
-          notes: `Status changed to ${newStatus} via pharmacy queue`
-        })
+      await api.put(`/api/clinical/pharmacy/status/${medicationRequestId}`, {
+        status: newStatus,
+        updated_by: 'current-pharmacist', // This would come from auth context
+        notes: `Status changed to ${newStatus} via pharmacy queue`
       });
 
-      if (response.ok) {
-        // Publish workflow event
-        publish(CLINICAL_EVENTS.WORKFLOW_NOTIFICATION, {
-          type: 'pharmacy_status_change',
-          medicationRequestId,
-          newStatus,
-          category,
-          timestamp: new Date().toISOString()
-        });
+      // Publish workflow event
+      publish(CLINICAL_EVENTS.WORKFLOW_NOTIFICATION, {
+        type: 'pharmacy_status_change',
+        medicationRequestId,
+        newStatus,
+        category,
+        timestamp: new Date().toISOString()
+      });
 
-        // Refresh queue to show changes
-        handleRefresh();
-      }
+      // Refresh queue to show changes
+      handleRefresh();
     } catch (error) {
-      
+      console.error('Failed to update pharmacy status:', error);
     }
   }, [publish, handleRefresh, CLINICAL_EVENTS.WORKFLOW_NOTIFICATION]);
 

--- a/frontend/src/pages/QualityMeasuresPage.js
+++ b/frontend/src/pages/QualityMeasuresPage.js
@@ -23,6 +23,7 @@ import {
 } from '@mui/icons-material';
 import ClinicalLoadingState from '../components/clinical/shared/ClinicalLoadingState';
 import ClinicalEmptyState from '../components/clinical/shared/ClinicalEmptyState';
+import api from '../services/api';
 
 const QualityMeasuresPage = () => {
   const [summary, setSummary] = useState(null);
@@ -34,12 +35,8 @@ const QualityMeasuresPage = () => {
       try {
         setLoading(true);
         setError(null);
-        const response = await fetch('/api/quality/measures/summary');
-        if (!response.ok) {
-          throw new Error(`Failed to fetch quality measures: ${response.status}`);
-        }
-        const data = await response.json();
-        setSummary(data);
+        const response = await api.get('/api/quality/measures/summary');
+        setSummary(response.data);
       } catch (err) {
         console.error('Error fetching quality measures:', err);
         setError(err.message);

--- a/frontend/src/services/MedicationCRUDService.js
+++ b/frontend/src/services/MedicationCRUDService.js
@@ -16,6 +16,7 @@ import { fhirClient } from '../core/fhir/services/fhirClient';
 import { CLINICAL_EVENTS } from '../contexts/ClinicalWorkflowContext';
 import { format, addDays, addWeeks, addMonths, parseISO, isAfter, differenceInDays } from 'date-fns';
 import { EXTENSION_URLS } from '../constants/fhirExtensions';
+import api from './api';
 
 class MedicationCRUDService {
   constructor() {
@@ -737,19 +738,8 @@ class MedicationCRUDService {
       }
 
       // Initialize lists via backend API
-      const response = await fetch(`/api/clinical/medication-lists/initialize/${patientId}`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        }
-      });
+      await api.post(`/api/clinical/medication-lists/initialize/${patientId}`);
 
-      if (!response.ok) {
-        throw new Error(`Failed to initialize medication lists: ${response.statusText}`);
-      }
-
-      const result = await response.json();
-      
       // Fetch the created lists to update cache
       const createdLists = await this.getPatientMedicationLists(patientId);
       
@@ -770,13 +760,9 @@ class MedicationCRUDService {
         params.append('list_type', listType);
       }
 
-      const response = await fetch(`/api/clinical/medication-lists/${patientId}?${params}`);
-      
-      if (!response.ok) {
-        throw new Error(`Failed to fetch medication lists: ${response.statusText}`);
-      }
+      const response = await api.get(`/api/clinical/medication-lists/${patientId}?${params}`);
 
-      const lists = await response.json();
+      const lists = response.data;
       
       // Update cache
       lists.forEach(list => {
@@ -813,19 +799,9 @@ class MedicationCRUDService {
       };
 
       // Add medication to list via API
-      const response = await fetch(`/api/clinical/medication-lists/${list.id}/entries`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify(entryData)
-      });
+      const response = await api.post(`/api/clinical/medication-lists/${list.id}/entries`, entryData);
 
-      if (!response.ok) {
-        throw new Error(`Failed to add medication to list: ${response.statusText}`);
-      }
-
-      const result = await response.json();
+      const result = response.data;
 
       // Refresh the list in cache
       const updatedLists = await this.getPatientMedicationLists(patientId);
@@ -858,18 +834,11 @@ class MedicationCRUDService {
         throw new Error(`${listType} list not found for patient`);
       }
 
-      const response = await fetch(
-        `/api/clinical/medication-lists/${list.id}/entries/${medicationRequestId}`,
-        {
-          method: 'DELETE'
-        }
+      const response = await api.delete(
+        `/api/clinical/medication-lists/${list.id}/entries/${medicationRequestId}`
       );
 
-      if (!response.ok) {
-        throw new Error(`Failed to remove medication from list: ${response.statusText}`);
-      }
-
-      const result = await response.json();
+      const result = response.data;
 
       // Refresh the list in cache
       await this.getPatientMedicationLists(patientId);
@@ -903,23 +872,13 @@ class MedicationCRUDService {
       }
 
       // Create new list
-      const response = await fetch('/api/clinical/medication-lists', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
-          patient_id: patientId,
-          list_type: listType,
-          title: `${listType.charAt(0).toUpperCase() + listType.slice(1)} Medications`
-        })
+      const response = await api.post('/api/clinical/medication-lists', {
+        patient_id: patientId,
+        list_type: listType,
+        title: `${listType.charAt(0).toUpperCase() + listType.slice(1)} Medications`
       });
 
-      if (!response.ok) {
-        throw new Error(`Failed to create medication list: ${response.statusText}`);
-      }
-
-      const result = await response.json();
+      const result = response.data;
       
       // Update cache
       this.medicationLists.set(`${patientId}-${listType}`, result.resource);
@@ -936,22 +895,12 @@ class MedicationCRUDService {
    */
   async reconcileMedicationLists(patientId, sourceListIds) {
     try {
-      const response = await fetch('/api/clinical/medication-lists/reconcile', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
-          patient_id: patientId,
-          source_lists: sourceListIds
-        })
+      const response = await api.post('/api/clinical/medication-lists/reconcile', {
+        patient_id: patientId,
+        source_lists: sourceListIds
       });
 
-      if (!response.ok) {
-        throw new Error(`Failed to reconcile medication lists: ${response.statusText}`);
-      }
-
-      const result = await response.json();
+      const result = response.data;
       
       // Notify subscribers of reconciliation
       this.notifyListUpdated(patientId, 'reconciliation', 'create', result);

--- a/frontend/src/services/fhirSchemaService.js
+++ b/frontend/src/services/fhirSchemaService.js
@@ -5,6 +5,7 @@
  */
 
 import { getBackendUrl } from '../config/apiConfig';
+import api from './api';
 
 // Use centralized configuration for API base URL
 const API_BASE = getBackendUrl();
@@ -27,10 +28,8 @@ class FHIRSchemaService {
     }
 
     try {
-      const response = await fetch(`${API_BASE}/api/fhir-schemas-v2/capability-statement`);
-      if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
-      
-      const data = await response.json();
+      const response = await api.get(`${API_BASE}/api/fhir-schemas-v2/capability-statement`);
+      const data = response.data;
       this.capabilityStatementCache = {
         data,
         timestamp: Date.now()
@@ -41,15 +40,13 @@ class FHIRSchemaService {
       console.error('Error fetching capability statement:', error);
       // Fall back to direct HAPI FHIR metadata endpoint (proxied through backend)
       try {
-        const response = await fetch(`${API_BASE}/fhir/metadata`);
-        if (response.ok) {
-          const data = await response.json();
-          this.capabilityStatementCache = {
-            data,
-            timestamp: Date.now()
-          };
-          return data;
-        }
+        const response = await api.get(`${API_BASE}/fhir/metadata`);
+        const data = response.data;
+        this.capabilityStatementCache = {
+          data,
+          timestamp: Date.now()
+        };
+        return data;
       } catch (e) {
         console.error('Error fetching metadata directly:', e);
       }
@@ -68,22 +65,21 @@ class FHIRSchemaService {
     try {
       // Try new capability-based endpoint first
       if (this.useCapabilityStatement) {
-        const response = await fetch(`${API_BASE}/api/fhir-schemas-v2/resources`);
-        if (response.ok) {
-          const data = await response.json();
+        try {
+          const response = await api.get(`${API_BASE}/api/fhir-schemas-v2/resources`);
           this.resourceListCache = {
-            data,
+            data: response.data,
             timestamp: Date.now()
           };
-          return data;
+          return response.data;
+        } catch (v2Error) {
+          // fall through to the original endpoint
         }
       }
-      
+
       // Fall back to original endpoint
-      const response = await fetch(`${API_BASE}/api/fhir-schemas/resources`);
-      if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
-      
-      const data = await response.json();
+      const response = await api.get(`${API_BASE}/api/fhir-schemas/resources`);
+      const data = response.data;
       this.resourceListCache = {
         data,
         timestamp: Date.now()
@@ -110,29 +106,24 @@ class FHIRSchemaService {
     try {
       // Try new capability-based endpoint first
       if (this.useCapabilityStatement) {
-        const response = await fetch(`${API_BASE}/api/fhir-schemas-v2/resource/${resourceType}`);
-        if (response.ok) {
-          const data = await response.json();
+        try {
+          const response = await api.get(`${API_BASE}/api/fhir-schemas-v2/resource/${resourceType}`);
           this.schemaCache.set(cacheKey, {
-            data,
+            data: response.data,
             timestamp: Date.now()
           });
-          return data;
-        }
-        // Check for 404 specifically
-        if (response.status === 404) {
-          throw new Error(`404: No data found for resource type ${resourceType}`);
+          return response.data;
+        } catch (v2Error) {
+          // 404 means the resource type genuinely has no schema — don't fall back
+          if (v2Error.response?.status === 404) {
+            throw new Error(`404: No data found for resource type ${resourceType}`);
+          }
         }
       }
-      
+
       // Fall back to original endpoint
-      const response = await fetch(`${API_BASE}/api/fhir-schemas/resource/${resourceType}`);
-      if (!response.ok) {
-        // Include status code in error message for better handling
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
-      
-      const data = await response.json();
+      const response = await api.get(`${API_BASE}/api/fhir-schemas/resource/${resourceType}`);
+      const data = response.data;
       this.schemaCache.set(cacheKey, {
         data,
         timestamp: Date.now()
@@ -157,10 +148,8 @@ class FHIRSchemaService {
     }
 
     try {
-      const response = await fetch(`${API_BASE}/api/fhir-schemas/resource/${resourceType}/full`);
-      if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
-      
-      const data = await response.json();
+      const response = await api.get(`${API_BASE}/api/fhir-schemas/resource/${resourceType}/full`);
+      const data = response.data;
       this.schemaCache.set(cacheKey, {
         data,
         timestamp: Date.now()
@@ -178,12 +167,10 @@ class FHIRSchemaService {
    */
   async searchSchemas(query, limit = 20) {
     try {
-      const response = await fetch(
+      const response = await api.get(
         `${API_BASE}/api/fhir-schemas/search?q=${encodeURIComponent(query)}&limit=${limit}`
       );
-      if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
-      
-      return await response.json();
+      return response.data;
     } catch (error) {
       console.error('Error searching schemas:', error);
       throw error;
@@ -202,10 +189,8 @@ class FHIRSchemaService {
     }
 
     try {
-      const response = await fetch(`${API_BASE}/api/fhir-schemas/element-types`);
-      if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
-      
-      const data = await response.json();
+      const response = await api.get(`${API_BASE}/api/fhir-schemas/element-types`);
+      const data = response.data;
       this.schemaCache.set(cacheKey, {
         data,
         timestamp: Date.now()
@@ -226,17 +211,17 @@ class FHIRSchemaService {
     try {
       // Try v2 endpoint first
       if (this.useCapabilityStatement) {
-        const response = await fetch(`${API_BASE}/api/fhir-schemas-v2/stats`);
-        if (response.ok) {
-          return await response.json();
+        try {
+          const response = await api.get(`${API_BASE}/api/fhir-schemas-v2/stats`);
+          return response.data;
+        } catch (v2Error) {
+          // fall through to the v1 endpoint
         }
       }
-      
+
       // Fall back to v1 endpoint
-      const response = await fetch(`${API_BASE}/api/fhir-schemas/stats`);
-      if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
-      
-      return await response.json();
+      const response = await api.get(`${API_BASE}/api/fhir-schemas/stats`);
+      return response.data;
     } catch (error) {
       console.error('Error fetching schema stats:', error);
       // Return default stats on error
@@ -265,10 +250,8 @@ class FHIRSchemaService {
     }
 
     try {
-      const response = await fetch(`${API_BASE}/api/fhir-schemas-v2/resource/${resourceType}/interactions`);
-      if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
-      
-      const data = await response.json();
+      const response = await api.get(`${API_BASE}/api/fhir-schemas-v2/resource/${resourceType}/interactions`);
+      const data = response.data;
       this.schemaCache.set(cacheKey, {
         data,
         timestamp: Date.now()
@@ -293,10 +276,8 @@ class FHIRSchemaService {
     }
 
     try {
-      const response = await fetch(`${API_BASE}/api/fhir-schemas-v2/search-parameters/${resourceType}`);
-      if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
-      
-      const data = await response.json();
+      const response = await api.get(`${API_BASE}/api/fhir-schemas-v2/search-parameters/${resourceType}`);
+      const data = response.data;
       this.schemaCache.set(cacheKey, {
         data,
         timestamp: Date.now()

--- a/frontend/src/services/medicationSearchService.js
+++ b/frontend/src/services/medicationSearchService.js
@@ -3,6 +3,7 @@
  * Comprehensive medication database and search functionality for prescribing
  */
 
+import api from './api';
 
 class MedicationSearchService {
   constructor() {
@@ -209,10 +210,8 @@ class MedicationSearchService {
       // First try backend search if available
       let backendResults = [];
       try {
-        const response = await fetch(`/api/catalogs/medications?search=${encodeURIComponent(query)}&limit=${limit}`);
-        if (response.ok) {
-          backendResults = await response.json();
-        }
+        const response = await api.get(`/api/catalogs/medications?search=${encodeURIComponent(query)}&limit=${limit}`);
+        backendResults = response.data;
       } catch (error) {
         // Backend medication search unavailable, using local database
       }

--- a/frontend/src/services/qualityMeasureDocumentationService.js
+++ b/frontend/src/services/qualityMeasureDocumentationService.js
@@ -4,6 +4,7 @@
  */
 
 import { fhirClient } from '../core/fhir/services/fhirClient';
+import api from './api';
 
 export class QualityMeasureDocumentationService {
   constructor() {
@@ -17,10 +18,8 @@ export class QualityMeasureDocumentationService {
    */
   async initializeQualityMeasures() {
     try {
-      const response = await fetch('/api/quality/measures/');
-      if (response.ok) {
-        this.qualityMeasures = await response.json();
-      }
+      const response = await api.get('/api/quality/measures/');
+      this.qualityMeasures = response.data;
     } catch (error) {
       // Fallback to built-in measures
       this.qualityMeasures = this.getBuiltInQualityMeasures();


### PR DESCRIPTION
Second execution pass of the hygiene backlog (items E1 + E7 + F3), two commits.

## E1 + E7 — frontend: raw `fetch` calls lose the auth header

~66 call sites used raw `fetch`, skipping the axios interceptor in `services/api.js` that injects `Authorization: Bearer`. They work in training mode (most clinical routers are unauthenticated) but 401 under `JWT_ENABLED=true`. All now go through the shared `api` client:

| File | Sites | Notes |
|---|---|---|
| `modules/cds-studio/services/cdsStudioApi.js` | 26 | Whole file rewritten onto the shared client via one `request()` helper (433 → 215 lines). Every method signature/return shape preserved, incl. `deleteValueSet`'s 404 tolerance. All 8 consumers use the default import, unchanged. |
| `services/fhirSchemaService.js` | 13 | v2→v1 endpoint fallback semantics preserved, incl. `getResourceSchema`'s 404-means-stop behavior |
| MAR `AdministrationRecord` (2 hooks, `QuickAdminPopover`, 3 recording dialogs) | 6+ | AbortController wiring kept via axios `signal`; error surfaces still prefer backend `detail` |
| `services/MedicationCRUDService.js` | 6 | Also removes an unused `result` variable (−1 lint warning vs master) |
| `modules/ui-composer` (`ProviderTestHarness`, `ProviderComparison`, `CostDisplay`) | 7 | `CostDisplay` drops its hand-rolled `Authorization` header |
| `QuestionnairesSection` | 3 | |
| `PharmacyPage` | 1 | Its previously **silent** catch now logs the failure |
| `ImagingTab` study-ZIP download | 1 | Was hiding under `/dicom/`; now also fails loudly instead of blobbing error pages |
| `QueryStudioEnhanced` distinct-values, `QualityMeasuresPage`, `qualityMeasureDocumentationService`, `medicationSearchService` | 4 | Catalog/built-in fallbacks preserved |

**Test updates:** `TaskPane.test.jsx` and `QueryStudioEnhanced.test.js` now mock the `api` module instead of `global.fetch`. TaskPane passes; QueryStudioEnhanced still fails to *load* on the pre-existing missing-`@testing-library/dom` issue, byte-identical to master.

**Deliberately untouched:** SMART pages (OAuth token exchange / external-app simulation must not carry the app session header — `pages/CLAUDE.md` updated to document this), `utils/quickLogin.js` (pre-auth bootstrap), `core/performance/performance.js` (generic wrapper), `ServiceTestRunner`'s `/fhir` fetch (fhirClient migration is a separate backlog item).

## F3 — backend: hardcoded URLs → env-driven (root CLAUDE.md rule 4)

- **ui_composer agents** (`fhir_http_client.py`, `query_orchestrator.py`, `ui_generation_orchestrator.py`): `http://localhost:8000/fhir/R4` literals now derive from `BACKEND_BASE_URL` — the env var the SMART module already uses, so no new configuration surface.
- **`cds_hooks/prefetch/engine.py`**: `HAPIFHIRPrefetchClient` hardcoded the `http://hapi-fhir:8080/fhir` docker hostname; now reads `HAPI_FHIR_URL` with the same fallback, matching `services/hapi_fhir_client.py`.
- **`smart/authorization_server.py`**: removed the stale `http://localhost:3001/callback` demo redirect URI (its env-derived sibling remains; `api/smart/CLAUDE.md` documents redirect URIs as env-derived).

All constructor changes are `Optional[str] = None` with the env fallback inside — every existing call site is no-arg or passes explicitly, verified by grep.

## Verification (both commits)

- **Frontend**: jest `--json` runs on this branch vs. identical runs on master (same `node_modules` via worktree) — per-test results **byte-identical** across all 491 tests (same 84 pre-existing failures; none added, none flipped) after each commit.
- **Backend**: pytest failure set **byte-identical** to master (73 lines, all pre-existing).
- **Lint**: eslint fingerprints on every touched file identical to master (E1 commit is one warning *better*).
- All 5 edited Python files compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)