### PR TITLE
perf(frontend): fast patient open — paint on Patient load, kill the fetch storm, lazy routes

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -69,38 +69,46 @@ function ThemedApp() {
     return baseTheme;
   }, [currentTheme, currentMode, clinicalContext, autoDetectContext]);
   
-  const handleThemeChange = (themeName) => {
+  // Stable handlers (they close over nothing but setState, which is stable)
+  // + memoized context value: an inline object here re-rendered every
+  // MedicalThemeContext consumer on each App render.
+  const handleThemeChange = React.useCallback((themeName) => {
     setCurrentTheme(themeName);
     localStorage.setItem('medicalTheme', themeName);
-  };
-  
-  const handleModeChange = (mode) => {
+  }, []);
+
+  const handleModeChange = React.useCallback((mode) => {
     setCurrentMode(mode);
     localStorage.setItem('medicalMode', mode);
-  };
-  
-  const handleDepartmentChange = (dept) => {
+  }, []);
+
+  const handleDepartmentChange = React.useCallback((dept) => {
     setDepartment(dept);
     localStorage.setItem('medicalDepartment', dept);
-  };
-  
-  const handleAutoDetectChange = (enabled) => {
+  }, []);
+
+  const handleAutoDetectChange = React.useCallback((enabled) => {
     setAutoDetectContext(enabled);
     localStorage.setItem('autoDetectClinicalContext', enabled.toString());
-  };
-  
+  }, []);
+
+  const themeContextValue = useMemo(() => ({
+    currentTheme,
+    currentMode,
+    department,
+    clinicalContext,
+    autoDetectContext,
+    onThemeChange: handleThemeChange,
+    onModeChange: handleModeChange,
+    onDepartmentChange: handleDepartmentChange,
+    onAutoDetectChange: handleAutoDetectChange
+  }), [
+    currentTheme, currentMode, department, clinicalContext, autoDetectContext,
+    handleThemeChange, handleModeChange, handleDepartmentChange, handleAutoDetectChange
+  ]);
+
   return (
-    <MedicalThemeContext.Provider value={{ 
-      currentTheme, 
-      currentMode,
-      department,
-      clinicalContext,
-      autoDetectContext,
-      onThemeChange: handleThemeChange, 
-      onModeChange: handleModeChange,
-      onDepartmentChange: handleDepartmentChange,
-      onAutoDetectChange: handleAutoDetectChange
-    }}>
+    <MedicalThemeContext.Provider value={themeContextValue}>
       <ThemeProvider theme={theme}>
         <CssBaseline />
         <LocalizationProvider dateAdapter={AdapterDateFns}>

--- a/frontend/src/components/LayoutV3.js
+++ b/frontend/src/components/LayoutV3.js
@@ -522,7 +522,7 @@ function LayoutV3({ children }) {
             : 'linear-gradient(180deg, rgba(99,102,241,0.10) 0%, rgba(99,102,241,0.03) 200px, transparent 500px)',
         }}>
           <BreadcrumbNavigation location={location} />
-          <TransitionWrapper transition="fade" duration={300}>
+          <TransitionWrapper transition="fade" duration={150}>
             {children}
           </TransitionWrapper>
         </Box>

--- a/frontend/src/components/clinical/layouts/EnhancedClinicalLayout.js
+++ b/frontend/src/components/clinical/layouts/EnhancedClinicalLayout.js
@@ -22,6 +22,7 @@ import { useResponsive } from '../../../hooks/useResponsive';
 import { MedicalThemeContext } from '../../../App';
 import { LAYOUT_HEIGHTS, Z_INDEX } from '../theme/clinicalThemeConstants';
 import { CLINICAL_TABS } from '../workspace/clinicalTabRegistry';
+import { decodeFhirId } from '../../../core/navigation/navigationUtils';
 
 // Module configuration — id → {id, label, index}, derived from the single
 // tab registry. `index` is the registry's array position, so tab order
