### PR TITLE
refactor(results): one acknowledgment store — Provenance everywhere (R32)

### DIFF
--- a/backend/api/clinical/results/results_router.py
+++ b/backend/api/clinical/results/results_router.py
@@ -11,7 +11,6 @@ import logging
 
 from services.hapi_fhir_client import HAPIFHIRClient
 from pydantic import BaseModel
-from api.cds_hooks.constants import ExtensionURLs
 from api.clinical.notifications_helper import CRITICAL_VALUES
 
 logger = logging.getLogger(__name__)
@@ -73,12 +72,12 @@ async def get_patient_results(
     FHIR Implementation:
     - Queries Observation resources from HAPI FHIR
     - Checks each result against critical value thresholds
-    - Returns acknowledgment status from extensions
-    
+    - Returns acknowledgment status resolved from Provenance resources
+
     Educational notes:
     - FHIR Observation is the standard resource for lab results
     - Critical values are determined by comparing against defined thresholds
-    - Acknowledgment is tracked via FHIR extensions
+    - Acknowledgment is tracked as Provenance targeting the Observation
     """
     try:
         hapi_client = HAPIFHIRClient()
@@ -99,14 +98,16 @@ async def get_patient_results(
         
         # Query HAPI FHIR for observations
         bundle = await hapi_client.search("Observation", search_params)
-        
-        results = []
-        for entry in bundle.get("entry", []):
-            observation = entry.get("resource", {})
-            result_summary = _build_result_summary(observation, include_critical_check)
-            results.append(result_summary)
-        
-        return results
+
+        observations = [entry.get("resource", {}) for entry in bundle.get("entry", [])]
+        acks = await _fetch_acknowledgments(
+            hapi_client, [o.get("id") for o in observations if o.get("id")]
+        )
+
+        return [
+            _build_result_summary(o, include_critical_check, ack=acks.get(o.get("id")))
+            for o in observations
+        ]
         
     except Exception as e:
         logger.error(f"Failed to get patient results: {str(e)}", exc_info=True)
@@ -155,21 +156,25 @@ async def get_critical_values(
         # Query HAPI FHIR for observations
         bundle = await hapi_client.search("Observation", search_params)
         
-        critical_alerts = []
+        # Collect the criticals first, then resolve acknowledgment status for
+        # just those in one batched Provenance lookup.
+        flagged = []
         for entry in bundle.get("entry", []):
             observation = entry.get("resource", {})
-            
-            # Check if this observation has a critical value
             alert = _check_critical_value(observation)
             if alert:
-                # Check acknowledgment status if filter is specified
-                if acknowledged is not None:
-                    is_acked = _is_acknowledged(observation)
-                    if is_acked != acknowledged:
-                        continue
-                
-                critical_alerts.append(alert)
-        
+                flagged.append((observation, alert))
+
+        critical_alerts = [alert for _, alert in flagged]
+        if acknowledged is not None and flagged:
+            acks = await _fetch_acknowledgments(
+                hapi_client, [o.get("id") for o, _ in flagged if o.get("id")]
+            )
+            critical_alerts = [
+                alert for o, alert in flagged
+                if (o.get("id") in acks) == acknowledged
+            ]
+
         return critical_alerts
         
     except Exception as e:
@@ -184,74 +189,63 @@ async def get_critical_values(
 async def acknowledge_result(acknowledgment: ResultAcknowledgment):
     """
     Acknowledge a lab result (especially critical values).
-    
+
     FHIR Implementation:
-    - Updates Observation with acknowledgment extension
-    - Records who acknowledged and when
-    - Creates audit trail via FHIR provenance pattern
-    
+    - Creates a Provenance resource targeting the Observation — the same
+      store the frontend writes (resultsManagementService.acknowledgeResult),
+      so an acknowledgment via either path is visible to both.
+    - The Observation itself is never mutated.
+
     Educational notes:
     - Result acknowledgment is a key clinical workflow
-    - FHIR extensions allow tracking custom workflow states
-    - This creates a defensible audit trail
+    - Provenance is FHIR's standard resource for "who did what, when" —
+      a defensible audit trail without inventing custom workflow extensions
     """
     try:
         hapi_client = HAPIFHIRClient()
-        
-        # Get the observation
+
+        # Verify the observation exists before acknowledging it
         observation = await hapi_client.read("Observation", acknowledgment.observation_id)
         if not observation:
             raise HTTPException(
                 status_code=http_status.HTTP_404_NOT_FOUND,
                 detail="Observation not found"
             )
-        
+
         current_time = datetime.now(timezone.utc)
-        
-        # Initialize extensions if needed
-        if "extension" not in observation:
-            observation["extension"] = []
-        
-        # Remove any existing acknowledgment extension
-        observation["extension"] = [
-            ext for ext in observation["extension"]
-            if ext.get("url") != f"{ExtensionURLs.BASE_URL}/result-acknowledgment"
-        ]
-        
-        # Add acknowledgment extension
-        acknowledgment_ext = {
-            "url": f"{ExtensionURLs.BASE_URL}/result-acknowledgment",
-            "extension": [
-                {
-                    "url": "acknowledged",
-                    "valueBoolean": True
-                },
-                {
-                    "url": "acknowledgedBy",
-                    "valueReference": {
-                        "reference": f"Practitioner/{acknowledgment.acknowledged_by}"
-                    }
-                },
-                {
-                    "url": "acknowledgedAt",
-                    "valueDateTime": current_time.isoformat()
-                }
-            ]
+
+        # Shape mirrors the frontend's Provenance write exactly
+        provenance = {
+            "resourceType": "Provenance",
+            "target": [{"reference": f"Observation/{acknowledgment.observation_id}"}],
+            "recorded": current_time.isoformat(),
+            "agent": [{
+                "who": {"reference": f"Practitioner/{acknowledgment.acknowledged_by}"}
+            }],
+            "activity": {
+                "coding": [{
+                    "system": "http://terminology.hl7.org/CodeSystem/v3-DocumentCompletion",
+                    "code": "LA",
+                    "display": "Legally authenticated"
+                }]
+            },
+            "signature": [{
+                "type": [{
+                    "system": "urn:iso-astm:E1762-95:2013",
+                    "code": "1.2.840.10065.1.12.1.5",
+                    "display": "Verification Signature"
+                }],
+                "when": current_time.isoformat(),
+                "who": {"reference": f"Practitioner/{acknowledgment.acknowledged_by}"}
+            }]
         }
-        
         if acknowledgment.notes:
-            acknowledgment_ext["extension"].append({
-                "url": "notes",
-                "valueString": acknowledgment.notes
-            })
-        
-        observation["extension"].append(acknowledgment_ext)
-        
-        # Update the observation
-        await hapi_client.update("Observation", acknowledgment.observation_id, observation)
-        
-        logger.info(f"Acknowledged Observation/{acknowledgment.observation_id} by Practitioner/{acknowledgment.acknowledged_by}")
-        
+            provenance["reason"] = [{"text": acknowledgment.notes}]
+
+        await hapi_client.create("Provenance", provenance)
+
+        logger.info(f"Acknowledged Observation/{acknowledgment.observation_id} by Practitioner/{acknowledgment.acknowledged_by} (Provenance)")
+
         return {
             "message": "Result acknowledged successfully",
             "observation_id": acknowledgment.observation_id,
@@ -288,8 +282,11 @@ async def get_result_detail(observation_id: str):
                 status_code=http_status.HTTP_404_NOT_FOUND,
                 detail="Observation not found"
             )
-        
-        return _build_result_summary(observation, include_critical_check=True)
+
+        acks = await _fetch_acknowledgments(hapi_client, [observation_id])
+        return _build_result_summary(
+            observation, include_critical_check=True, ack=acks.get(observation_id)
+        )
         
     except HTTPException:
         raise
@@ -405,8 +402,65 @@ async def get_result_trends(
 # Helper Functions
 # =============================================================================
 
-def _build_result_summary(observation: Dict[str, Any], include_critical_check: bool = True) -> ResultSummary:
-    """Build a result summary from a FHIR Observation resource."""
+async def _fetch_acknowledgments(
+    hapi_client: HAPIFHIRClient, observation_ids: List[str]
+) -> Dict[str, Dict[str, Any]]:
+    """Resolve acknowledgment status for a set of Observations from Provenance.
+
+    Acknowledgments are Provenance resources targeting the Observation (the
+    same store the frontend writes). Searches are chunked so a large result
+    list doesn't overflow the query string; the most recently recorded
+    Provenance wins when duplicates exist.
+    Returns {observation_id: {"by": practitioner_id, "at": datetime|None}}.
+    """
+    acks: Dict[str, Dict[str, Any]] = {}
+    CHUNK = 40
+    ids = [oid for oid in observation_ids if oid]
+    for i in range(0, len(ids), CHUNK):
+        chunk = ids[i:i + CHUNK]
+        try:
+            bundle = await hapi_client.search("Provenance", {
+                "target": ",".join(f"Observation/{oid}" for oid in chunk),
+                "_count": len(chunk) * 5,
+            })
+        except Exception as e:
+            logger.warning(f"Provenance acknowledgment lookup failed: {e}")
+            continue
+        for entry in bundle.get("entry", []):
+            prov = entry.get("resource", {})
+            recorded = prov.get("recorded", "")
+            who = ""
+            if prov.get("agent"):
+                who = prov["agent"][0].get("who", {}).get("reference", "")
+            practitioner = who.replace("Practitioner/", "") if who.startswith("Practitioner/") else who
+            for target in prov.get("target", []):
+                ref = target.get("reference", "")
+                if not ref.startswith("Observation/"):
+                    continue
+                oid = ref.replace("Observation/", "")
+                existing = acks.get(oid)
+                if existing and existing.get("recorded", "") >= recorded:
+                    continue
+                ack_at = None
+                try:
+                    ack_at = datetime.fromisoformat(recorded.replace("Z", "+00:00"))
+                except (ValueError, TypeError):
+                    pass
+                acks[oid] = {"by": practitioner, "at": ack_at, "recorded": recorded}
+    return acks
+
+
+def _build_result_summary(
+    observation: Dict[str, Any],
+    include_critical_check: bool = True,
+    ack: Optional[Dict[str, Any]] = None,
+) -> ResultSummary:
+    """Build a result summary from a FHIR Observation resource.
+
+    `ack` is the pre-resolved Provenance acknowledgment for this observation
+    (see _fetch_acknowledgments) — acknowledgment no longer lives on the
+    Observation itself.
+    """
     
     # Extract patient ID
     subject_ref = observation.get("subject", {}).get("reference", "")
@@ -470,23 +524,12 @@ def _build_result_summary(observation: Dict[str, Any], include_critical_check: b
         alert = _check_critical_value(observation)
         is_critical = alert is not None
     
-    # Check acknowledgment status
-    is_acknowledged = _is_acknowledged(observation)
-    acknowledged_by = None
-    acknowledged_at = None
-    
-    for ext in observation.get("extension", []):
-        if ext.get("url") == f"{ExtensionURLs.BASE_URL}/result-acknowledgment":
-            for sub_ext in ext.get("extension", []):
-                if sub_ext.get("url") == "acknowledgedBy":
-                    ref = sub_ext.get("valueReference", {}).get("reference", "")
-                    acknowledged_by = ref.replace("Practitioner/", "") if ref.startswith("Practitioner/") else ref
-                elif sub_ext.get("url") == "acknowledgedAt":
-                    try:
-                        acknowledged_at = datetime.fromisoformat(sub_ext.get("valueDateTime", "").replace("Z", "+00:00"))
-                    except (ValueError, TypeError):
-                        pass
-    
+    # Acknowledgment status comes from Provenance (pre-resolved by caller)
+    is_acknowledged = ack is not None
+    acknowledged_by = ack.get("by") if ack else None
+    acknowledged_at = ack.get("at") if ack else None
+
+
     return ResultSummary(
         observation_id=observation.get("id", ""),
         patient_id=patient_id,
@@ -572,11 +615,3 @@ def _check_critical_value(observation: Dict[str, Any]) -> Optional[CriticalValue
     )
 
 
-def _is_acknowledged(observation: Dict[str, Any]) -> bool:
-    """Check if an observation has been acknowledged."""
-    for ext in observation.get("extension", []):
-        if ext.get("url") == f"{ExtensionURLs.BASE_URL}/result-acknowledgment":
-            for sub_ext in ext.get("extension", []):
-                if sub_ext.get("url") == "acknowledged":
-                    return sub_ext.get("valueBoolean", False)
-    return False

--- a/frontend/src/components/clinical/results/ResultAcknowledgmentPanel.js
+++ b/frontend/src/components/clinical/results/ResultAcknowledgmentPanel.js
@@ -57,6 +57,8 @@ const ResultAcknowledgmentPanel = ({ patientId, providerId, onResultSelect }) =>
   const [anchorEl, setAnchorEl] = useState(null);
   const [searchTerm, setSearchTerm] = useState('');
   const [acknowledgingBatch, setAcknowledgingBatch] = useState(false);
+  // A failed load or acknowledgment must not look identical to success
+  const [error, setError] = useState(null);
   
   const { publish } = useClinicalWorkflow();
   const { currentPatient } = useFHIRResource();
@@ -88,8 +90,10 @@ const ResultAcknowledgmentPanel = ({ patientId, providerId, onResultSelect }) =>
       });
 
       setResults(filteredResults);
+      setError(null);
     } catch (error) {
-      // Handle error silently or add proper error handling here
+      console.error('ResultAcknowledgmentPanel: failed to load results', error);
+      setError('Failed to load results. ' + (error.message || ''));
     } finally {
       setLoading(false);
     }
@@ -115,7 +119,8 @@ const ResultAcknowledgmentPanel = ({ patientId, providerId, onResultSelect }) =>
       // Reload results
       loadResults();
     } catch (error) {
-      // Handle error silently or add proper error handling here
+      console.error('ResultAcknowledgmentPanel: acknowledge failed', error);
+      setError('Failed to acknowledge result. ' + (error.message || ''));
     }
   };
 
@@ -146,7 +151,8 @@ const ResultAcknowledgmentPanel = ({ patientId, providerId, onResultSelect }) =>
       setSelectedResults([]);
       loadResults();
     } catch (error) {
-      // Handle error silently or add proper error handling here
+      console.error('ResultAcknowledgmentPanel: batch acknowledge failed', error);
+      setError('Failed to acknowledge selected results. ' + (error.message || ''));
     } finally {
       setAcknowledgingBatch(false);
     }
@@ -177,6 +183,11 @@ const ResultAcknowledgmentPanel = ({ patientId, providerId, onResultSelect }) =>
 
   return (
     <Paper sx={{ p: 2, height: '100%', display: 'flex', flexDirection: 'column' }}>
+      {error && (
+        <Alert severity="error" onClose={() => setError(null)} sx={{ mb: 2 }}>
+          {error}
+        </Alert>
+      )}
       {/* Header */}
       <Stack direction="row" justifyContent="space-between" alignItems="center" mb={2}>
         <Typography variant="h6">Result Acknowledgment</Typography>


### PR DESCRIPTION
## Refinement R32 — two acknowledgment stores → Provenance (approved decision)

The UI wrote Provenance while the backend results router persisted Observation extensions — an ack via one path was invisible to the other.

- `POST /api/clinical/results/acknowledge` now **creates a Provenance** targeting the Observation, shape-identical to the frontend's `resultsManagementService.acknowledgeResult` write, and never mutates the Observation
- Read paths (`/patient/{id}`, `/critical-values`, `/{observation_id}`) resolve acknowledgment via **batched Provenance target searches** (chunked, latest `recorded` wins) instead of scanning extensions; `_is_acknowledged` and the extension machinery deleted
- `ResultAcknowledgmentPanel`: the three silent catches now log with context and surface a dismissible error Alert — a failed acknowledgment no longer looks identical to success

Purpose lens: Provenance is the standards-idiomatic FHIR audit pattern — the thing worth teaching — vs. custom workflow extensions.

### Verification
- Backend: failure set identical to master baseline (362 passed)
- Frontend: 500/84 identical to baseline; eslint 0 errors
- `py_compile` clean; no `ExtensionURLs`/`_is_acknowledged` stragglers

🤖 Generated with [Claude Code](https://claude.com/claude-code)