### PR TITLE
fix(websocket): repair the live-update protocol end-to-end

### DIFF
--- a/backend/api/clinical/administration/router.py
+++ b/backend/api/clinical/administration/router.py
@@ -34,6 +34,7 @@ from fastapi import status as http_status
 from pydantic import BaseModel, Field
 
 from services.hapi_fhir_client import HAPIFHIRClient
+from api.websocket.fhir_notifications import notification_service
 
 from .service import (
     ADMINISTRABLE_STATUSES,
@@ -295,6 +296,19 @@ async def record_administration_endpoint(body: RecordAdministrationRequest) -> R
     logger.info(
         "Recorded MedicationAdministration/%s (action=%s) for MedicationRequest/%s",
         new_id, body.action, body.medication_request_id,
+    )
+
+    # Broadcast so peer MAR views refetch live (failure-proof)
+    patient_ref = (med_admin.get("subject") or {}).get("reference", "")
+    await notification_service.notify_clinical_event(
+        event_type="medication.administered",
+        resource_type="MedicationAdministration",
+        resource_id=new_id,
+        patient_id=patient_ref.replace("Patient/", "") or None,
+        details={
+            "medication_request_id": body.medication_request_id,
+            "action": body.action,
+        },
     )
 
     return RecordAdministrationResponse(

--- a/backend/api/clinical/pharmacy/pharmacy_router.py
+++ b/backend/api/clinical/pharmacy/pharmacy_router.py
@@ -12,6 +12,7 @@ import logging
 from services.hapi_fhir_client import HAPIFHIRClient
 from pydantic import BaseModel
 from api.cds_hooks.constants import ExtensionURLs
+from api.websocket.fhir_notifications import notification_service
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/clinical/pharmacy", tags=["pharmacy"])
@@ -263,6 +264,17 @@ async def dispense_medication(dispense_request: MedicationDispenseRequest):
         med_request["status"] = "completed"
         await hapi_client.update("MedicationRequest", dispense_request.medication_request_id, med_request)
 
+        # Broadcast so open pharmacy queues refresh live (failure-proof —
+        # notification_service never raises into the write path)
+        patient_ref = (med_request.get("subject") or {}).get("reference", "")
+        await notification_service.notify_clinical_event(
+            event_type="medication.dispensed",
+            resource_type="MedicationDispense",
+            resource_id=created_dispense.get("id"),
+            patient_id=patient_ref.replace("Patient/", "") or None,
+            details={"medication_request_id": dispense_request.medication_request_id},
+        )
+
         return {
             "message": "Medication dispensed successfully",
             "dispense_id": created_dispense.get("id"),
@@ -358,6 +370,16 @@ async def update_pharmacy_status(
 
         # Update the resource in HAPI FHIR
         await hapi_client.update("MedicationRequest", medication_request_id, med_request)
+
+        # Broadcast the status change (failure-proof)
+        patient_ref = (med_request.get("subject") or {}).get("reference", "")
+        await notification_service.notify_clinical_event(
+            event_type="medication.status.changed",
+            resource_type="MedicationRequest",
+            resource_id=medication_request_id,
+            patient_id=patient_ref.replace("Patient/", "") or None,
+            details={"status": status_update.status},
+        )
 
         return {
             "message": f"Pharmacy status updated to {status_update.status}",

--- a/backend/api/fhir/proxy.py
+++ b/backend/api/fhir/proxy.py
@@ -11,15 +11,79 @@ for R4 compliance.
 
 from fastapi import APIRouter, Request, Response
 from fastapi.responses import StreamingResponse
+import asyncio
 import httpx
 import logging
 import os
 import json
 from typing import Optional, List, Dict, Any
 
+from api.websocket.fhir_notifications import notification_service
+
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+def _extract_patient_id(resource: Dict[str, Any]) -> Optional[str]:
+    """Best-effort patient id from a FHIR resource (subject/patient reference)."""
+    if resource.get("resourceType") == "Patient":
+        return resource.get("id")
+    for field in ("subject", "patient"):
+        ref = (resource.get(field) or {}).get("reference", "")
+        if ref.startswith("Patient/"):
+            return ref.split("/", 1)[1]
+    return None
+
+
+def _notify_fhir_write(method: str, path: str, response: httpx.Response) -> None:
+    """Schedule a WebSocket broadcast for a successful write through the proxy.
+
+    This is the single funnel for frontend-originated FHIR writes (order
+    signing, dialog saves, ...), so hooking it here gives connected clients
+    live resource updates without per-caller wiring. Only plain `{Type}` /
+    `{Type}/{id}` paths broadcast — searches, operations ($...), history and
+    Bundle posts are skipped. Fire-and-forget: never blocks or fails the
+    proxied response.
+    """
+    try:
+        segments = [s for s in path.split("/") if s]
+        if not segments or len(segments) > 2 or "$" in path:
+            return
+        resource_type = segments[0]
+        if not resource_type[:1].isupper() or resource_type == "Bundle":
+            return
+
+        action = {"POST": "created", "PUT": "updated", "PATCH": "updated", "DELETE": "deleted"}[method]
+        resource_id = segments[1] if len(segments) == 2 else None
+        resource_data: Dict[str, Any] = {}
+        patient_id = None
+
+        if action != "deleted":
+            try:
+                parsed = response.json()
+            except Exception:
+                parsed = None
+            if isinstance(parsed, dict) and parsed.get("resourceType") == resource_type:
+                resource_data = parsed
+                resource_id = parsed.get("id") or resource_id
+                patient_id = _extract_patient_id(parsed)
+
+        if not resource_id:
+            return
+
+        if action == "created":
+            coro = notification_service.notify_resource_created(
+                resource_type, resource_id, resource_data, patient_id=patient_id)
+        elif action == "updated":
+            coro = notification_service.notify_resource_updated(
+                resource_type, resource_id, resource_data, patient_id=patient_id)
+        else:
+            coro = notification_service.notify_resource_deleted(
+                resource_type, resource_id, patient_id=patient_id)
+        asyncio.create_task(coro)
+    except Exception as exc:  # noqa: BLE001 — broadcasting must never break the proxy
+        logger.warning(f"FHIR write broadcast skipped: {exc}")
 
 
 def create_operation_outcome(
@@ -144,6 +208,11 @@ async def proxy_to_hapi_fhir(path: str, request: Request):
                 headers=headers,
                 content=body
             )
+
+            # Broadcast successful writes so connected clients see live
+            # updates (fire-and-forget; see _notify_fhir_write)
+            if request.method in ("POST", "PUT", "PATCH", "DELETE") and response.status_code < 300:
+                _notify_fhir_write(request.method, path, response)
 
             # Prepare response headers — strip hop-by-hop and encoding headers
             # that conflict when nginx proxies to us (causes "Content-Length and

--- a/backend/api/websocket/connection_manager.py
+++ b/backend/api/websocket/connection_manager.py
@@ -19,6 +19,7 @@ class Subscription(BaseModel):
     client_id: str
     resource_types: List[str] = []
     patient_ids: List[str] = []
+    room: Optional[str] = None
     created_at: datetime = Field(default_factory=datetime.utcnow)
     
     class Config:
@@ -92,14 +93,16 @@ class ConnectionManager:
         client_id: str,
         subscription_id: str,
         resource_types: List[str] = None,
-        patient_ids: List[str] = None
+        patient_ids: List[str] = None,
+        room: Optional[str] = None
     ):
         """Create a new subscription for a client."""
         subscription = Subscription(
             id=subscription_id,
             client_id=client_id,
             resource_types=resource_types or [],
-            patient_ids=patient_ids or []
+            patient_ids=patient_ids or [],
+            room=room
         )
         
         if client_id not in self.subscriptions:
@@ -125,7 +128,12 @@ class ConnectionManager:
                 if resource_types:
                     for resource_type in resource_types:
                         await self.pool.join_room(client_id, f"patient:{patient_id}:resource:{resource_type}")
-        
+
+        # Custom rooms (e.g. "pharmacy:queue") — the frontend's
+        # subscribeToRoom sends a bare room name
+        if room:
+            await self.pool.join_room(client_id, room)
+
         # Send confirmation
         await self._send_message(
             client_id,
@@ -135,7 +143,8 @@ class ConnectionManager:
                     "action": "created",
                     "subscription_id": subscription_id,
                     "resource_types": resource_types,
-                    "patient_ids": patient_ids
+                    "patient_ids": patient_ids,
+                    "room": room
                 }
             )
         )
@@ -218,33 +227,56 @@ class ConnectionManager:
     async def handle_message(self, client_id: str, message: dict):
         """Handle incoming WebSocket messages."""
         msg_type = message.get("type")
-        
-        if msg_type == "pong":
+
+        if msg_type == "ping":
+            # Client heartbeat — reply, or the client's 10s pong timeout kills
+            # the connection every cycle and the status chip flaps forever
+            await self.pool.send_to_client(client_id, {
+                "type": "pong",
+                "timestamp": datetime.utcnow().isoformat()
+            })
+
+        elif msg_type == "pong":
             # Client responded to ping, connection is healthy
             logger.debug(f"Received pong from client {client_id}")
-            
+
         elif msg_type == "subscribe":
             data = message.get("data", {})
             await self.subscribe(
                 client_id,
                 data.get("subscription_id"),
                 data.get("resource_types"),
-                data.get("patient_ids")
+                data.get("patient_ids"),
+                room=data.get("room")
             )
-            
+
         elif msg_type == "unsubscribe":
             data = message.get("data", {})
             await self.unsubscribe(
                 client_id,
                 data.get("subscription_id")
             )
-            
+
         elif msg_type == "authenticate":
             # Authentication is handled in the WebSocket endpoint, ignore here
             logger.debug(f"Ignoring authenticate message from client {client_id} (handled by endpoint)")
-            
+
+        elif isinstance(msg_type, str) and "." in msg_type and "payload" in message:
+            # Client-published clinical event (the ClinicalWorkflowContext
+            # bridge sends {type: 'order.placed', payload: {...}}). Rebroadcast
+            # verbatim to every OTHER client: their websocket service
+            # dispatches unrecognized types straight to event listeners, so
+            # same-session pub/sub extends across browsers.
+            await self.broadcast_event_to_others(client_id, message)
+
         else:
             logger.warning(f"Unknown message type from client {client_id}: {msg_type}")
+
+    async def broadcast_event_to_others(self, sender_id: str, message: dict):
+        """Rebroadcast a client-published clinical event to all other clients."""
+        for other_id in list(self.pool.connections.keys()):
+            if other_id != sender_id:
+                await self.pool.send_to_client(other_id, message)
             
 
 # Global connection manager instance

--- a/backend/api/websocket/fhir_notifications.py
+++ b/backend/api/websocket/fhir_notifications.py
@@ -8,8 +8,21 @@ logger = logging.getLogger(__name__)
 
 
 class FHIRNotificationService:
-    """Service for sending FHIR resource notifications via WebSocket."""
-    
+    """Service for sending FHIR resource notifications via WebSocket.
+
+    Every notify method is failure-proof: a broadcast problem is logged and
+    swallowed, because notifying must never break the write path that
+    triggered it.
+    """
+
+    async def _safe_broadcast(self, **kwargs):
+        try:
+            await manager.broadcast_resource_update(**kwargs)
+            return True
+        except Exception as exc:  # noqa: BLE001 — never break the caller's write
+            logger.warning(f"WebSocket broadcast failed (ignored): {exc}")
+            return False
+
     async def notify_resource_created(
         self,
         resource_type: str,
@@ -27,7 +40,7 @@ class FHIRNotificationService:
             if subject_ref.startswith("Patient/"):
                 patient_id = subject_ref.replace("Patient/", "")
                 
-        await manager.broadcast_resource_update(
+        await self._safe_broadcast(
             resource_type=resource_type,
             resource_id=resource_id,
             action="created",
@@ -53,7 +66,7 @@ class FHIRNotificationService:
             if subject_ref.startswith("Patient/"):
                 patient_id = subject_ref.replace("Patient/", "")
                 
-        await manager.broadcast_resource_update(
+        await self._safe_broadcast(
             resource_type=resource_type,
             resource_id=resource_id,
             action="updated",
@@ -69,7 +82,7 @@ class FHIRNotificationService:
         patient_id: Optional[str] = None
     ):
         """Notify clients about a deleted FHIR resource."""
-        await manager.broadcast_resource_update(
+        await self._safe_broadcast(
             resource_type=resource_type,
             resource_id=resource_id,
             action="deleted",
@@ -88,7 +101,7 @@ class FHIRNotificationService:
     ):
         """Notify clients about clinical events (e.g., critical lab results)."""
         # This is a specialized notification for clinical use cases
-        await manager.broadcast_resource_update(
+        await self._safe_broadcast(
             resource_type=resource_type,
             resource_id=resource_id,
             action="clinical_event",

--- a/frontend/src/services/websocket.js
+++ b/frontend/src/services/websocket.js
@@ -108,10 +108,14 @@ class WebSocketService {
       
       // Send any queued messages
       this.flushMessageQueue();
-      
+
       // Start heartbeat
       this.startHeartbeat();
-      
+
+      // Re-establish server-side subscriptions — they don't survive a new
+      // socket, and without this a reconnect permanently kills live updates
+      this.resubscribeAll();
+
       // Notify connection listeners
       this.notifyConnectionListeners('connected');
     };
@@ -172,17 +176,23 @@ class WebSocketService {
         // Subscription confirmed
         break;
       case 'update':
-        // Handle FHIR resource updates from other users
+        // FHIR resource updates broadcast by the backend. The server sends
+        // { action, resource_type, resource_id, patient_id, resource };
+        // clinical events carry event_type inside resource. Derive the local
+        // event name from whichever is present.
         if (messageData) {
-          // Resource update received
-          const { event_type, patient_id, resource_type, resource } = messageData;
-          
-          // Dispatch as a clinical event
-          if (event_type && resource) {
-            this.dispatch(event_type, {
+          const { action, event_type, patient_id, resource_type, resource_id, resource } = messageData;
+          const derivedType = event_type
+            || resource?.event_type
+            || (['created', 'updated', 'deleted'].includes(action) ? `resource.${action}` : null);
+
+          if (derivedType) {
+            this.dispatch(derivedType, {
               patientId: patient_id,
-              resource: resource,
+              resourceId: resource_id,
               resourceType: resource_type,
+              resource: resource,
+              details: resource?.details,
               fromWebSocket: true // Mark as coming from WebSocket
             });
           }
@@ -207,7 +217,9 @@ class WebSocketService {
     
     const subscriptionId = `patient-${patientId}-${Date.now()}`;
     const message = {
-      type: 'subscription',
+      // NB: the server's message type is 'subscribe' — 'subscription' lands
+      // in its unknown-type branch and silently registers nothing
+      type: 'subscribe',
       data: {
         subscription_id: subscriptionId,
         patient_ids: [patientId],
@@ -263,7 +275,7 @@ class WebSocketService {
     
     const subscriptionId = `room-${roomName}-${Date.now()}`;
     const message = {
-      type: 'subscription',
+      type: 'subscribe',
       data: {
         subscription_id: subscriptionId,
         room: roomName
@@ -303,6 +315,25 @@ class WebSocketService {
     if (this.activeSubscriptions) {
       this.activeSubscriptions.delete(subscriptionId);
     }
+  }
+
+  /**
+   * Re-send every active server-side subscription (after (re)connect)
+   */
+  resubscribeAll() {
+    if (!this.activeSubscriptions || this.activeSubscriptions.size === 0) {
+      return;
+    }
+    this.activeSubscriptions.forEach((info, subscriptionId) => {
+      const data = info.room
+        ? { subscription_id: subscriptionId, room: info.room }
+        : {
+            subscription_id: subscriptionId,
+            patient_ids: [info.patientId],
+            resource_types: info.resourceTypes || []
+          };
+      this.send({ type: 'subscribe', data });
+    });
   }
 
   /**
@@ -451,6 +482,10 @@ class WebSocketService {
       this.reconnectDelay * Math.pow(2, this.reconnectAttempts - 1),
       this.maxReconnectDelay
     );
+
+    // Let the status chip show "reconnecting" instead of flapping
+    // between connected/disconnected
+    this.notifyConnectionListeners('reconnecting');
 
     this.reconnectTimer = setTimeout(async () => {
       this.reconnectTimer = null;


### PR DESCRIPTION
Second implementation pass of the refinement plan (items R3 + R4). The WebSocket layer was decorative — five independent breaks meant no live update ever reached another browser, and the heartbeat killed the connection every ~40 seconds. 7 files, all small aligned diffs.

## The five breaks → fixes

1. **Wrong subscribe message type** — client sent `type:'subscription'`, server only handles `'subscribe'`; every subscription from 8 components landed in the unknown-type branch. Client now sends `'subscribe'`, and the server's handler accepts a `room` field so `subscribeToRoom('pharmacy:queue')` actually joins a pool room.
2. **No pong** — the server had no `'ping'` case; the client's 10s pong timeout closed the socket every 30s heartbeat (this is why the status chip flapped perpetually). Server replies `pong` now.
3. **Payload shape mismatch** — the client's `'update'` handler required an `event_type` the server never sent (`action`). It now derives the event three ways: explicit `event_type`, a clinical-event type inside the resource payload, or `resource.{created|updated|deleted}` — all keys in `constants/clinicalEvents.js`.
4. **Subscriptions lost on reconnect** — stored "for reconnection" but never replayed; any drop permanently killed realtime. `onopen` replays them all, and `scheduleReconnect` emits the `'reconnecting'` state the status chip already renders.
5. **Nothing ever broadcast** — `FHIRNotificationService` had zero call sites. Now three sources feed it:
   - **The FHIR proxy** broadcasts every successful plain-resource write (`{Type}` / `{Type}/{id}`; searches, `$operations`, Bundles skipped) — the single funnel for frontend-originated writes (order signing, dialog saves), fire-and-forget so it can never block or fail the proxied response.
   - **Backend-internal write paths** that bypass the proxy notify explicitly: dispense → `medication.dispensed`, pharmacy status → `medication.status.changed`, MAR record → `medication.administered` — keys the frontend bridge already subscribes to.
   - **Client-published clinical events** (`{type:'order.placed', payload}` from the context bridge) are rebroadcast verbatim to every other client — same-session pub/sub extended across browsers with zero client format changes.

All notify paths are failure-proof: broadcast errors are logged and swallowed, never surfacing into the write that triggered them.

## What this makes real

- The connection stays up (no more 40s kill cycle); the status chip shows *reconnecting* instead of flapping.
- Two-browser flows work: a dispense in one browser refreshes the pharmacy queue in another; a dose charted by one nurse refetches a peer's MAR; any order/dialog save broadcasts a resource update.

## Composition note

The generic `resource.*` channel reaches local listeners fully once **PR #197**'s event-catalog unification merges (RESOURCE_CREATED/UPDATED/DELETED live in the constants catalog). Different files — the two PRs compose without conflict; the clinical-event notifications work with master's catalog today.

## Verification

- Backend pytest failure set and frontend jest per-test results **byte-identical to master**; eslint clean on the touched service.
- All changed modules compile and import cleanly (including the new proxy → websocket import chain, checked for cycles); patient-id extraction and the safe-broadcast wrapper smoke-tested directly.
- ⚠️ True live behavior needs a **two-browser smoke** on a running stack: open the pharmacy queue in browser A, dispense in browser B → A refreshes; watch the connection chip stay green past the one-minute mark.

Refinement plan: 10 of 45 items done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)