### PR TITLE
fix(frontend): reconnect feedback + event plumbing; fix workspace-tab wrongness

### DIFF
--- a/frontend/src/components/clinical/workspace/dialogs/AllergyDialogEnhanced.js
+++ b/frontend/src/components/clinical/workspace/dialogs/AllergyDialogEnhanced.js
@@ -566,16 +566,18 @@ const AllergyDialogEnhanced = ({
       };
 
       // Use the consistent save handler
-      const success = await performSave(fhirAllergy, `Allergy ${allergy ? 'updated' : 'added'} successfully`);
-      
-      if (success) {
-        // Publish event
-        publish(CLINICAL_EVENTS.ALLERGY_ADDED, {
+      const savedAllergy = await performSave(fhirAllergy, `Allergy ${allergy ? 'updated' : 'added'} successfully`);
+
+      if (savedAllergy) {
+        // Publish the SAVED resource (it carries the server id — the local
+        // fhirAllergy has none on create), keyed by add vs update
+        const eventType = allergy ? CLINICAL_EVENTS.ALLERGY_UPDATED : CLINICAL_EVENTS.ALLERGY_ADDED;
+        publish(eventType, {
           patientId,
-          allergyId: fhirAllergy.id,
-          allergy: fhirAllergy
+          allergyId: savedAllergy.id,
+          allergy: savedAllergy
         });
-        
+
         // Close dialog on success
         handleClose();
       }

--- a/frontend/src/components/clinical/workspace/dialogs/CarePlanDialog.js
+++ b/frontend/src/components/clinical/workspace/dialogs/CarePlanDialog.js
@@ -27,6 +27,7 @@ import {
 } from '@mui/icons-material';
 import { format } from 'date-fns';
 import { fhirClient } from '../../../../core/fhir/services/fhirClient';
+import { useClinicalWorkflow, CLINICAL_EVENTS } from '../../../../contexts/ClinicalWorkflowContext';
 
 const INITIAL_FORM = {
   title: '',
@@ -41,6 +42,7 @@ const INITIAL_FORM = {
 
 const CarePlanDialog = ({ open, onClose, carePlan, patientId, onSaved }) => {
   const isViewMode = !!carePlan;
+  const { publish } = useClinicalWorkflow();
   const [formData, setFormData] = useState(INITIAL_FORM);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState(null);
@@ -122,7 +124,14 @@ const CarePlanDialog = ({ open, onClose, carePlan, patientId, onSaved }) => {
         }));
       }
 
-      await fhirClient.create('CarePlan', fhirCarePlan);
+      const savedCarePlan = await fhirClient.create('CarePlan', fhirCarePlan);
+
+      // Publish so subscribed views (Chart Review) refresh without a reload
+      await publish(CLINICAL_EVENTS.CARE_PLAN_CREATED, {
+        patientId,
+        carePlanId: savedCarePlan?.id,
+        carePlan: savedCarePlan || fhirCarePlan
+      });
 
       if (onSaved) {
         onSaved();

--- a/frontend/src/components/clinical/workspace/dialogs/DocumentReferenceDialog.js
+++ b/frontend/src/components/clinical/workspace/dialogs/DocumentReferenceDialog.js
@@ -30,6 +30,7 @@ import {
 } from '@mui/icons-material';
 import { format } from 'date-fns';
 import { fhirClient } from '../../../../core/fhir/services/fhirClient';
+import { useClinicalWorkflow, CLINICAL_EVENTS } from '../../../../contexts/ClinicalWorkflowContext';
 
 const DOCUMENT_TYPES = [
   { value: 'clinical-note', display: 'Clinical Note', system: 'http://loinc.org', code: '11506-3' },
@@ -51,6 +52,7 @@ const INITIAL_FORM = {
 
 const DocumentReferenceDialog = ({ open, onClose, document, patientId, onSaved }) => {
   const isViewMode = !!document;
+  const { publish } = useClinicalWorkflow();
   const [formData, setFormData] = useState(INITIAL_FORM);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState(null);
@@ -103,7 +105,14 @@ const DocumentReferenceDialog = ({ open, onClose, document, patientId, onSaved }
         fhirDocRef.description = formData.description.trim();
       }
 
-      await fhirClient.create('DocumentReference', fhirDocRef);
+      const savedDocRef = await fhirClient.create('DocumentReference', fhirDocRef);
+
+      // Publish so subscribed views (Chart Review) refresh without a reload
+      await publish(CLINICAL_EVENTS.DOCUMENT_CREATED, {
+        patientId,
+        documentId: savedDocRef?.id,
+        document: savedDocRef || fhirDocRef
+      });
 
       if (onSaved) {
         onSaved();

--- a/frontend/src/components/clinical/workspace/tabs/ChartReviewTabOptimized.js
+++ b/frontend/src/components/clinical/workspace/tabs/ChartReviewTabOptimized.js
@@ -166,7 +166,7 @@ const ChartReviewTabOptimized = ({
   const { resolvedMedications, getMedicationDisplay } = useMedicationResolver(medications);
 
   // View and filter states
-  const [viewMode, setViewMode] = useState('dashboard'); // dashboard, timeline, list
+  const [viewMode] = useState('dashboard'); // locked to dashboard — the list/timeline views are unimplemented stubs
   const [dateRange, setDateRange] = useState('all'); // all, 30d, 90d, 1y
   const [showInactive, setShowInactive] = useState(true); // Changed to true - show all by default
   const [searchQuery, setSearchQuery] = useState('');
@@ -552,14 +552,30 @@ const ChartReviewTabOptimized = ({
   
   return (
     <Box sx={{ backgroundColor: theme.palette.mode === 'dark' ? 'background.default' : 'background.paper' }}>
-      {/* Collapsible Filter Panel */}
+      {/* Load failure — without this, a failed load renders as an empty patient */}
+      {error && (
+        <Alert
+          severity="error"
+          sx={{ m: 1 }}
+          action={
+            <Button color="inherit" size="small" onClick={refresh}>
+              Retry
+            </Button>
+          }
+        >
+          <AlertTitle>Failed to load chart data</AlertTitle>
+          {typeof error === 'string' ? error : 'Some clinical data could not be loaded.'}
+        </Alert>
+      )}
+
+      {/* Collapsible Filter Panel — view-mode toggle hidden: the 'list' and
+          'timeline' views are unimplemented stubs that blank the tab */}
       <CollapsibleFilterPanel
         searchQuery={searchQuery}
         onSearchChange={handleSearch}
         dateRange={dateRange}
         onDateRangeChange={handleDateRangeChange}
-        viewMode={viewMode}
-        onViewModeChange={setViewMode}
+        showViewMode={false}
         showInactive={showInactive}
         onShowInactiveChange={setShowInactive}
         onRefresh={refresh}

--- a/frontend/src/components/clinical/workspace/tabs/SummaryTab.js
+++ b/frontend/src/components/clinical/workspace/tabs/SummaryTab.js
@@ -1229,21 +1229,25 @@ const SummaryTab = ({ patientId, onNotificationUpdate, onNavigateToTab }) => {
       }));
     
     return {
+      // The card is titled "Active Problems" and its count is active-filtered —
+      // the list must be too. Copy before sorting: these arrays live in the
+      // shared FHIR cache and in-place sort mutates it.
       recentConditions: conditions
+        .filter(isConditionActive)
         .sort((a, b) => new Date(b.recordedDate || 0) - new Date(a.recordedDate || 0))
         .slice(0, 5),
-      
+
       recentMedications: medications
         .filter(isMedicationActive)
         .sort((a, b) => new Date(b.authoredOn || 0) - new Date(a.authoredOn || 0))
         .slice(0, 5),
-      
+
       recentLabs: observations
         .filter(isObservationLaboratory)
         .sort((a, b) => new Date(b.effectiveDateTime || b.issued || 0) - new Date(a.effectiveDateTime || a.issued || 0))
         .slice(0, 5),
-      
-      recentEncounters: encounters
+
+      recentEncounters: [...encounters]
         .sort((a, b) => new Date(b.period?.start || 0) - new Date(a.period?.start || 0))
         .slice(0, 5),
         
@@ -1599,7 +1603,11 @@ const SummaryTab = ({ patientId, onNotificationUpdate, onNavigateToTab }) => {
                   {recentLabs.length > 0 ? (
                     recentLabs.slice(0, density === 'compact' ? 3 : 5).map((lab) => {
                       const interpretation = getObservationInterpretation(lab);
-                      const interpCode = interpretation?.coding?.[0]?.code || interpretation;
+                      // interpretation is a CodeableConcept — extract a string
+                      // (rendering the object as a Chip label crashes React)
+                      const interpCode = typeof interpretation === 'string'
+                        ? interpretation
+                        : interpretation?.coding?.[0]?.code || interpretation?.text || null;
                       const isAbnormal = interpCode === 'H' || interpCode === 'L' || interpCode === 'HH' || interpCode === 'LL';
                       
                       return (
@@ -1628,9 +1636,9 @@ const SummaryTab = ({ patientId, onNotificationUpdate, onNavigateToTab }) => {
                                   {getResourceDisplayText(lab)}
                                 </Typography>
                                 {isAbnormal && (
-                                  <Chip 
-                                    label={interpretation} 
-                                    size="small" 
+                                  <Chip
+                                    label={interpCode}
+                                    size="small"
                                     color="error"
                                     sx={{ height: 16, fontSize: '0.7rem' }}
                                   />

--- a/frontend/src/constants/clinicalEvents.js
+++ b/frontend/src/constants/clinicalEvents.js
@@ -19,6 +19,8 @@ export const CLINICAL_EVENTS = {
   CONDITION_UPDATED: 'condition.updated',
   CONDITION_RESOLVED: 'condition.resolved',
   CONDITION_DELETED: 'condition.deleted',
+  PROBLEM_ADDED: 'problem.added',
+  PROBLEM_RESOLVED: 'problem.resolved',
 
   // Medication events
   MEDICATION_PRESCRIBED: 'medication.prescribed',
@@ -27,6 +29,12 @@ export const CLINICAL_EVENTS = {
   MEDICATION_DISPENSED: 'medication.dispensed',
   MEDICATION_ADMINISTERED: 'medication.administered',
   MEDICATION_REFILLED: 'medication.refilled',
+  MEDICATION_STATUS_CHANGED: 'medication.status.changed',
+  PRESCRIPTION_VERIFIED: 'prescription.verified',
+
+  // MAR (medication administration record) events
+  MAR_ADMINISTRATION_RECORDED: 'mar.administration.recorded',
+  MAR_DOSE_MISSED: 'mar.dose.missed',
 
   // Allergy events
   ALLERGY_ADDED: 'allergy.added',
@@ -55,6 +63,8 @@ export const CLINICAL_EVENTS = {
   OBSERVATION_UPDATED: 'observation.updated',
   VITAL_SIGNS_RECORDED: 'vital.signs.recorded',
   LAB_RESULT_READY: 'lab.result.ready',
+  RESULT_RECEIVED: 'result.received',
+  RESULT_ACKNOWLEDGED: 'result.acknowledged',
 
   // Diagnostic Report events
   DIAGNOSTIC_REPORT_CREATED: 'diagnostic.report.created',
@@ -82,6 +92,7 @@ export const CLINICAL_EVENTS = {
   ORDER_STATUS_CHANGED: 'order.status.changed',
 
   // Encounter events
+  ENCOUNTER_CREATED: 'encounter.created',
   ENCOUNTER_STARTED: 'encounter.started',
   ENCOUNTER_UPDATED: 'encounter.updated',
   ENCOUNTER_FINISHED: 'encounter.finished',
@@ -91,6 +102,8 @@ export const CLINICAL_EVENTS = {
   DOCUMENT_UPDATED: 'document.updated',
   DOCUMENT_SIGNED: 'document.signed',
   NOTE_CREATED: 'note.created',
+  DOCUMENTATION_CREATED: 'documentation.created',
+  DOCUMENTATION_SHARED: 'documentation.shared',
 
   // Care Plan events
   CARE_PLAN_CREATED: 'care.plan.created',
@@ -101,11 +114,13 @@ export const CLINICAL_EVENTS = {
   ALERT_TRIGGERED: 'alert.triggered',
   ALERT_ACKNOWLEDGED: 'alert.acknowledged',
   CDS_ALERT_FIRED: 'cds.alert.fired',
+  CRITICAL_ALERT: 'alert.critical',
 
   // Tab/View events
   TAB_CHANGED: 'tab.changed',
   VIEW_REFRESHED: 'view.refreshed',
   MODULE_SELECTED: 'module.selected',
+  TAB_UPDATE: 'tab.update',
 
   // Batch operation events
   BATCH_OPERATION_STARTED: 'batch.operation.started',
@@ -115,6 +130,8 @@ export const CLINICAL_EVENTS = {
   // Workflow events
   WORKFLOW_STARTED: 'workflow.started',
   WORKFLOW_COMPLETED: 'workflow.completed',
+  WORKFLOW_NOTIFICATION: 'workflow.notification',
+  QUALITY_DOCUMENTATION_INITIATED: 'quality.documentation.initiated',
   TASK_ASSIGNED: 'task.assigned',
   TASK_COMPLETED: 'task.completed',
 

--- a/frontend/src/contexts/ClinicalWorkflowContext.js
+++ b/frontend/src/contexts/ClinicalWorkflowContext.js
@@ -6,33 +6,16 @@ import React, { createContext, useContext, useState, useEffect, useCallback, use
 import { useFHIRResource } from './FHIRResourceContext';
 import { useAuth } from './AuthContext';
 import websocketService from '../services/websocket';
+import { CLINICAL_EVENTS } from '../constants/clinicalEvents';
 
 const ClinicalWorkflowContext = createContext();
 
-// Clinical Event Types
-export const CLINICAL_EVENTS = {
-  ORDER_PLACED: 'order.placed',
-  ORDER_COMPLETED: 'order.completed',
-  RESULT_RECEIVED: 'result.received',
-  RESULT_ACKNOWLEDGED: 'result.acknowledged',
-  MEDICATION_DISPENSED: 'medication.dispensed',
-  MEDICATION_ADMINISTERED: 'medication.administered',
-  MEDICATION_STATUS_CHANGED: 'medication.status.changed',
-  MAR_ADMINISTRATION_RECORDED: 'mar.administration.recorded',
-  MAR_DOSE_MISSED: 'mar.dose.missed',
-  ENCOUNTER_CREATED: 'encounter.created',
-  ENCOUNTER_UPDATED: 'encounter.updated',
-  DOCUMENTATION_CREATED: 'documentation.created',
-  DOCUMENTATION_SHARED: 'documentation.shared',
-  QUALITY_DOCUMENTATION_INITIATED: 'quality.documentation.initiated',
-  PROBLEM_ADDED: 'problem.added',
-  PROBLEM_RESOLVED: 'problem.resolved',
-  CRITICAL_ALERT: 'alert.critical',
-  WORKFLOW_NOTIFICATION: 'workflow.notification',
-  TAB_UPDATE: 'tab.update',
-  IMAGING_STUDY_AVAILABLE: 'imaging.study.available',
-  CARE_PLAN_UPDATED: 'careplan.updated'
-};
+// Clinical Event Types — one catalog for the whole app.
+// constants/clinicalEvents.js is the single source of truth; this re-export
+// exists because ~28 files import CLINICAL_EVENTS from this context. Do NOT
+// redefine keys here — a second catalog is how 47 publish/subscribe sites
+// ended up on undefined event keys.
+export { CLINICAL_EVENTS };
 
 // Workflow Types
 export const WORKFLOW_TYPES = {

--- a/frontend/src/hooks/patient/usePatientData.js
+++ b/frontend/src/hooks/patient/usePatientData.js
@@ -15,7 +15,7 @@ export const usePatientData = (patientId, options = {}) => {
   const {
     currentPatient,
     setCurrentPatient,
-    getResourcesByType,
+    getPatientResources,
     isLoading: fhirLoading,
     error: fhirError,
     searchResources,
@@ -150,21 +150,25 @@ export const usePatientData = (patientId, options = {}) => {
       };
     }
 
+    // Scope to the current patient's compartment — getResourcesByType returns
+    // every cached resource of a type across ALL patients, which bleeds the
+    // previous patient's data into header counts and tab props after a switch.
+    const forPatient = (type) => getPatientResources(currentPatient.id, type) || [];
     return {
       patient: currentPatient,
-      conditions: getResourcesByType('Condition') || [],
-      medications: getResourcesByType('MedicationRequest') || [],
-      allergies: getResourcesByType('AllergyIntolerance') || [],
-      encounters: getResourcesByType('Encounter') || [],
-      observations: getResourcesByType('Observation') || [],
-      procedures: getResourcesByType('Procedure') || [],
-      immunizations: getResourcesByType('Immunization') || [],
-      carePlans: getResourcesByType('CarePlan') || [],
-      goals: getResourcesByType('Goal') || [],
-      documentReferences: getResourcesByType('DocumentReference') || [],
-      diagnosticReports: getResourcesByType('DiagnosticReport') || [],
+      conditions: forPatient('Condition'),
+      medications: forPatient('MedicationRequest'),
+      allergies: forPatient('AllergyIntolerance'),
+      encounters: forPatient('Encounter'),
+      observations: forPatient('Observation'),
+      procedures: forPatient('Procedure'),
+      immunizations: forPatient('Immunization'),
+      carePlans: forPatient('CarePlan'),
+      goals: forPatient('Goal'),
+      documentReferences: forPatient('DocumentReference'),
+      diagnosticReports: forPatient('DiagnosticReport'),
     };
-  }, [currentPatient, getResourcesByType]);
+  }, [currentPatient, getPatientResources]);
 
   // Derived data
   const derivedData = useMemo(() => {

--- a/frontend/src/pages/PharmacyPage.js
+++ b/frontend/src/pages/PharmacyPage.js
@@ -333,8 +333,9 @@ const PharmacyPage = () => {
         break;
         
       case CLINICAL_EVENTS.ORDER_PLACED:
-        // Only handle medication orders
-        if (eventData.category === 'medication') {
+        // Only handle medication orders (match on resourceType — OrderComposer
+        // drafts don't carry a category)
+        if (eventData.resourceType === 'MedicationRequest' || eventData.category === 'medication') {
           handleRefresh(); // Refresh to get the new order
         }
         break;
@@ -363,7 +364,9 @@ const PharmacyPage = () => {
         });
         
         // Handle medication events regardless of patient
-        if (eventType === CLINICAL_EVENTS.ORDER_PLACED && event.category !== 'medication') {
+        if (eventType === CLINICAL_EVENTS.ORDER_PLACED &&
+            event.resourceType !== 'MedicationRequest' &&
+            event.category !== 'medication') {
           return; // Skip non-medication orders
         }
         

--- a/frontend/src/providers/AppProviders.js
+++ b/frontend/src/providers/AppProviders.js
@@ -1,4 +1,5 @@
 import React, { memo } from 'react';
+import { SnackbarProvider } from 'notistack';
 import { AuthProvider } from '../contexts/AuthContext';
 import { FHIRResourceProvider } from '../contexts/FHIRResourceContext';
 import { WorkflowProvider } from '../contexts/WorkflowContext';
@@ -55,17 +56,24 @@ const CommunicationProvider = createCompoundProvider([
  */
 export const AppProviders = memo(({ children }) => {
   return (
-    <CoreDataProvider>
-      <WorkflowProvider>
-        <ClinicalDomainProvider>
-          <CommunicationProvider>
-            <ClinicalWorkflowProvider>
-              {children}
-            </ClinicalWorkflowProvider>
-          </CommunicationProvider>
-        </ClinicalDomainProvider>
-      </WorkflowProvider>
-    </CoreDataProvider>
+    <SnackbarProvider
+      maxSnack={3}
+      autoHideDuration={4000}
+      preventDuplicate
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+    >
+      <CoreDataProvider>
+        <WorkflowProvider>
+          <ClinicalDomainProvider>
+            <CommunicationProvider>
+              <ClinicalWorkflowProvider>
+                {children}
+              </ClinicalWorkflowProvider>
+            </CommunicationProvider>
+          </ClinicalDomainProvider>
+        </WorkflowProvider>
+      </CoreDataProvider>
+    </SnackbarProvider>
   );
 });
 


### PR DESCRIPTION
First implementation pass of the refinement plan (`claudedocs/REFINEMENT_PLAN.md`, items R1–R2, R5, R16–R17, R19–R21) — the "turn the lights on" PR. 10 files, +132/−73. Every change reconnects wiring the app already has or fixes user-visible wrongness; no new features.

## What was broken → fixed

| Item | Before | After |
|---|---|---|
| **R1** Toasts | notistack's `SnackbarProvider` mounted **nowhere** — every `enqueueSnackbar` (incl. all 7 Enhanced resource dialogs' save confirmations) was a silent no-op | Mounted once in `AppProviders` (max 3, bottom-left, 4s, dedupe). Saving anything now confirms; failures now show |
| **R2** Events | Two diverged `CLINICAL_EVENTS` catalogs → **47 publish/subscribe sites in 17 files on `undefined` keys**, all sharing one `undefined` channel (dead refresh loops + cross-talk) | `ClinicalWorkflowContext` re-exports `constants/clinicalEvents.js` (what the docs always claimed). The 15 context-only keys moved into the constants file with their existing strings; `PRESCRIPTION_VERIFIED` (defined nowhere, used by PharmacyPage) added. One deliberate string change: `CARE_PLAN_UPDATED` `careplan.updated` → `care.plan.updated` — its only pub/sub pair moves together, no literals exist |
| **R5** Order→pharmacy | Queue refresh filtered on `event.category === 'medication'`, but OrderComposer publishes `category: undefined` — signed orders never refreshed the queue | Match on `resourceType === 'MedicationRequest'` (category kept as fallback) |
| **R16** Summary crash | Any abnormal lab in the last 7 days passed a whole CodeableConcept as a Chip label → React throws, error boundary eats the tab | Renders the extracted interpretation code with safe fallbacks |
| **R17** Chart Review | Load `error` destructured and dropped — failure rendered as an *empty patient*; view-mode toggle exposed two unimplemented views that blanked the tab | Error Alert with Retry; toggle hidden (`showViewMode={false}`) until the views exist |
| **R19** Stale after save | CarePlan/Document dialogs published nothing (new items invisible until patient switch); Allergy dialog published the *pre-save* resource (no server id → an edit forked a duplicate) and always as ADDED | All three publish the saved resource, keyed created/updated by mode |
| **R20** Active Problems | "Active Problems" card sorted **all** conditions (count said active, list showed recent-resolved first); memo `.sort`ed shared cache arrays in place | Filters `isConditionActive` first; copies before sorting |
| **R21** Patient bleed | `usePatientData` read the cache **unscoped** — after switching A→B, patient A's rows fed header counts and tab props until LRU eviction | Reads via `getPatientResources(patientId, type)` (the pattern the patient header already used) |

## Verification

- jest per-test results **byte-identical to master** (491 tests, same 84 pre-existing failures) — the changed behavior is uncovered by the suite, so no-diff is the expected clean result.
- eslint fingerprints identical on all ten touched files.
- ⚠️ **Recommend a runtime smoke pass before merge** (the point of this PR is behavior): save a medication → success toast appears; sign a med order with the pharmacy queue open → queue refreshes; open a patient with a recent abnormal lab → Summary renders (previously crashed); switch patients → header counts change immediately; add a care plan → appears in Chart Review without reload.

## Ripple-effect notes for review

- Mounting `SnackbarProvider` means components that *already* called `enqueueSnackbar` will start showing toasts — that's the intent, but expect new (correct) toasts in ChartReview flows that were silent before.
- Unifying the event catalog activates subscriptions that never fired before (e.g., Results tab refresh on `OBSERVATION_RECORDED`, PatientSummaryV4 refreshes). These are the behaviors the code always declared; they just start working.

Refinement plan: 8 of 45 items done with this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)