@@ -40,7 +41,10 @@ const EnhancedClinicalLayout = ({
   navigationContext = {}
 }) => {
   const theme = useTheme();
-  const { id: patientId } = useParams();
+  // Route param is URL-encoded; an un-decoded id creates a second patient
+  // compartment in the FHIR cache (split-brain with pages that decode).
+  const { id: rawPatientId } = useParams();
+  const patientId = rawPatientId ? decodeFhirId(rawPatientId).toLowerCase() : rawPatientId;
   const { user } = useAuth();
   const { currentMode, onModeChange } = React.useContext(MedicalThemeContext);
   const isDarkMode = currentMode === 'dark';

--- a/frontend/src/components/transitions/TransitionWrapper.js
+++ b/frontend/src/components/transitions/TransitionWrapper.js
@@ -9,17 +9,17 @@ import { useLocation } from 'react-router-dom';
 import { Box, Fade } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 
-const TransitionWrapper = ({ children, transition = 'fade', duration = 300 }) => {
+const TransitionWrapper = ({ children, transition = 'fade', duration = 150 }) => {
   const location = useLocation();
   const theme = useTheme();
   const [show, setShow] = useState(false);
 
   useEffect(() => {
+    // One animation frame instead of a 50ms timer: the old hide→wait→fade
+    // cycle added ~350ms of artificial latency to every navigation.
     setShow(false);
-    const timer = setTimeout(() => {
-      setShow(true);
-    }, 50);
-    return () => clearTimeout(timer);
+    const raf = requestAnimationFrame(() => setShow(true));
+    return () => cancelAnimationFrame(raf);
   }, [location.pathname]);
 
   // Apply transition based on type

--- a/frontend/src/contexts/ClinicalWorkflowContext.js
+++ b/frontend/src/contexts/ClinicalWorkflowContext.js
@@ -2,7 +2,7 @@
  * Clinical Workflow Context
  * Manages cross-tab communication, workflow orchestration, and clinical context sharing
  */
-import React, { createContext, useContext, useState, useEffect, useCallback, useRef } from 'react';
+import React, { createContext, useContext, useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useFHIRResource } from './FHIRResourceContext';
 import { useAuth } from './AuthContext';
 import websocketService from '../services/websocket';
@@ -671,36 +671,43 @@ export const ClinicalWorkflowProvider = ({ children }) => {
     setNotifications([]);
   }, []);
 
-  const value = {
+  // Memoized: an unmemoized object identity re-rendered every consumer of
+  // this context (most of the clinical workspace) on each provider render.
+  const value = useMemo(() => ({
     // Clinical context
     clinicalContext,
     getCurrentClinicalContext,
     updateClinicalContext,
-    
+
     // Event system
     subscribe,
     publish,
     CLINICAL_EVENTS,
     WORKFLOW_TYPES,
-    
+
     // Notifications
     notifications,
     clearNotification,
     clearAllNotifications,
     createCriticalAlert,
     createWorkflowNotification,
-    
+
     // Navigation
     navigateWithContext,
-    
+
     // Workflow states
     workflowStates,
     setWorkflowStates,
-    
+
     // WebSocket status
     wsConnected,
     wsReconnecting
-  };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }), [
+    clinicalContext, subscribe, publish, notifications,
+    clearNotification, clearAllNotifications, navigateWithContext,
+    workflowStates, wsConnected, wsReconnecting
+  ]);
 
   return (
     <ClinicalWorkflowContext.Provider value={value}>

--- a/frontend/src/contexts/FHIRResourceContext.js
+++ b/frontend/src/contexts/FHIRResourceContext.js
@@ -400,6 +400,12 @@ export function FHIRResourceProvider({ children }) {
   
   // Track in-flight requests to prevent duplicates
   const inFlightRequests = useRef(new Map());
+  // Completed warm-cache runs (cacheKey -> timestamp). Without this, every
+  // consumer that calls warmPatientCache after the first run completes
+  // (PatientSummaryV4 on mount, tabs) re-fires the whole 9-type batch —
+  // the in-flight map only dedupes concurrent calls, not repeats.
+  const completedWarms = useRef(new Map());
+  const WARM_RESULT_TTL_MS = 2 * 60 * 1000;
   // Track timeouts for cleanup
   const timeoutRefs = useRef(new Set());
   // Memoization for getPatientResources to prevent duplicate calculations
@@ -449,20 +455,34 @@ export function FHIRResourceProvider({ children }) {
     });
   }, []);
 
-  // Cleanup old resources to prevent memory growth - more aggressive
+  // Cleanup old resources to prevent memory growth.
+  // Cap must stay ABOVE the largest fetch size (warm batch requests up to
+  // 50/type, $everything pages 100, refresh paths up to 200 with includes):
+  // at the old cap of 50, rows fetched for the current patient were evicted
+  // the moment they landed. Eviction also prefers keeping the current
+  // patient's compartment — the pool is shared across patients.
   const cleanupOldResources = useCallback(() => {
-    const MAX_RESOURCES_PER_TYPE = 50; // Reduced from 200 to 50
+    const MAX_RESOURCES_PER_TYPE = 300;
+    const currentPatientId = state.currentPatient?.id;
     const resourceTypes = Object.keys(state.resources);
-    
+
     resourceTypes.forEach(resourceType => {
       const resources = state.resources[resourceType];
       const resourceIds = Object.keys(resources);
-      
+
       if (resourceIds.length > MAX_RESOURCES_PER_TYPE) {
-        // Sort by lastUpdated or meta.lastUpdated to keep recent ones
+        const belongsToCurrent = (resource) => {
+          if (!currentPatientId) return false;
+          const ref = resource.subject?.reference || resource.patient?.reference;
+          return ref === `Patient/${currentPatientId}` || ref === `urn:uuid:${currentPatientId}`;
+        };
+        // Keep current patient's rows first, then most recently updated
         const sortedResources = resourceIds
           .map(id => ({ id, resource: resources[id] }))
           .sort((a, b) => {
+            const aCur = belongsToCurrent(a.resource) ? 1 : 0;
+            const bCur = belongsToCurrent(b.resource) ? 1 : 0;
+            if (aCur !== bCur) return bCur - aCur;
             const dateA = new Date(a.resource.meta?.lastUpdated || a.resource.lastUpdated || 0);
             const dateB = new Date(b.resource.meta?.lastUpdated || b.resource.lastUpdated || 0);
             return dateB - dateA;
@@ -486,7 +506,7 @@ export function FHIRResourceProvider({ children }) {
         });
       }
     });
-  }, [state.resources]);
+  }, [state.resources, state.currentPatient]);
 
   // Resource Management Functions
   const setResources = useCallback((resourceType, resources) => {
@@ -495,9 +515,10 @@ export function FHIRResourceProvider({ children }) {
       payload: { resourceType, resources }
     });
     
-    // Trigger cleanup if needed - more aggressive threshold
+    // Trigger cleanup only when the pool is actually over the cap —
+    // the old threshold (30) fired eviction on nearly every fetch.
     const resourceCount = Object.keys(state.resources[resourceType] || {}).length;
-    if (resourceCount > 30) { // Reduced from 150 to 30
+    if (resourceCount > 300) {
       setTimeout(cleanupOldResources, 0);
     }
   }, [state.resources, cleanupOldResources]);
