### PR TITLE
fix(tabs): correctness sweep — Timeline, Results, Encounters, Chart Review (R18, R22–R25)

### DIFF
--- a/frontend/src/components/clinical/workspace/tabs/ChartReviewTabOptimized.js
+++ b/frontend/src/components/clinical/workspace/tabs/ChartReviewTabOptimized.js
@@ -487,14 +487,15 @@ const ChartReviewTabOptimized = ({
         result = await fhirClient.update(resource.resourceType, resource.id, resource);
         // Update the FHIRResourceContext
         updateResource(resource.resourceType, resource.id, result);
-        enqueueSnackbar(`${resource.resourceType} updated successfully`, { variant: 'success' });
       } else {
         // Create new resource
         result = await fhirClient.create(resource.resourceType, resource);
         // Add to the FHIRResourceContext - addResource expects resourceType and resource parameters
         addResource(resource.resourceType, result);
-        enqueueSnackbar(`${resource.resourceType} created successfully`, { variant: 'success' });
       }
+      // No success toast here: the Enhanced dialogs' save helpers already
+      // enqueue one — firing both produced double toasts, this one with a
+      // raw FHIR type name ("MedicationRequest updated successfully").
 
       // Dispatch fhir-resources-updated event to trigger FHIRResourceContext refresh
       // This ensures all caches are properly invalidated and fresh data is fetched
@@ -881,7 +882,12 @@ const ChartReviewTabOptimized = ({
                         </InteractiveButton>
                       </Stack>
                       
-                      {(showInactive ? conditions.length : processedData.activeConditions.length) === 0 ? (
+                      {/* Gate must count the same date-filtered set the rows
+                          render — the raw array made a narrow date range show
+                          neither rows nor the empty message */}
+                      {(showInactive
+                        ? processedData.activeConditions.length + processedData.inactiveConditions.length
+                        : processedData.activeConditions.length) === 0 ? (
                         <EmptyConditions onAdd={() => handleOpenDialog('condition')} />
                       ) : (
                         <Box sx={{ 
@@ -974,7 +980,9 @@ const ChartReviewTabOptimized = ({
                         </InteractiveButton>
                       </Stack>
                       
-                      {(showInactive ? medications.length : processedData.activeMedications.length) === 0 ? (
+                      {(showInactive
+                        ? processedData.activeMedications.length + processedData.inactiveMedications.length
+                        : processedData.activeMedications.length) === 0 ? (
                         <EmptyMedications onAdd={() => handleOpenDialog('medication')} />
                       ) : (
                         <Box sx={{ 

--- a/frontend/src/components/clinical/workspace/tabs/EncountersTab.js
+++ b/frontend/src/components/clinical/workspace/tabs/EncountersTab.js
@@ -14,20 +14,14 @@ import {
   IconButton,
   Tooltip,
   Divider,
-  TextField,
   InputAdornment,
-  Menu,
-  MenuItem,
-  FormControl,
-  Select,
-  InputLabel,
-  CircularProgress,
   Alert,
   Snackbar,
   Badge,
   Grid,
   ToggleButton,
-  ToggleButtonGroup
+  ToggleButtonGroup,
+  Skeleton
 } from '@mui/material';
 import {
   LocalHospital as HospitalIcon,
@@ -43,15 +37,13 @@ import {
   AccessTime as TimeIcon,
   Draw as SignIcon,
   Assignment as AssignmentIcon,
-  Science as LabIcon,
-  CheckCircle as CheckCircleIcon
+  Science as LabIcon
 } from '@mui/icons-material';
 import { format, parseISO, isWithinInterval, subMonths } from 'date-fns';
 import { formatClinicalDate } from '../../../../core/fhir/utils/dateFormatUtils';
 import { useFHIRResource } from '../../../../contexts/FHIRResourceContext';
 import { navigateToTab, TAB_IDS } from '../../utils/navigationHelper';
 import EncounterSummaryDialogEnhanced from '../dialogs/EncounterSummaryDialogEnhanced';
-import EncounterSigningDialog from '../dialogs/EncounterSigningDialog';
 import EncounterCreationDialog from '../dialogs/EncounterCreationDialog';
 import EnhancedNoteEditor from '../dialogs/EnhancedNoteEditor';
 import Dialog from '@mui/material/Dialog';
@@ -62,7 +54,6 @@ import { printDocument, formatEncountersForPrint } from '../../../../core/export
 import { exportClinicalData, EXPORT_COLUMNS } from '../../../../core/export/exportUtils';
 import { GetApp as ExportIcon } from '@mui/icons-material';
 import { useClinicalWorkflow, CLINICAL_EVENTS } from '../../../../contexts/ClinicalWorkflowContext';
-import { fhirClient } from '../../../../core/fhir/services/fhirClient';
 import { getEncounterClass, getCodeableConceptDisplay, getEncounterStatus } from '../../../../core/fhir/utils/fhirFieldUtils';
 import EnhancedProviderDisplay from '../components/EnhancedProviderDisplay';
 import { ClinicalResourceCard } from '../../shared/cards';
@@ -122,7 +113,7 @@ const EncountersTab = ({
   onNavigateToTab // Cross-tab navigation support
 }) => {
   const { getPatientResources, isLoading, currentPatient, resources, searchResources } = useFHIRResource();
-  const { publish, subscribe } = useClinicalWorkflow();
+  const { subscribe } = useClinicalWorkflow();
   
   const [viewMode, setViewMode] = useState('cards'); // 'cards', 'timeline', or 'table'
   const [filterType, setFilterType] = useState('all');
@@ -130,25 +121,14 @@ const EncountersTab = ({
   const [searchTerm, setSearchTerm] = useState('');
   const scrollContainerRef = useRef(null);
   const [selectedEncounter, setSelectedEncounter] = useState(null);
-  const [expandedCards, setExpandedCards] = useState(new Set());
   const [density, setDensity] = useDensity('comfortable');
   const [snackbar, setSnackbar] = useState({ open: false, message: '', severity: 'success' });
   const [summaryDialogOpen, setSummaryDialogOpen] = useState(false);
-  const [signingDialogOpen, setSigningDialogOpen] = useState(false);
-  const [newEncounterDialogOpen, setNewEncounterDialogOpen] = useState(false);
   const [encounterCreationDialogOpen, setEncounterCreationDialogOpen] = useState(false);
   const [editEncounterDialogOpen, setEditEncounterDialogOpen] = useState(false);
   const [selectedEncounterForEdit, setSelectedEncounterForEdit] = useState(null);
-  const [exportAnchorEl, setExportAnchorEl] = useState(null);
   const [noteEditorOpen, setNoteEditorOpen] = useState(false);
   const [selectedEncounterForNote, setSelectedEncounterForNote] = useState(null);
-  const [newEncounterData, setNewEncounterData] = useState({
-    type: 'AMB',
-    reasonForVisit: '',
-    provider: '',
-    startDate: new Date().toISOString().split('T')[0],
-    startTime: new Date().toTimeString().split(' ')[0].slice(0, 5)
-  });
 
   // Subscribe to encounter-related events
   useEffect(() => {
@@ -194,28 +174,8 @@ const EncountersTab = ({
     setSelectedEncounter(null);
   };
 
-  const handleSignEncounter = (encounter) => {
-    setSelectedEncounter(encounter);
-    setSigningDialogOpen(true);
-  };
 
-  const handleCloseSigningDialog = () => {
-    setSigningDialogOpen(false);
-    setSelectedEncounter(null);
-  };
 
-  const handleEncounterSigned = (signedEncounter) => {
-    setSnackbar({
-      open: true,
-      message: 'Encounter signed successfully',
-      severity: 'success'
-    });
-    
-    // Refresh encounter data
-    window.dispatchEvent(new CustomEvent('fhir-resources-updated', { 
-      detail: { patientId } 
-    }));
-  };
 
   // Handle adding note to encounter
   const handleAddNoteToEncounter = (encounter) => {
@@ -312,88 +272,6 @@ const EncountersTab = ({
     });
   };
   
-  const handleCreateEncounter = async () => {
-    try {
-      // Create FHIR Encounter resource
-      const encounter = {
-        resourceType: 'Encounter',
-        status: 'in-progress',
-        class: {
-          system: 'http://terminology.hl7.org/CodeSystem/v3-ActCode',
-          code: newEncounterData.type,
-          display: newEncounterData.type === 'AMB' ? 'ambulatory' : 
-                  newEncounterData.type === 'IMP' ? 'inpatient' : 
-                  newEncounterData.type === 'EMER' ? 'emergency' : 'ambulatory'
-        },
-        type: [{
-          text: 'Office Visit'
-        }],
-        subject: {
-          reference: `Patient/${patientId}`
-        },
-        period: {
-          start: `${newEncounterData.startDate}T${newEncounterData.startTime}:00`
-        },
-        reasonCode: newEncounterData.reasonForVisit ? [{
-          text: newEncounterData.reasonForVisit
-        }] : [],
-        participant: newEncounterData.provider ? [{
-          type: [{
-            coding: [{
-              system: 'http://terminology.hl7.org/CodeSystem/v3-ParticipationType',
-              code: 'ATND',
-              display: 'attender'
-            }]
-          }],
-          individual: {
-            display: newEncounterData.provider
-          }
-        }] : []
-      };
-
-      const savedEncounter = await fhirClient.create('Encounter', encounter);
-
-      if (savedEncounter) {
-        
-        // Publish encounter created event
-        await publish(CLINICAL_EVENTS.ENCOUNTER_CREATED, {
-          encounterId: savedEncounter.id,
-          patientId,
-          type: newEncounterData.type,
-          reasonForVisit: newEncounterData.reasonForVisit,
-          provider: newEncounterData.provider,
-          timestamp: new Date().toISOString()
-        });
-        
-        // Refresh patient resources to show new encounter
-        window.dispatchEvent(new CustomEvent('fhir-resources-updated', { 
-          detail: { patientId } 
-        }));
-        
-        setNewEncounterDialogOpen(false);
-        setNewEncounterData({
-          type: 'AMB',
-          reasonForVisit: '',
-          provider: '',
-          startDate: new Date().toISOString().split('T')[0],
-          startTime: new Date().toTimeString().split(' ')[0].slice(0, 5)
-        });
-
-        setSnackbar({
-          open: true,
-          message: 'New encounter created successfully',
-          severity: 'success'
-        });
-      }
-    } catch (error) {
-      // Handle error
-      setSnackbar({
-        open: true,
-        message: 'Failed to create encounter: ' + error.message,
-        severity: 'error'
-      });
-    }
-  };
 
   // Get encounters - memoized to prevent dependency issues
   const encounters = useMemo(() => {
@@ -422,43 +300,6 @@ const EncountersTab = ({
     }
   }, [encounters.length, loadEncounters]);
 
-  // Get all clinical resources for timeline
-  const allClinicalResources = useMemo(() => {
-    const resourceTypes = ['Observation', 'MedicationRequest', 'Procedure', 'DiagnosticReport'];
-    const allResources = [];
-    
-    // Add encounters
-    encounters.forEach(enc => {
-      allResources.push({
-        ...enc,
-        resourceType: 'Encounter',
-        date: enc.actualPeriod?.start || enc.period?.start || enc.meta?.lastUpdated
-      });
-    });
-    
-    // Add other clinical resources that reference encounters
-    resourceTypes.forEach(type => {
-      const typeResources = getPatientResources(patientId, type) || [];
-      
-      typeResources.forEach(resource => {
-        if (resource.encounter?.reference || resource.context?.reference) {
-          allResources.push({
-            ...resource,
-            resourceType: type,
-            date: resource.effectiveDateTime || 
-                  resource.authoredOn || 
-                  resource.performedDateTime || 
-                  resource.issued ||
-                  resource.meta?.lastUpdated
-          });
-        }
-      });
-    });
-    
-    return allResources.sort((a, b) => 
-      new Date(b.date || 0) - new Date(a.date || 0)
-    );
-  }, [encounters, patientId, getPatientResources]);
 
   // Filter encounters - memoized for performance
   const filteredEncounters = useMemo(() => {
@@ -535,59 +376,25 @@ const EncountersTab = ({
   }, [encounters, sortedEncounters]);
 
   // Prepare metrics for MetricsBar
-  const encounterMetrics = useMemo(() => [
-    {
-      label: 'Total Visits',
-      value: encounterStats.total,
-      icon: <CalendarIcon />,
-      color: 'primary',
-      severity: 'normal'
-    },
-    {
-      label: 'In Progress',
-      value: encounterStats.inProgress,
-      icon: <TimeIcon />,
-      color: encounterStats.inProgress > 0 ? 'warning' : 'default',
-      severity: encounterStats.inProgress > 0 ? 'moderate' : 'normal'
-    },
-    {
-      label: 'Emergency',
-      value: encounterStats.emergency,
-      icon: <EmergencyIcon />,
-      color: encounterStats.emergency > 0 ? 'error' : 'default',
-      severity: encounterStats.emergency > 0 ? 'high' : 'normal'
-    },
-    {
-      label: 'Completed',
-      value: encounterStats.completed,
-      icon: <CheckCircleIcon />,
-      color: 'success',
-      severity: 'normal',
-      progress: (encounterStats.completed / Math.max(encounterStats.total, 1)) * 100
-    }
-  ], [encounterStats]);
 
   // Handle card expansion toggle
-  const handleToggleCardExpand = useCallback((encounterId, expanded) => {
-    setExpandedCards(prev => {
-      const newSet = new Set(prev);
-      if (expanded) {
-        newSet.add(encounterId);
-      } else {
-        newSet.delete(encounterId);
-      }
-      return newSet;
-    });
-  }, []);
 
   // Use context's isLoading state - this properly reflects when data is actually loading
   if (isLoading) {
+    // Skeleton rows instead of a centered spinner: the layout doesn't jump
+    // when data lands, and the user sees the shape of what's coming.
     return (
-      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', p: 4 }}>
-        <CircularProgress />
-        <Typography sx={{ ml: 2 }} variant="body1" color="text.secondary">
-          Loading encounters...
-        </Typography>
+      <Box sx={{ p: 2 }}>
+        <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
+          {[0, 1, 2, 3].map(i => (
+            <Skeleton key={i} variant="rounded" width="25%" height={72} />
+          ))}
+        </Stack>
+        <Stack spacing={1.5}>
+          {[0, 1, 2, 3, 4].map(i => (
+            <Skeleton key={i} variant="rounded" height={88} />
+          ))}
+        </Stack>
       </Box>
     );
   }
@@ -902,21 +709,6 @@ const EncountersTab = ({
       />
 
       {/* Export Menu */}
-      <Menu
-        anchorEl={exportAnchorEl}
-        open={Boolean(exportAnchorEl)}
-        onClose={() => setExportAnchorEl(null)}
-      >
-        <MenuItem onClick={() => { handleExportEncounters('csv'); setExportAnchorEl(null); }}>
-          Export as CSV
-        </MenuItem>
-        <MenuItem onClick={() => { handleExportEncounters('json'); setExportAnchorEl(null); }}>
-          Export as JSON
-        </MenuItem>
-        <MenuItem onClick={() => { handleExportEncounters('pdf'); setExportAnchorEl(null); }}>
-          Export as PDF
-        </MenuItem>
-      </Menu>
 
       {/* Enhanced Encounter Summary Dialog */}
       <EncounterSummaryDialogEnhanced
@@ -927,12 +719,6 @@ const EncountersTab = ({
       />
 
       {/* Encounter Signing Dialog */}
-      <EncounterSigningDialog
-        open={signingDialogOpen}
-        onClose={handleCloseSigningDialog}
-        encounter={selectedEncounter}
-        onEncounterSigned={handleEncounterSigned}
-      />
 
       {/* New Encounter Creation Dialog */}
       <EncounterCreationDialog
@@ -999,117 +785,7 @@ const EncountersTab = ({
 
       {/* Dialogs are rendered above (lines 934-965), not duplicated here */}
 
-      {/* New Encounter Dialog */}
-      <Dialog open={newEncounterDialogOpen} onClose={() => setNewEncounterDialogOpen(false)} maxWidth="sm" fullWidth>
-        <DialogTitle>New Encounter</DialogTitle>
-        <DialogContent>
-          <Stack spacing={3} sx={{ mt: 2 }}>
-            <FormControl fullWidth>
-              <InputLabel>Encounter Type</InputLabel>
-              <Select
-                value={newEncounterData.type}
-                onChange={(e) => setNewEncounterData({ ...newEncounterData, type: e.target.value })}
-                label="Encounter Type"
-              >
-                <MenuItem value="AMB">Ambulatory (Office Visit)</MenuItem>
-                <MenuItem value="IMP">Inpatient</MenuItem>
-                <MenuItem value="EMER">Emergency</MenuItem>
-                <MenuItem value="HH">Home Health</MenuItem>
-              </Select>
-            </FormControl>
 
-            <TextField
-              fullWidth
-              label="Reason for Visit"
-              value={newEncounterData.reasonForVisit}
-              onChange={(e) => setNewEncounterData({ ...newEncounterData, reasonForVisit: e.target.value })}
-              multiline
-              rows={2}
-            />
-
-            <TextField
-              fullWidth
-              label="Provider"
-              value={newEncounterData.provider}
-              onChange={(e) => setNewEncounterData({ ...newEncounterData, provider: e.target.value })}
-              placeholder="Enter provider name"
-            />
-
-            <Stack direction="row" spacing={2}>
-              <TextField
-                label="Date"
-                type="date"
-                value={newEncounterData.startDate}
-                onChange={(e) => setNewEncounterData({ ...newEncounterData, startDate: e.target.value })}
-                InputLabelProps={{ shrink: true }}
-                fullWidth
-              />
-              <TextField
-                label="Time"
-                type="time"
-                value={newEncounterData.startTime}
-                onChange={(e) => setNewEncounterData({ ...newEncounterData, startTime: e.target.value })}
-                InputLabelProps={{ shrink: true }}
-                fullWidth
-              />
-            </Stack>
-          </Stack>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setNewEncounterDialogOpen(false)}>Cancel</Button>
-          <Button 
-            variant="contained" 
-            onClick={handleCreateEncounter}
-            disabled={!newEncounterData.reasonForVisit.trim()}
-          >
-            Create Encounter
-          </Button>
-        </DialogActions>
-      </Dialog>
-
-      {/* Edit Encounter Dialog */}
-      <Dialog
-        open={editEncounterDialogOpen}
-        onClose={handleCloseEditEncounter}
-        maxWidth="md"
-        fullWidth
-      >
-        <DialogTitle>Edit Encounter</DialogTitle>
-        <DialogContent>
-          {selectedEncounterForEdit && (
-            <Box sx={{ mt: 2 }}>
-              <Typography variant="body1" sx={{ mb: 2 }}>
-                Encounter editing functionality is being enhanced. For now, encounter details can be viewed but not directly edited.
-              </Typography>
-              <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>
-                Current Encounter: {getEncounterTypeLabel(selectedEncounterForEdit)}
-              </Typography>
-              <Typography variant="body2" color="text.secondary">
-                Status: {getEncounterStatus(selectedEncounterForEdit)}
-              </Typography>
-              {(selectedEncounterForEdit.actualPeriod?.start || selectedEncounterForEdit.period?.start) && (
-                <Typography variant="body2" color="text.secondary">
-                  Date: {formatClinicalDate(selectedEncounterForEdit.actualPeriod?.start || selectedEncounterForEdit.period.start, 'withTime')}
-                </Typography>
-              )}
-            </Box>
-          )}
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={handleCloseEditEncounter}>
-            Close
-          </Button>
-          <Button
-            variant="contained"
-            onClick={() => {
-              handleCloseEditEncounter();
-              setEncounterCreationDialogOpen(true);
-            }}
-          >
-            Create New Encounter
-          </Button>
-        </DialogActions>
-      </Dialog>
 
       {/* Snackbar for notifications */}
       <Snackbar

--- a/frontend/src/components/clinical/workspace/tabs/ResultsTabOptimized.js
+++ b/frontend/src/components/clinical/workspace/tabs/ResultsTabOptimized.js
@@ -136,19 +136,28 @@ const enhanceObservationWithReferenceRange = (observation) => {
   
   const loincCode = observation.code?.coding?.[0]?.code;
   const refRange = REFERENCE_RANGES[loincCode];
-  
-  if (refRange) {
-    return {
-      ...observation,
-      referenceRange: [{
-        low: { value: refRange.low, unit: refRange.unit },
-        high: { value: refRange.high, unit: refRange.unit },
-        text: `${refRange.low}-${refRange.high} ${refRange.unit}`
-      }]
-    };
+
+  if (!refRange) {
+    return observation;
   }
-  
-  return observation;
+
+  // Only synthesize a range when the observation's unit matches the fallback's
+  // assumed unit — comparing e.g. mmol/L against a mg/dL range would produce
+  // false Critical/Abnormal verdicts. When units differ (or are absent), show
+  // no synthesized range rather than a wrong verdict.
+  const observedUnit = observation.valueQuantity?.unit || observation.valueQuantity?.code;
+  if (!observedUnit || observedUnit.toLowerCase() !== refRange.unit.toLowerCase()) {
+    return observation;
+  }
+
+  return {
+    ...observation,
+    referenceRange: [{
+      low: { value: refRange.low, unit: refRange.unit },
+      high: { value: refRange.high, unit: refRange.unit },
+      text: `${refRange.low}-${refRange.high} ${refRange.unit}`
+    }]
+  };
 };
 
 // Detect critical values by comparing value to referenceRange
@@ -229,6 +238,30 @@ const getResultStatus = (observation) => {
   }
 
   return { icon: <NormalRangeIcon />, color: 'default', label: 'Normal', isCritical: false };
+};
+
+// Get status icon and color for DiagnosticReport rows — reports carry a
+// workflow status (final/preliminary/...), not an observation interpretation
+const getReportStatus = (report) => {
+  const status = report.status || 'unknown';
+  const label = (status.charAt(0).toUpperCase() + status.slice(1)).replace(/-/g, ' ');
+
+  switch (status) {
+    case 'final':
+    case 'amended':
+    case 'corrected':
+    case 'appended':
+      return { icon: <NormalIcon color="success" />, color: 'success', label, isCritical: false };
+    case 'preliminary':
+    case 'partial':
+    case 'registered':
+      return { icon: <PendingIcon color="warning" />, color: 'warning', label, isCritical: false };
+    case 'cancelled':
+    case 'entered-in-error':
+      return { icon: <AbnormalIcon color="error" />, color: 'error', label: status === 'entered-in-error' ? 'Entered in error' : label, isCritical: false };
+    default:
+      return { icon: <PendingIcon />, color: 'default', label, isCritical: false };
+  }
 };
 
 const ResultsTabOptimized = ({
@@ -603,6 +636,23 @@ const ResultsTabOptimized = ({
     setPage(0);
   };
 
+  // Filter changes shrink/reshape the result set — reset to the first page so
+  // the user never lands on a now-empty page N
+  const handleSearchChange = (value) => {
+    setSearchTerm(value);
+    setPage(0);
+  };
+
+  const handleFilterPeriodChange = (value) => {
+    setFilterPeriod(value);
+    setPage(0);
+  };
+
+  const handleFilterStatusChange = (value) => {
+    setFilterStatus(value);
+    setPage(0);
+  };
+
   const handleViewDetails = (result) => {
     setSelectedResult(result);
     setDetailsDialogOpen(true);
@@ -655,65 +705,75 @@ const ResultsTabOptimized = ({
       );
     }
 
-    if (viewMode === 'cards') {
-      // Card view using ObservationCardTemplate
-      return (
-        <Grid container spacing={1} sx={{ p: { xs: 0.5, sm: 1 } }}>
-          {paginatedData.map((item, index) => (
-            <Grid item xs={12} md={6} key={item.id}>
-              <ObservationCardTemplate
-                observation={item}
-                onEdit={() => handleViewDetails(item)}
-                onMore={() => handleViewDetails(item)}
-                isAlternate={index % 2 === 1}
-                customActions={
-                  item.basedOn?.[0]?.reference && onNavigateToTab ? (
-                    <Tooltip title="View Related Order">
-                      <IconButton
-                        size="small"
-                        onClick={() => {
-                          const orderId = item.basedOn[0].reference.split('/')[1];
-                          navigateToTab(onNavigateToTab, TAB_IDS.ORDERS, {
-                            resourceId: orderId,
-                            resourceType: 'ServiceRequest',
-                            action: 'highlight'
-                          });
-                        }}
-                      >
-                        <OrderIcon fontSize="small" />
-                      </IconButton>
-                    </Tooltip>
-                  ) : null
-                }
-              />
-            </Grid>
-          ))}
-        </Grid>
-      );
-    }
-
-    // Empty state
+    // Shared empty state — both cards and table views fall through here
     if (filteredData.length === 0) {
       return (
         <ClinicalEmptyState
-          title={searchTerm || filterPeriod !== 'all' || filterStatus !== 'all' ? 
+          title={searchTerm || filterPeriod !== 'all' || filterStatus !== 'all' ?
             'No results match your filters' : 'No results available'}
           message={searchTerm || filterPeriod !== 'all' || filterStatus !== 'all' ?
             'Try adjusting your search criteria or clearing filters' :
             'No test results found for this patient'}
           actions={[
             ...(searchTerm || filterPeriod !== 'all' || filterStatus !== 'all' ? [
-              { 
-                label: 'Clear Filters', 
+              {
+                label: 'Clear Filters',
                 onClick: () => {
-                  setSearchTerm('');
-                  setFilterPeriod('all');
-                  setFilterStatus('all');
+                  handleSearchChange('');
+                  handleFilterPeriodChange('all');
+                  handleFilterStatusChange('all');
                 }
               }
             ] : [])
           ]}
         />
+      );
+    }
+
+    if (viewMode === 'cards') {
+      // Card view using ObservationCardTemplate
+      return (
+        <Box>
+          <Grid container spacing={1} sx={{ p: { xs: 0.5, sm: 1 } }}>
+            {paginatedData.map((item, index) => (
+              <Grid item xs={12} md={6} key={item.id}>
+                <ObservationCardTemplate
+                  observation={item}
+                  onEdit={() => handleViewDetails(item)}
+                  onMore={() => handleViewDetails(item)}
+                  isAlternate={index % 2 === 1}
+                  customActions={
+                    item.basedOn?.[0]?.reference && onNavigateToTab ? (
+                      <Tooltip title="View Related Order">
+                        <IconButton
+                          size="small"
+                          onClick={() => {
+                            const orderId = item.basedOn[0].reference.split('/')[1];
+                            navigateToTab(onNavigateToTab, TAB_IDS.ORDERS, {
+                              resourceId: orderId,
+                              resourceType: 'ServiceRequest',
+                              action: 'highlight'
+                            });
+                          }}
+                        >
+                          <OrderIcon fontSize="small" />
+                        </IconButton>
+                      </Tooltip>
+                    ) : null
+                  }
+                />
+              </Grid>
+            ))}
+          </Grid>
+          <TablePagination
+            component="div"
+            count={filteredData.length}
+            page={page}
+            onPageChange={handleChangePage}
+            rowsPerPage={rowsPerPage}
+            onRowsPerPageChange={handleChangeRowsPerPage}
+          />
+        </Box>
       );
     }
 
@@ -733,20 +793,29 @@ const ResultsTabOptimized = ({
           </TableHead>
           <TableBody>
             {paginatedData.map((item, index) => {
-              const status = getResultStatus(item);
-              const value = item.valueQuantity ? 
-                `${item.valueQuantity.value} ${item.valueQuantity.unit || ''}` :
-                item.valueString || 'Pending';
-              
+              // DiagnosticReports carry a workflow status and result references,
+              // not observation-shaped value/interpretation fields — give them
+              // their own accessors instead of falling through to 'Pending'
+              const isReport = item.resourceType === 'DiagnosticReport';
+              const status = isReport ? getReportStatus(item) : getResultStatus(item);
+              const value = isReport ?
+                (item.code?.text ||
+                 (item.result?.length ?
+                  `${item.result.length} result${item.result.length === 1 ? '' : 's'}` :
+                  '-')) :
+                (item.valueQuantity ?
+                  `${item.valueQuantity.value} ${item.valueQuantity.unit || ''}` :
+                  item.valueString || 'Pending');
+
               // Format reference range from low/high values
               const refRange = item.referenceRange?.[0];
-              const reference = refRange ? 
-                (refRange.text || 
-                 (refRange.low || refRange.high ? 
-                  `${refRange.low?.value || ''} - ${refRange.high?.value || ''} ${refRange.low?.unit || refRange.high?.unit || ''}`.trim() : 
+              const reference = refRange ?
+                (refRange.text ||
+                 (refRange.low || refRange.high ?
+                  `${refRange.low?.value || ''} - ${refRange.high?.value || ''} ${refRange.low?.unit || refRange.high?.unit || ''}`.trim() :
                   '-')) :
                 '-';
-              
+
               const date = item.effectiveDateTime || item.issued;
               
               return (
@@ -776,7 +845,7 @@ const ResultsTabOptimized = ({
                     </Stack>
                   </TableCell>
                   <TableCell>
-                    <Typography variant="body2" fontWeight={status.label !== 'Normal' ? 'bold' : 'normal'}>
+                    <Typography variant="body2" fontWeight={!isReport && status.label !== 'Normal' ? 'bold' : 'normal'}>
                       {value}
                     </Typography>
                   </TableCell>
@@ -871,7 +940,7 @@ const ResultsTabOptimized = ({
                 label={filterPeriod}
                 size="small"
                 variant="outlined"
-                onDelete={() => setFilterPeriod('all')}
+                onDelete={() => handleFilterPeriodChange('all')}
                 sx={{ height: 24 }}
               />
             )}
@@ -920,9 +989,9 @@ const ResultsTabOptimized = ({
       <Box sx={{ px: 2 }}>
         <ClinicalFilterPanel
           searchQuery={searchTerm}
-          onSearchChange={setSearchTerm}
+          onSearchChange={handleSearchChange}
           dateRange={filterPeriod}
-          onDateRangeChange={setFilterPeriod}
+          onDateRangeChange={handleFilterPeriodChange}
           onRefresh={fetchAllData}
           scrollContainerRef={scrollContainerRef}
           compact
@@ -933,7 +1002,7 @@ const ResultsTabOptimized = ({
               <InputLabel>Status</InputLabel>
               <Select
                 value={filterStatus}
-                onChange={(e) => setFilterStatus(e.target.value)}
+                onChange={(e) => handleFilterStatusChange(e.target.value)}
                 label="Status"
               >
                 <MenuItem value="all">All</MenuItem>

--- a/frontend/src/components/clinical/workspace/tabs/TimelineTabModern.js
+++ b/frontend/src/components/clinical/workspace/tabs/TimelineTabModern.js
@@ -40,7 +40,6 @@ import {
   Checkbox,
   Collapse,
   Badge,
-  Slider,
   CircularProgress,
   Skeleton,
   List,
@@ -90,8 +89,6 @@ import {
   Description as PlanIcon,
   Group as TeamIcon,
   CreditCard as InsuranceIcon,
-  ZoomIn as ZoomInIcon,
-  ZoomOut as ZoomOutIcon,
   Refresh as RefreshIcon,
   ViewWeek as MultiTrackIcon,
   ViewStream as SingleTrackIcon,
@@ -105,11 +102,6 @@ import {
   History as HistoryIcon,
   Visibility as VisibilityIcon,
   VisibilityOff as VisibilityOffIcon,
-  PlayArrow as PlayIcon,
-  Pause as PauseIcon,
-  SkipNext as SkipNextIcon,
-  SkipPrevious as SkipPrevIcon,
-  Speed as SpeedIcon,
   ShowChart as ChartIcon,
   CalendarViewMonth as CalendarViewIcon,
   AccountTree as JourneyIcon,
@@ -248,6 +240,7 @@ import { printDocument } from '../../../../core/export/printUtils';
 import { getMedicationName, getMedicationDosageDisplay } from '../../../../core/fhir/utils/medicationDisplayUtils';
 import { formatClinicalDate } from '../../../../core/fhir/utils/dateFormatUtils';
 import { useClinicalWorkflow, CLINICAL_EVENTS } from '../../../../contexts/ClinicalWorkflowContext';
+import { getTabForResourceType } from '../../utils/navigationHelper';
 import { resourceBelongsToPatient } from '../../../../utils/fhir';
 import websocketService from '../../../../services/websocket';
 
@@ -847,16 +840,11 @@ const TimelineTabModern = ({ patientId, patient, onNavigateToTab }) => {
   const [detailsDialogOpen, setDetailsDialogOpen] = useState(false);
   const [dayDetailsDialogOpen, setDayDetailsDialogOpen] = useState(false);
   const [selectedDayEvents, setSelectedDayEvents] = useState({ date: null, events: [] });
-  const [isPlaying, setIsPlaying] = useState(false);
-  const [playbackSpeed, setPlaybackSpeed] = useState(1);
-  const [currentPlaybackIndex, setCurrentPlaybackIndex] = useState(0);
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [isDarkMode, setIsDarkMode] = useState(theme.palette.mode === 'dark');
   const [showLegend, setShowLegend] = useState(true);
   const [groupBy, setGroupBy] = useState('type'); // 'type', 'category', 'date', 'severity'
-  const [zoomLevel, setZoomLevel] = useState(100);
   const [selectedMilestone, setSelectedMilestone] = useState(null);
-  const [animationEnabled, setAnimationEnabled] = useState(true);
   const [selectedCategories, setSelectedCategories] = useState(new Set(['clinical', 'treatment', 'diagnostic', 'prevention', 'planning', 'documentation', 'administrative']));
   const [heatmapView, setHeatmapView] = useState('activity'); // 'activity', 'severity', 'category'
   const [snackbar, setSnackbar] = useState({ open: false, message: '', severity: 'success' });
@@ -867,7 +855,10 @@ const TimelineTabModern = ({ patientId, patient, onNavigateToTab }) => {
   // Refs
   const timelineRef = useRef(null);
   const containerRef = useRef(null);
-  const playbackIntervalRef = useRef(null);
+  // When true, the next data load bypasses the fhirClient cache. Set by the
+  // date-range selector and the manual refresh button — a widened range must
+  // hit the server, not be served the previously cached (narrower) window.
+  const forceNextLoadRef = useRef(false);
   
   // Animation controls
   const controls = useAnimation();
@@ -888,7 +879,9 @@ const TimelineTabModern = ({ patientId, patient, onNavigateToTab }) => {
       
       try {
         setLoadingError(null);
-        
+
+        const forceRefresh = forceNextLoadRef.current || !hasLoadedInitialData;
+
         const promises = Array.from(selectedTypes).map(async (resourceType) => {
           // Each FHIR resource type names its date search parameter differently;
           // sending the wrong one makes HAPI reject the whole query (HAPI-0524).
@@ -929,14 +922,15 @@ const TimelineTabModern = ({ patientId, patient, onNavigateToTab }) => {
           }
           
           try {
-            await searchResources(resourceType, params, !hasLoadedInitialData);
+            await searchResources(resourceType, params, forceRefresh);
           } catch (error) {
             console.error(`Timeline: Error loading ${resourceType}:`, error);
           }
         });
-        
+
         await Promise.all(promises);
-        
+
+        forceNextLoadRef.current = false;
         setHasLoadedInitialData(true);
       } catch (error) {
         console.error('Timeline: Error loading data', error);
@@ -1202,7 +1196,14 @@ const TimelineTabModern = ({ patientId, patient, onNavigateToTab }) => {
     
     return calendarGridData;
   }, [processedEvents, heatmapView, dateRange]);
-  
+
+  // calendarData holds EVERY day in the range (zero-count days included, so
+  // the heatmap grid can render) — only days that actually have events count.
+  const daysWithEventsCount = useMemo(
+    () => calendarData.filter(day => day.count > 0).length,
+    [calendarData]
+  );
+
   // Calculate patient journey milestones
   const patientJourneyData = useMemo(() => {
     const milestones = [];
@@ -1353,31 +1354,6 @@ const TimelineTabModern = ({ patientId, patient, onNavigateToTab }) => {
     };
   }, [processedEvents]);
   
-  // Playback functionality
-  useEffect(() => {
-    if (isPlaying && processedEvents.length > 0) {
-      playbackIntervalRef.current = setInterval(() => {
-        setCurrentPlaybackIndex(prev => {
-          if (prev >= processedEvents.length - 1) {
-            setIsPlaying(false);
-            return 0;
-          }
-          return prev + 1;
-        });
-      }, 3000 / playbackSpeed);
-    } else {
-      if (playbackIntervalRef.current) {
-        clearInterval(playbackIntervalRef.current);
-      }
-    }
-    
-    return () => {
-      if (playbackIntervalRef.current) {
-        clearInterval(playbackIntervalRef.current);
-      }
-    };
-  }, [isPlaying, playbackSpeed, processedEvents.length]);
-  
   // Handle resource updates from WebSocket
   const handleResourceUpdate = useCallback((event) => {
     if (event.patientId === patientId && selectedTypes.has(event.resourceType)) {
@@ -1402,23 +1378,32 @@ const TimelineTabModern = ({ patientId, patient, onNavigateToTab }) => {
     setSelectedEvent(event);
     setDetailsDialogOpen(true);
   };
-  
-  const handlePlayPause = () => {
-    setIsPlaying(!isPlaying);
+
+  const handleDateRangeChange = (value) => {
+    setDateRangeValue(value);
+    // Convert string date range to actual dates
+    const now = new Date();
+    switch (value) {
+      case '30d':
+        setDateRange({ start: subDays(now, 30), end: now });
+        break;
+      case '90d':
+        setDateRange({ start: subDays(now, 90), end: now });
+        break;
+      case '1y':
+        setDateRange({ start: subYears(now, 1), end: now });
+        break;
+      case 'all':
+      default:
+        setDateRange({ start: subYears(now, 5), end: now });
+        break;
+    }
+    // The initial load only fetched the previous window — a changed (possibly
+    // wider) range must refetch from the server, bypassing the client cache.
+    forceNextLoadRef.current = true;
+    setReloadTrigger(prev => prev + 1);
   };
-  
-  const handleSpeedChange = (event, newValue) => {
-    setPlaybackSpeed(newValue);
-  };
-  
-  const handleZoomIn = () => {
-    setZoomLevel(Math.min(200, zoomLevel + 20));
-  };
-  
-  const handleZoomOut = () => {
-    setZoomLevel(Math.max(50, zoomLevel - 20));
-  };
-  
+
   const handleToggleFullscreen = () => {
     if (!document.fullscreenElement) {
       containerRef.current?.requestFullscreen();
@@ -1668,27 +1653,11 @@ const TimelineTabModern = ({ patientId, patient, onNavigateToTab }) => {
           searchQuery={searchQuery}
           onSearchChange={setSearchQuery}
           dateRange={dateRangeValue}
-          onDateRangeChange={(value) => {
-            setDateRangeValue(value);
-            // Convert string date range to actual dates
-            const now = new Date();
-            switch(value) {
-              case '30d':
-                setDateRange({ start: subDays(now, 30), end: now });
-                break;
-              case '90d':
-                setDateRange({ start: subDays(now, 90), end: now });
-                break;
-              case '1y':
-                setDateRange({ start: subYears(now, 1), end: now });
-                break;
-              case 'all':
-              default:
-                setDateRange({ start: subYears(now, 5), end: now });
-                break;
-            }
+          onDateRangeChange={handleDateRangeChange}
+          onRefresh={() => {
+            forceNextLoadRef.current = true;
+            setReloadTrigger(prev => prev + 1);
           }}
-          onRefresh={() => setReloadTrigger(prev => prev + 1)}
           showCategories={false}
           onCategoriesChange={() => {}} // Not using categories in this component
           additionalFilters={
@@ -1713,26 +1682,17 @@ const TimelineTabModern = ({ patientId, patient, onNavigateToTab }) => {
                 Filters
               </Button>
               {viewMode === 'timeline' && (
-                <>
-                  <FormControl size="small" sx={{ minWidth: 120 }}>
-                    <Select
-                      value={groupBy}
-                      onChange={(e) => setGroupBy(e.target.value)}
-                    >
-                      <MenuItem value="type">By Type</MenuItem>
-                      <MenuItem value="category">By Category</MenuItem>
-                      <MenuItem value="severity">By Severity</MenuItem>
-                      <MenuItem value="none">No Grouping</MenuItem>
-                    </Select>
-                  </FormControl>
-                  <IconButton onClick={handleZoomOut} size="small">
-                    <ZoomOutIcon />
-                  </IconButton>
-                  <Typography variant="caption">{zoomLevel}%</Typography>
-                  <IconButton onClick={handleZoomIn} size="small">
-                    <ZoomInIcon />
-                  </IconButton>
-                </>
+                <FormControl size="small" sx={{ minWidth: 120 }}>
+                  <Select
+                    value={groupBy}
+                    onChange={(e) => setGroupBy(e.target.value)}
+                  >
+                    <MenuItem value="type">By Type</MenuItem>
+                    <MenuItem value="category">By Category</MenuItem>
+                    <MenuItem value="severity">By Severity</MenuItem>
+                    <MenuItem value="none">No Grouping</MenuItem>
+                  </Select>
+                </FormControl>
               )}
               {viewMode === 'calendar' && (
                 <FormControl size="small" sx={{ minWidth: 120 }}>
@@ -1886,47 +1846,6 @@ const TimelineTabModern = ({ patientId, patient, onNavigateToTab }) => {
                         orientation: 'top'
                       }}
                     />
-                    
-                    {/* Playback Controls */}
-                    {animationEnabled && (
-                      <Paper
-                        elevation={4}
-                        sx={{
-                          position: 'absolute',
-                          bottom: 16,
-                          left: '50%',
-                          transform: 'translateX(-50%)',
-                          p: 2,
-                          borderRadius: 2,
-                          bgcolor: alpha(theme.palette.background.paper, 0.95)
-                        }}
-                      >
-                        <Stack direction="row" alignItems="center" spacing={2}>
-                          <IconButton onClick={() => setCurrentPlaybackIndex(Math.max(0, currentPlaybackIndex - 1))}>
-                            <SkipPrevIcon />
-                          </IconButton>
-                          <IconButton onClick={handlePlayPause} color="primary">
-                            {isPlaying ? <PauseIcon /> : <PlayIcon />}
-                          </IconButton>
-                          <IconButton onClick={() => setCurrentPlaybackIndex(Math.min(processedEvents.length - 1, currentPlaybackIndex + 1))}>
-                            <SkipNextIcon />
-                          </IconButton>
-                          <Stack direction="row" alignItems="center" spacing={1}>
-                            <SpeedIcon />
-                            <Slider
-                              value={playbackSpeed}
-                              onChange={handleSpeedChange}
-                              min={0.5}
-                              max={3}
-                              step={0.5}
-                              marks
-                              sx={{ width: 100 }}
-                            />
-                            <Typography variant="caption">{playbackSpeed}x</Typography>
-                          </Stack>
-                        </Stack>
-                      </Paper>
-                    )}
                   </Box>
                 )}
               </motion.div>
@@ -2074,17 +1993,14 @@ const TimelineTabModern = ({ patientId, patient, onNavigateToTab }) => {
                 transition={{ duration: 0.3 }}
                 style={{ height: '100%', padding: theme.spacing(2) }}
               >
-                {calendarData.length === 0 ? (
+                {daysWithEventsCount === 0 ? (
                   <ClinicalEmptyState
                     title="No events to display"
                     message="No events found in the selected date range"
                     actions={[
-                      { 
-                        label: 'Adjust Date Range', 
-                        onClick: () => {
-                          setDateRangeValue('all');
-                          setDateRange({ start: subYears(new Date(), 5), end: new Date() });
-                        }
+                      {
+                        label: 'Adjust Date Range',
+                        onClick: () => handleDateRangeChange('all')
                       }
                     ]}
                   />
@@ -2101,7 +2017,7 @@ const TimelineTabModern = ({ patientId, patient, onNavigateToTab }) => {
                       Activity Calendar
                     </Typography>
                     <Typography variant="body2" color="text.secondary" gutterBottom>
-                      {calendarData.length} days with events
+                      {daysWithEventsCount} day{daysWithEventsCount !== 1 ? 's' : ''} with events
                     </Typography>
                     <Box sx={{ flex: 1, minHeight: 500, overflow: 'auto' }}>
                       {/* Custom calendar heatmap component */}
@@ -2401,26 +2317,11 @@ const TimelineTabModern = ({ patientId, patient, onNavigateToTab }) => {
           </DialogContent>
           <DialogActions>
             {onNavigateToTab && selectedEvent && (
-              <Button 
+              <Button
                 onClick={() => {
-                  const resourceTypeToTab = {
-                    'Encounter': 'encounters',
-                    'MedicationRequest': 'chart-review',
-                    'MedicationStatement': 'medications',
-                    'Observation': 'results',
-                    'Condition': 'chart-review',
-                    'AllergyIntolerance': 'chart-review',
-                    'Immunization': 'chart-review',
-                    'ImagingStudy': 'imaging',
-                    'DocumentReference': 'documentation',
-                    'Goal': 'care-plan',
-                    'CarePlan': 'care-plan',
-                    'CareTeam': 'care-plan',
-                    'Procedure': 'chart-review',
-                    'DiagnosticReport': 'results'
-                  };
-                  
-                  const tab = resourceTypeToTab[selectedEvent.resourceType] || 'summary';
+                  // Single source of truth for resource-type → workspace-tab
+                  // routing (ids validated against clinicalTabRegistry).
+                  const tab = getTabForResourceType(selectedEvent.resourceType);
                   onNavigateToTab(tab, {
                     resourceId: selectedEvent.id,
                     resourceType: selectedEvent.resourceType
@@ -2460,36 +2361,13 @@ const TimelineTabModern = ({ patientId, patient, onNavigateToTab }) => {
               {selectedDayEvents.events.map((event, index) => {
                 const eventType = themedEventTypes[event.resourceType];
                 const navigateToResource = () => {
-                  // Determine which tab to navigate to based on resource type
-                  let targetTab = 'chart-review'; // default
-                  switch (event.resourceType) {
-                    case 'Encounter':
-                      targetTab = 'encounters';
-                      break;
-                    case 'Observation':
-                    case 'DiagnosticReport':
-                      targetTab = 'results';
-                      break;
-                    case 'MedicationRequest':
-                      targetTab = 'orders';
-                      break;
-                    case 'ImagingStudy':
-                      targetTab = 'imaging';
-                      break;
-                    case 'DocumentReference':
-                      targetTab = 'documentation';
-                      break;
-                    case 'CarePlan':
-                    case 'Goal':
-                      targetTab = 'care-plan';
-                      break;
-                    default:
-                      targetTab = 'chart-review';
-                  }
-                  
+                  // Single source of truth for resource-type → workspace-tab
+                  // routing (ids validated against clinicalTabRegistry).
+                  const targetTab = getTabForResourceType(event.resourceType);
+
                   // Close dialog and navigate
                   setDayDetailsDialogOpen(false);
-                  onNavigateToTab(targetTab, { 
+                  onNavigateToTab(targetTab, {
                     resourceId: event.id, 
                     resourceType: event.resourceType,
                     highlight: true 


### PR DESCRIPTION
## Refinement plan Phase 3 leftovers, one PR per the task plan

### Timeline (R18 + R25)
- Widening the date range now **refetches** (bumps the reload trigger + forces past the search cache) instead of re-filtering the initially-fetched 1-year window — "All" no longer presents missing data as complete
- Removed the dead zoom buttons and playback bar (state fed no render; app is modal-first)
- Both event dialogs now route through the canonical `getTabForResourceType()` — MedicationRequest previously went to three different tabs, one a nonexistent registry id
- "N days with events" now counts days **with events**, not days in range; the calendar empty state can actually trigger

### Results (R22)
- Pager now renders in cards view (pagination was applied but uncontrollable); shared empty state reachable from both views
- Page index resets on every filter change (no more blank page N)
- Synthesized reference ranges only apply when the observation's **unit matches** — no more false "Critical" labels from cross-unit comparisons
- DiagnosticReport rows get real accessors (status chip from `report.status`, result count) instead of falling through observation columns to eternal "Pending"

### Encounters (R23)
- The Edit dialog was mounted **twice from one flag** — two stacked dialogs on every open; second mount removed
- Removed the dead legacy New Encounter inline dialog (no opener — `EncounterCreationDialog` is the real path), the dead signing path (opener never called), the dead export menu (anchor never set), and two unused memos
- Loading spinner → skeleton rows

### Chart Review (R24)
- Conditions/medications **empty-state gates counted the raw arrays** while rows render the date-filtered set — a narrow date range showed neither rows nor message
- Removed the duplicate success toast (dialog helpers already toast; this one leaked raw FHIR type names)

### Verification
- 500 tests / 84 failed — per-test results identical to master baseline
- eslint: 0 errors on all touched files; unused-import counts reduced below master's
- Timeline/Results/Encounters have no dedicated test files (noted for future coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)