@@ -1425,11 +1446,18 @@ export function FHIRResourceProvider({ children }) {
       }
       
       dispatch({ type: FHIR_ACTIONS.SET_CURRENT_PATIENT, payload: patient });
-      
+
+      // First paint must not wait for the 9-type summary warm: resolve as
+      // soon as the Patient resource is in context so the workspace shell
+      // (header, tab strip) can render. Tabs own their per-resource loading
+      // states, and warmPatientCache deduplicates with the identical call
+      // PatientSummaryV4 makes on mount, so the background warm is safe.
+      dispatch({ type: FHIR_ACTIONS.SET_GLOBAL_LOADING, payload: false });
+
       // Check if we already have critical resources cached
-      const hasExistingData = state.relationships[patientId] && 
+      const hasExistingData = state.relationships[patientId] &&
         Object.keys(state.relationships[patientId]).length > 0;
-      
+
       if (!hasExistingData) {
         // Use the typed batch loader (same path PatientSummaryV4 calls).
         //
@@ -1449,23 +1477,26 @@ export function FHIRResourceProvider({ children }) {
         // AllergyIntolerance 20, Observation 30 vital-signs only, …).
         // It also deduplicates inflight requests, so a concurrent call
         // from PatientSummaryV4 merges instead of races.
-        try {
-          await warmPatientCache(patientId, 'summary');
-        } catch (warmError) {
-          // Last-resort fallback: the legacy $everything path. Kept for
-          // safety in case the batch endpoint returns a structurally
-          // odd response. fetchPatientEverything itself paginates
-          // properly (see the change in fetchPatientEverything).
-          await fetchPatientEverything(patientId, {
-            types: ['Condition', 'MedicationRequest', 'AllergyIntolerance', 'Observation', 'Encounter'],
-            count: 100,
-            autoSince: false,
-            forceRefresh: false,
-          }).catch(() => fetchPatientBundle(patientId, false, 'critical'));
-        }
+        // Fire-and-forget: the fallback chain (legacy $everything path,
+        // then the critical bundle) is preserved, but nothing here blocks
+        // the patient-open promise anymore. Note warmPatientCache resolves
+        // {success:false} rather than rejecting, so the fallback keys off
+        // the result value.
+        warmPatientCache(patientId, 'summary')
+          .then((result) => {
+            if (result && result.success === false) {
+              return fetchPatientEverything(patientId, {
+                types: ['Condition', 'MedicationRequest', 'AllergyIntolerance', 'Observation', 'Encounter'],
+                count: 100,
+                autoSince: false,
+                forceRefresh: false,
+              }).catch(() => fetchPatientBundle(patientId, false, 'critical'));
+            }
+            return result;
+          })
+          .catch(() => { /* background warm failed; tabs fetch on demand */ });
       }
-      
-      dispatch({ type: FHIR_ACTIONS.SET_GLOBAL_LOADING, payload: false });
+
       return patient;
     } catch (error) {
       dispatch({ type: FHIR_ACTIONS.SET_GLOBAL_LOADING, payload: false });
@@ -1495,7 +1526,14 @@ export function FHIRResourceProvider({ children }) {
     if (existingRequest) {
       return existingRequest;
     }
-    
+
+    // A warm that completed recently is a no-op — the compartment data is
+    // already in context state.
+    const lastWarm = completedWarms.current.get(cacheKey);
+    if (lastWarm && Date.now() - lastWarm < WARM_RESULT_TTL_MS) {
+      return { success: true, patientId, cached: true };
+    }
+
     const warmingPromise = (async () => {
       try {
         if (priority === 'all' || priority === 'critical') {
@@ -1537,14 +1575,16 @@ export function FHIRResourceProvider({ children }) {
                 params.append('_sort', '-date');
               } else if (resourceType === 'Procedure') {
                 params.append('_count', '10'); // Recent procedures
-                params.append('_sort', '-performed-date');
+                // HAPI's Procedure date search param is 'date' (Procedure.performed)
+                params.append('_sort', '-date');
               } else if (resourceType === 'DiagnosticReport') {
                 params.append('_count', '10'); // Recent lab reports
                 params.append('_sort', '-date');
                 params.append('category', 'LAB'); // Focus on lab reports
               } else if (resourceType === 'Immunization') {
                 params.append('_count', '20'); // Get all immunizations
-                params.append('_sort', '-occurrence-date');
+                // HAPI's Immunization date search param is 'date' (occurrenceDateTime)
+                params.append('_sort', '-date');
               }
               
               return {
@@ -1643,6 +1683,7 @@ export function FHIRResourceProvider({ children }) {
           }
         }
         
+        completedWarms.current.set(cacheKey, Date.now());
         return { success: true, patientId };
       } catch (error) {
         // Log but don't throw - cache warming should fail silently
@@ -1676,9 +1717,14 @@ export function FHIRResourceProvider({ children }) {
   }, [state.errors]);
 
   const clearCache = useCallback((cacheType = null) => {
+    // getCachedData consults intelligentCache BEFORE the state cache, so an
+    // invalidation that only touches state leaves stale reads for up to the
+    // intelligent-cache TTL (~5 min after an edit). Clear both layers.
     if (cacheType) {
+      intelligentCache.clearByTag(cacheType);
       dispatch({ type: FHIR_ACTIONS.INVALIDATE_CACHE, payload: { cacheType } });
     } else {
+      intelligentCache.clear();
       // Clear all caches
       Object.keys(state.cache).forEach(type => {
         dispatch({ type: FHIR_ACTIONS.INVALIDATE_CACHE, payload: { cacheType: type } });
@@ -1689,8 +1735,9 @@ export function FHIRResourceProvider({ children }) {
   const refreshPatientResources = useStableCallback(async (patientId) => {
     try {
       
-      // Clear the patient bundle cache
+      // Clear the patient bundle cache — both layers (see clearCache)
       const cacheKey = `patient_bundle_${patientId}`;
+      intelligentCache.clearPatient(patientId);
       dispatch({ type: FHIR_ACTIONS.INVALIDATE_CACHE, payload: { cacheType: 'bundles', key: cacheKey } });
       
       // Clear the relationships for this patient to ensure fresh data
@@ -1716,7 +1763,7 @@ export function FHIRResourceProvider({ children }) {
         // Add appropriate sort parameters for each resource type
         switch (resourceType) {
           case 'Procedure':
-            params._sort = '-performed-date';
+            params._sort = '-date';
             break;
           case 'Observation':
             params._sort = '-date';
@@ -1759,6 +1806,7 @@ export function FHIRResourceProvider({ children }) {
         }
         
         const searchKey = `${resourceType}_${JSON.stringify(params)}`;
+        intelligentCache.delete(`searches:${searchKey}`);
         dispatch({ type: FHIR_ACTIONS.INVALIDATE_CACHE, payload: { cacheType: 'searches', key: searchKey } });
       });
       

--- a/frontend/src/core/fhir/services/fhirClient.ts
+++ b/frontend/src/core/fhir/services/fhirClient.ts
@@ -1659,7 +1659,7 @@ class FHIRClient {
   async getProcedures(patientId: string, count: number = 50): Promise<SearchResult<Procedure>> {
     return this.search<Procedure>('Procedure', {
       patient: patientId,
-      _sort: '-performed-date',
+      _sort: '-date',
       _count: count
     });
   }

--- a/frontend/src/hooks/patient/usePatientData.js
+++ b/frontend/src/hooks/patient/usePatientData.js
@@ -8,7 +8,12 @@ import { useProgressiveLoading } from '../ui/useProgressiveLoading';
 
 export const usePatientData = (patientId, options = {}) => {
   const {
-    useProgressive = true, // Enable progressive loading by default
+    // Off by default: setCurrentPatient's summary warm already batch-loads
+    // the compartment. With this on, the hook fired ~12 additional per-type
+    // searches whose params don't match the warm batch (different counts/
+    // sorts/filters), so nothing deduplicated — 20+ HAPI queries per patient
+    // open. Opt in per-consumer if a surface genuinely needs the extra types.
+    useProgressive = false,
     ...progressiveOptions
   } = options;
 

--- a/frontend/src/hooks/ui/useProgressiveLoading.js
+++ b/frontend/src/hooks/ui/useProgressiveLoading.js
@@ -35,7 +35,10 @@ export const useProgressiveLoading = (patientId, options = {}) => {
     priorityOverrides = {},
     loadDelay = 100, // Delay between priority levels
     maxConcurrent = 3, // Max concurrent requests
-    onProgressUpdate = null // Callback for progress updates
+    onProgressUpdate = null, // Callback for progress updates
+    // Callers (usePatientData) have always passed `enabled`, but the hook
+    // silently dropped it and loaded regardless — honor it.
+    enabled = true
   } = options;
 
   const { searchResources } = useFHIRResource();
@@ -270,7 +273,7 @@ export const useProgressiveLoading = (patientId, options = {}) => {
 
   // Start loading when patient changes
   useEffect(() => {
-    if (patientId) {
+    if (patientId && enabled) {
       startProgressiveLoad();
     }
 
@@ -280,7 +283,7 @@ export const useProgressiveLoading = (patientId, options = {}) => {
         abortController.current.abort();
       }
     };
-  }, [patientId]); // Don't include startProgressiveLoad to avoid loops
+  }, [patientId, enabled]); // Don't include startProgressiveLoad to avoid loops
 
   // Refresh function
   const refresh = useCallback(() => {

--- a/frontend/src/pages/PatientList.js
+++ b/frontend/src/pages/PatientList.js
@@ -147,7 +147,7 @@ function PatientList() {
   // This effect only runs for All Patients tab (activeTab === 1) after initial load
   // Dependencies are carefully selected to prevent re-fetching loops
 
-  const fetchMyPatients = async () => {
+  const fetchMyPatients = async (term = searchTerm) => {
     try {
       setLoading(true);
       // For now, use the same as all patients but filter by provider
@@ -157,15 +157,16 @@ function PatientList() {
         _sort: '-_lastUpdated'
       };
 
-      if (searchTerm && searchTerm.length >= 2) {
+      const searchTermToUse = term;
+      if (searchTermToUse && searchTermToUse.length >= 2) {
         // FHIR search supports name parameter for patient names
         // Also search by identifier (MRN) if the search term looks like it could be an MRN
-        if (/^\d+$/.test(searchTerm)) {
+        if (/^\d+$/.test(searchTermToUse)) {
           // Numeric search term - search by identifier
-          searchParams.identifier = searchTerm;
+          searchParams.identifier = searchTermToUse;
         } else {
           // Text search term - search by name
-          searchParams.name = searchTerm;
+          searchParams.name = searchTermToUse;
         }
       }
 
@@ -327,14 +328,24 @@ function PatientList() {
     }
   };
 
-  // Debounced search function - use ref to avoid recreating
+  // Debounced search. The debounce wrapper is created once, but it must not
+  // freeze first-render state: the old version captured the initial pageSize
+  // (so searches ignored a changed page size) and always hit the
+  // all-patients fetch even from the My Patients tab. The impl ref is
+  // reassigned every render, so the debounced call always sees fresh state.
   const debouncedSearchRef = useRef(null);
-  
-  if (!debouncedSearchRef.current) {
-    debouncedSearchRef.current = debounce((term) => {
-      setPage(0); // Reset to first page on new search
+  const searchImplRef = useRef(null);
+  searchImplRef.current = (term) => {
+    setPage(0); // Reset to first page on new search
+    if (activeTab === 0) {
+      fetchMyPatients(term);
+    } else {
       fetchAllPatients(0, pageSize, term);
-    }, 500);
+    }
+  };
+
+  if (!debouncedSearchRef.current) {
+    debouncedSearchRef.current = debounce((term) => searchImplRef.current(term), 500);
   }
 
   const handleSearchChange = (event) => {
@@ -558,14 +569,18 @@ function PatientList() {
           onChange={handleTabChange}
           sx={{ borderBottom: 1, borderColor: 'divider' }}
         >
-          <Tab 
-            icon={<PeopleIcon />} 
+          <Tab
+            icon={<PeopleIcon />}
             label={
               <SafeBadge badgeContent={myPatientsCount} color="primary">
                 My Patients
               </SafeBadge>
             }
             iconPosition="start"
+            // Honest labeling until provider attribution exists: this tab is
+            // not filtered to the signed-in provider (synthetic data has no
+            // provider assignment), so say so instead of implying it is.
+            title="Demo limitation: synthetic data has no provider assignment — this tab shows the most recently updated patients"
           />
           <Tab 
             icon={<PersonSearchIcon />} 

--- a/frontend/src/router/router.js
+++ b/frontend/src/router/router.js
@@ -1,34 +1,52 @@
-import React from 'react';
+import React, { Suspense, lazy } from 'react';
 import { createBrowserRouter, Navigate } from 'react-router-dom';
+import { Box, CircularProgress } from '@mui/material';
 import ProtectedRoute from '../components/ProtectedRoute';
 import LayoutV3 from '../components/LayoutV3';
 import Login from '../pages/Login';
 import PatientList from '../pages/PatientList';
-import PatientDashboardV2Page from '../pages/PatientDashboardV2Page';
-import ClinicalWorkspaceWrapper from '../components/clinical/ClinicalWorkspaceWrapper';
-import Dashboard from '../pages/Dashboard';
-import Analytics from '../pages/Analytics';
-import FHIRExplorerApp from '../components/fhir-explorer-v4/core/FHIRExplorerApp';
-import QueryStudioEnhanced from '../components/fhir-explorer-v4/query-building/QueryStudioEnhanced';
-import { AppProviders } from '../providers/AppProviders';
-import Settings from '../pages/Settings';
-import Schedule from '../pages/Schedule';
-import NotFound from '../pages/NotFound';
-import MedicationReconciliationPage from '../pages/MedicationReconciliationPage';
-import { CDSStudioPage } from '../modules/cds-studio';
-import CDSPresentationModeTester from '../components/clinical/cds/CDSPresentationModeTester';
-import EncountersPage from '../pages/EncountersPage';
-import QualityMeasuresPage from '../pages/QualityMeasuresPage';
-import CareGapsPage from '../pages/CareGapsPage';
-import AuditTrailPage from '../pages/AuditTrailPage';
-import PharmacyPage from '../pages/PharmacyPage';
-import InventoryManagementPage from '../pages/InventoryManagementPage';
-import PatientTimelinePage from '../pages/PatientTimelinePage';
-import UIComposerMain from '../modules/ui-composer/UIComposerMain';
-import PerformanceTestPage from '../pages/PerformanceTestPage';
-import PageTransitionProvider, { transitionPresets } from '../components/transitions/PageTransitionProvider';
-import SMARTCallbackPage from '../pages/SMARTCallbackPage';
-import SMARTDemoApp from '../pages/SMARTDemoApp';
+
+// Every page except Login/PatientList is lazy: statically importing them
+// pulled d3 (FHIR Explorer), monaco (CDS Studio), and recharts (Analytics)
+// into the initial bundle, so those libraries downloaded before the login
+// screen could paint.
+const PatientDashboardV2Page = lazy(() => import('../pages/PatientDashboardV2Page'));
+const ClinicalWorkspaceWrapper = lazy(() => import('../components/clinical/ClinicalWorkspaceWrapper'));
+const Dashboard = lazy(() => import('../pages/Dashboard'));
+const Analytics = lazy(() => import('../pages/Analytics'));
+const FHIRExplorerApp = lazy(() => import('../components/fhir-explorer-v4/core/FHIRExplorerApp'));
+const QueryStudioEnhanced = lazy(() => import('../components/fhir-explorer-v4/query-building/QueryStudioEnhanced'));
+const Settings = lazy(() => import('../pages/Settings'));
+const Schedule = lazy(() => import('../pages/Schedule'));
+const NotFound = lazy(() => import('../pages/NotFound'));
+const MedicationReconciliationPage = lazy(() => import('../pages/MedicationReconciliationPage'));
+const CDSStudioPage = lazy(() => import('../modules/cds-studio').then(m => ({ default: m.CDSStudioPage })));
+const CDSPresentationModeTester = lazy(() => import('../components/clinical/cds/CDSPresentationModeTester'));
+const EncountersPage = lazy(() => import('../pages/EncountersPage'));
+const QualityMeasuresPage = lazy(() => import('../pages/QualityMeasuresPage'));
+const CareGapsPage = lazy(() => import('../pages/CareGapsPage'));
+const AuditTrailPage = lazy(() => import('../pages/AuditTrailPage'));
+const PharmacyPage = lazy(() => import('../pages/PharmacyPage'));
+const InventoryManagementPage = lazy(() => import('../pages/InventoryManagementPage'));
+const PatientTimelinePage = lazy(() => import('../pages/PatientTimelinePage'));
+const UIComposerMain = lazy(() => import('../modules/ui-composer/UIComposerMain'));
+const PerformanceTestPage = lazy(() => import('../pages/PerformanceTestPage'));
+const SMARTCallbackPage = lazy(() => import('../pages/SMARTCallbackPage'));
+const SMARTDemoApp = lazy(() => import('../pages/SMARTDemoApp'));
+
+const routeFallback = (
+  <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '60vh' }}>
+    <CircularProgress size={40} />
+  </Box>
+);
+
+// Wrap a lazy page in Suspense; optionally in the app chrome + auth guard.
+const page = (element, { layout = true, protect = true } = {}) => {
+  let node = <Suspense fallback={routeFallback}>{element}</Suspense>;
+  if (layout) node = <LayoutV3>{node}</LayoutV3>;
+  if (protect) node = <ProtectedRoute>{node}</ProtectedRoute>;
+  return node;
+};
 
 // Create router with future flags enabled
 export const router = createBrowserRouter([
@@ -52,61 +70,27 @@ export const router = createBrowserRouter([
   },
   {
     path: '/patients/:id',
-    element: (
-      <ProtectedRoute>
-        <LayoutV3>
-          <PatientDashboardV2Page />
-        </LayoutV3>
-      </ProtectedRoute>
-    )
+    element: page(<PatientDashboardV2Page />)
   },
   {
     path: '/patients/:id/clinical',
-    element: (
-      <ProtectedRoute>
-        <ClinicalWorkspaceWrapper />
-      </ProtectedRoute>
-    )
+    element: page(<ClinicalWorkspaceWrapper />, { layout: false })
   },
   {
     path: '/patients/:id/timeline',
-    element: (
-      <ProtectedRoute>
-        <LayoutV3>
-          <PatientTimelinePage />
-        </LayoutV3>
-      </ProtectedRoute>
-    )
+    element: page(<PatientTimelinePage />)
   },
   {
     path: '/patients/:id/medication-reconciliation',
-    element: (
-      <ProtectedRoute>
-        <LayoutV3>
-          <MedicationReconciliationPage />
-        </LayoutV3>
-      </ProtectedRoute>
-    )
+    element: page(<MedicationReconciliationPage />)
   },
   {
     path: '/patients/:id/encounters/:encounterId/medication-reconciliation',
-    element: (
-      <ProtectedRoute>
-        <LayoutV3>
-          <MedicationReconciliationPage />
-        </LayoutV3>
-      </ProtectedRoute>
-    )
+    element: page(<MedicationReconciliationPage />)
   },
   {
     path: '/dashboard',
-    element: (
-      <ProtectedRoute>
-        <LayoutV3>
-          <Dashboard />
-        </LayoutV3>
-      </ProtectedRoute>
-    )
+    element: page(<Dashboard />)
   },
   {
     path: '/clinical',
@@ -114,91 +98,42 @@ export const router = createBrowserRouter([
   },
   {
     path: '/encounters',
-    element: (
-      <ProtectedRoute>
-        <LayoutV3>
-          <EncountersPage />
-        </LayoutV3>
-      </ProtectedRoute>
-    )
+    element: page(<EncountersPage />)
   },
   {
     path: '/pharmacy',
-    element: (
-      <ProtectedRoute>
-        <LayoutV3>
-          <PharmacyPage />
-        </LayoutV3>
-      </ProtectedRoute>
-    )
+    element: page(<PharmacyPage />)
   },
   {
     path: '/inventory',
-    element: (
-      <ProtectedRoute>
-        <LayoutV3>
-          <InventoryManagementPage />
-        </LayoutV3>
-      </ProtectedRoute>
-    )
+    element: page(<InventoryManagementPage />)
   },
   {
     path: '/analytics',
-    element: (
-      <ProtectedRoute>
-        <LayoutV3>
-          <Analytics />
-        </LayoutV3>
-      </ProtectedRoute>
-    )
+    element: page(<Analytics />)
   },
   {
     path: '/quality',
-    element: (
-      <ProtectedRoute>
-        <LayoutV3>
-          <QualityMeasuresPage />
-        </LayoutV3>
-      </ProtectedRoute>
-    )
+    element: page(<QualityMeasuresPage />)
   },
   {
     path: '/care-gaps',
-    element: (
-      <ProtectedRoute>
-        <LayoutV3>
-          <CareGapsPage />
-        </LayoutV3>
-      </ProtectedRoute>
-    )
+    element: page(<CareGapsPage />)
   },
   {
+    // No LayoutV3 (the explorer owns its shell) and no extra AppProviders —
+    // App.js already wraps the whole RouterProvider in AppProviders, so the
+    // previous nested copy double-mounted every context for this route.
     path: '/fhir-explorer',
-    element: (
-      <ProtectedRoute>
-        <AppProviders>
-          <FHIRExplorerApp />
-        </AppProviders>
-      </ProtectedRoute>
-    )
+    element: page(<FHIRExplorerApp />, { layout: false })
   },
   {
     path: '/fhir-explorer/query-studio-enhanced',
-    element: (
-      <ProtectedRoute>
-        <LayoutV3>
-          <QueryStudioEnhanced />
-        </LayoutV3>
-      </ProtectedRoute>
-    )
+    element: page(<QueryStudioEnhanced />)
   },
   {
     path: '/ui-composer',
-    element: (
-      <ProtectedRoute>
-        <UIComposerMain />
-      </ProtectedRoute>
-    )
+    element: page(<UIComposerMain />, { layout: false })
   },
   // Redirect old CDS path to avoid conflicts with API endpoints
   {
@@ -207,87 +142,41 @@ export const router = createBrowserRouter([
   },
   {
     path: '/cds-studio',
-    element: (
-      <ProtectedRoute>
-        <LayoutV3>
-          <CDSStudioPage />
-        </LayoutV3>
-      </ProtectedRoute>
-    )
+    element: page(<CDSStudioPage />)
   },
   {
     path: '/cds-presentation-test',
-    element: (
-      <ProtectedRoute>
-        <LayoutV3>
-          <CDSPresentationModeTester />
-        </LayoutV3>
-      </ProtectedRoute>
-    )
+    element: page(<CDSPresentationModeTester />)
   },
   {
     path: '/schedule',
-    element: (
-      <ProtectedRoute>
-        <LayoutV3>
-          <Schedule />
-        </LayoutV3>
-      </ProtectedRoute>
-    )
+    element: page(<Schedule />)
   },
   {
     path: '/audit-trail',
-    element: (
-      <ProtectedRoute>
-        <LayoutV3>
-          <AuditTrailPage />
-        </LayoutV3>
-      </ProtectedRoute>
-    )
+    element: page(<AuditTrailPage />)
   },
   {
     path: '/settings',
-    element: (
-      <ProtectedRoute>
-        <LayoutV3>
-          <Settings />
-        </LayoutV3>
-      </ProtectedRoute>
-    )
+    element: page(<Settings />)
   },
   {
     path: '/performance-test',
-    element: (
-      <ProtectedRoute>
-        <LayoutV3>
-          <PerformanceTestPage />
-        </LayoutV3>
-      </ProtectedRoute>
-    )
+    element: page(<PerformanceTestPage />)
   },
   // SMART on FHIR authorization callback
   {
     path: '/smart-callback',
-    element: (
-      <ProtectedRoute>
-        <SMARTCallbackPage />
-      </ProtectedRoute>
-    )
+    element: page(<SMARTCallbackPage />, { layout: false })
   },
-  // Built-in SMART demo app (educational)
+  // Built-in SMART demo app (educational; unauthenticated by design)
   {
     path: '/smart-demo',
-    element: <SMARTDemoApp />
+    element: page(<SMARTDemoApp />, { layout: false, protect: false })
   },
   {
     path: '*',
-    element: (
-      <ProtectedRoute>
-        <LayoutV3>
-          <NotFound />
-        </LayoutV3>
-      </ProtectedRoute>
-    )
+    element: page(<NotFound />)
   }
 ], {
   // Enable future flags to prevent deprecation warnings


### PR DESCRIPTION
## Refinement plan Phase 4: R26, R27, R28, R30, R31 + smoke finding R48

### What changed
- **R26** — `setCurrentPatient` resolves as soon as the Patient resource is in context; the 9-type summary warm continues in the background (its fallback chain now keys off the warm's `success` flag — it never rejects). The workspace shell paints immediately instead of full-screen-spinning behind the whole batch.
- **R27** — `warmPatientCache` gets a completed-run TTL cache (repeat calls were re-firing the entire batch); `useProgressiveLoading` now honors the `enabled` option callers always passed (it silently ignored it), and `usePatientData` defaults progressive **off** — its ~12 per-type searches used params that never matched the warm batch, so nothing deduplicated: 20+ HAPI queries per patient open.
- **R28** — every route except Login/PatientList is `React.lazy`. **Main bundle: 92.97 kB gzipped** (d3, monaco, recharts no longer download before login paints). Also removed the nested `AppProviders` on `/fhir-explorer` (App.js already wraps the router in it — every context was double-mounted on that route).
- **R30** — `clearCache`/`refreshPatientResources` now clear the **intelligentCache** layer too (invalidation previously only touched the state cache, but reads consult intelligentCache first → stale lists up to 5 min after edits). LRU cap 50 → 300 (above the largest fetch — at 50, rows fetched for the current patient were evicted as they landed), and eviction prefers the current patient's compartment.
- **R31** — memoized `ClinicalWorkflowContext` and `MedicalThemeContext` values; TransitionWrapper's 50 ms timer + 300 ms fade → 1 rAF + 150 ms; `EnhancedClinicalLayout` decodes the route patient id (split-compartment risk); PatientList debounced search no longer captures first-render state (stale `pageSize`, tab-blind fetch) and the My Patients tab is labeled honestly.
- **R48** — `Procedure?_sort=-performed-date` / `Immunization?_sort=-occurrence-date` → `-date` (invalid HAPI params; entries 6 and 8 of the patient-open batch 400'd silently on every chart open, so Procedures/Immunizations never warmed).

### Verification
- Frontend: 500 tests, 84 failed — **per-test results byte-identical to master baseline**
- `npm run build` passes; eslint 0 errors on all touched files
- Runtime smoke on wintehrdev before merge (patient-open timing + network-request count)

🤖 Generated with [Claude Code](https://claude.com/claude-code)