### PR TITLE
chore(frontend): one URL resolver, one FHIR namespace; deployment-doc audience map (E4, E6, H6)

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -5,6 +5,14 @@
 
 This guide covers all deployment options for WintEHR, from local development to production deployment.
 
+> **Which guide do I need?** This file is the canonical operator guide.
+> - **Just trying it out** → the [README quick start](../README.md) (`./deploy.sh`, login `demo`/`password`)
+> - **Deploying into a client/on-prem environment** (hardening, networking, day-2 ops) → [CLIENT_DEPLOYMENT.md](CLIENT_DEPLOYMENT.md)
+> - **Azure VM specifics** → [AZURE_DEPLOYMENT.md](AZURE_DEPLOYMENT.md)
+> - `AUTOMATED_DEPLOYMENT.md` (repo root) is a **historical design doc** — its scripts never shipped; don't follow it.
+>
+> When these documents disagree, this file and `./deploy.sh --help` win.
+
 ---
 
 ## Table of Contents

--- a/frontend/src/components/clinical/shared/dialogs/BatchOperationsDialog.js
+++ b/frontend/src/components/clinical/shared/dialogs/BatchOperationsDialog.js
@@ -380,7 +380,7 @@ const BatchOperationsDialog = ({
                   tag: [
                     ...(resource.meta?.tag || []),
                     {
-                      system: 'http://emr.local/tags',
+                      system: 'http://wintehr.local/fhir/tags',
                       code: 'archived',
                       display: 'Archived'
                     }

--- a/frontend/src/components/clinical/workspace/dialogs/config/encounterDialogConfig.js
+++ b/frontend/src/components/clinical/workspace/dialogs/config/encounterDialogConfig.js
@@ -170,9 +170,9 @@ export const parseResource = (encounter) => {
       Math.round((new Date(encounter.period.end) - new Date(encounter.period.start)) / (1000 * 60)) : 30,
     priority: encounter.priority?.code || 'routine',
     status: encounter.status || 'planned',
-    checklist: encounter.extension?.find(ext => ext.url === 'http://wintehr.com/fhir/StructureDefinition/encounter-checklist')?.valueString?.split(',') || [],
-    expectedOrders: encounter.extension?.find(ext => ext.url === 'http://wintehr.com/fhir/StructureDefinition/encounter-expected-orders')?.valueString?.split(',') || [],
-    notes: encounter.extension?.find(ext => ext.url === 'http://wintehr.com/fhir/StructureDefinition/encounter-notes')?.valueString || ''
+    checklist: encounter.extension?.find(ext => ext.url === 'http://wintehr.local/fhir/fhir/StructureDefinition/encounter-checklist')?.valueString?.split(',') || [],
+    expectedOrders: encounter.extension?.find(ext => ext.url === 'http://wintehr.local/fhir/fhir/StructureDefinition/encounter-expected-orders')?.valueString?.split(',') || [],
+    notes: encounter.extension?.find(ext => ext.url === 'http://wintehr.local/fhir/fhir/StructureDefinition/encounter-notes')?.valueString || ''
   };
 };
 
@@ -258,19 +258,19 @@ export const updateResource = (encounter = {}, formData, patientId) => {
   const extensions = [];
   if (formData.checklist && formData.checklist.length > 0) {
     extensions.push({
-      url: 'http://wintehr.com/fhir/StructureDefinition/encounter-checklist',
+      url: 'http://wintehr.local/fhir/fhir/StructureDefinition/encounter-checklist',
       valueString: formData.checklist.join(',')
     });
   }
   if (formData.expectedOrders && formData.expectedOrders.length > 0) {
     extensions.push({
-      url: 'http://wintehr.com/fhir/StructureDefinition/encounter-expected-orders',
+      url: 'http://wintehr.local/fhir/fhir/StructureDefinition/encounter-expected-orders',
       valueString: formData.expectedOrders.join(',')
     });
   }
   if (formData.notes) {
     extensions.push({
-      url: 'http://wintehr.com/fhir/StructureDefinition/encounter-notes',
+      url: 'http://wintehr.local/fhir/fhir/StructureDefinition/encounter-notes',
       valueString: formData.notes
     });
   }

--- a/frontend/src/components/clinical/workspace/tabs/components/AdministrationDialog.js
+++ b/frontend/src/components/clinical/workspace/tabs/components/AdministrationDialog.js
@@ -225,7 +225,7 @@ const AdministrationDialog = ({
       // Add device information as extension
       if (administrationData.deviceUsed) {
         administrationRecord.extension = [{
-          url: 'http://wintehr.com/fhir/StructureDefinition/administration-device',
+          url: 'http://wintehr.local/fhir/fhir/StructureDefinition/administration-device',
           valueString: administrationData.deviceUsed
         }];
       }

--- a/frontend/src/contexts/DocumentationContext.js
+++ b/frontend/src/contexts/DocumentationContext.js
@@ -88,13 +88,13 @@ export const DocumentationProvider = ({ children }) => {
       encounterId: fhirDoc.context?.encounter?.[0]?.reference?.split('/')[1],
       noteType,
       title: getNoteTypeDisplay(noteType),
-      templateId: fhirDoc.extension?.find(e => e.url === 'http://wintehr.com/template-id')?.valueString,
+      templateId: fhirDoc.extension?.find(e => e.url === 'http://wintehr.local/fhir/template-id')?.valueString,
       status: fhirDoc.status,
       authorId: fhirDoc.author?.[0]?.reference?.split('/')[1],
       createdAt: fhirDoc.date,
       signedAt: fhirDoc.status === 'current' ? fhirDoc.date : null,
-      requiresCosignature: fhirDoc.extension?.find(e => e.url === 'http://wintehr.com/requires-cosignature')?.valueBoolean,
-      cosignerId: fhirDoc.extension?.find(e => e.url === 'http://wintehr.com/cosigner')?.valueReference?.reference?.split('/')[1],
+      requiresCosignature: fhirDoc.extension?.find(e => e.url === 'http://wintehr.local/fhir/requires-cosignature')?.valueBoolean,
+      cosignerId: fhirDoc.extension?.find(e => e.url === 'http://wintehr.local/fhir/cosigner')?.valueReference?.reference?.split('/')[1],
       isSOAPFormat,
       ...sections
     };
@@ -149,21 +149,21 @@ export const DocumentationProvider = ({ children }) => {
 
     if (note.templateId) {
       fhirDoc.extension.push({
-        url: 'http://wintehr.com/template-id',
+        url: 'http://wintehr.local/fhir/template-id',
         valueString: note.templateId
       });
     }
 
     if (note.requiresCosignature) {
       fhirDoc.extension.push({
-        url: 'http://wintehr.com/requires-cosignature',
+        url: 'http://wintehr.local/fhir/requires-cosignature',
         valueBoolean: true
       });
     }
 
     if (note.cosignerId) {
       fhirDoc.extension.push({
-        url: 'http://wintehr.com/cosigner',
+        url: 'http://wintehr.local/fhir/cosigner',
         valueReference: { reference: `Practitioner/${note.cosignerId}` }
       });
     }
@@ -382,7 +382,7 @@ export const DocumentationProvider = ({ children }) => {
       // Add authenticator extension
       if (!fhirDoc.extension) fhirDoc.extension = [];
       fhirDoc.extension.push({
-        url: 'http://wintehr.com/signed-at',
+        url: 'http://wintehr.local/fhir/signed-at',
         valueDateTime: new Date().toISOString()
       });
       

--- a/frontend/src/contexts/InboxContext.js
+++ b/frontend/src/contexts/InboxContext.js
@@ -288,7 +288,7 @@ export const InboxProvider = ({ children }) => {
         priority: messageData.priority || 'routine',
         category: [{
           coding: [{
-            system: 'http://wintehr.com/communication-category',
+            system: 'http://wintehr.local/fhir/communication-category',
             code: messageData.category || 'notification',
             display: messageData.categoryDisplay || 'Notification'
           }]

--- a/frontend/src/contexts/OrderContext.js
+++ b/frontend/src/contexts/OrderContext.js
@@ -69,7 +69,7 @@ export const OrderProvider = ({ children }) => {
 
   // Extract medication details from extensions or contained resources
   const extractMedicationDetails = (fhirRequest) => {
-    const extension = fhirRequest.extension?.find(e => e.url === 'http://wintehr.com/medication-details');
+    const extension = fhirRequest.extension?.find(e => e.url === 'http://wintehr.local/fhir/medication-details');
     if (!extension) return null;
     
     return {
@@ -129,7 +129,7 @@ export const OrderProvider = ({ children }) => {
     // Add order-type specific details
     if (order.orderType === 'medication' && order.medicationDetails) {
       fhirRequest.extension = [{
-        url: 'http://wintehr.com/medication-details',
+        url: 'http://wintehr.local/fhir/medication-details',
         valueString: order.medicationDetails.medicationName,
         extension: [
           { url: 'dosage', valueString: order.medicationDetails.dosage },
@@ -212,11 +212,11 @@ export const OrderProvider = ({ children }) => {
       description: questionnaire.description,
       specialty: getSpecialtyFromCode(code),
       orders: questionnaire.item?.map(item => ({
-        type: item.extension?.find(e => e.url === 'http://wintehr.com/order-type')?.valueCode || 'other',
+        type: item.extension?.find(e => e.url === 'http://wintehr.local/fhir/order-type')?.valueCode || 'other',
         code: item.code?.[0]?.code,
         display: item.text || item.code?.[0]?.display,
-        priority: item.extension?.find(e => e.url === 'http://wintehr.com/order-priority')?.valueCode || 'routine',
-        frequency: item.extension?.find(e => e.url === 'http://wintehr.com/order-frequency')?.valueString,
+        priority: item.extension?.find(e => e.url === 'http://wintehr.local/fhir/order-priority')?.valueCode || 'routine',
+        frequency: item.extension?.find(e => e.url === 'http://wintehr.local/fhir/order-frequency')?.valueString,
         selected: item.initial?.[0]?.valueBoolean || false,
         linkId: item.linkId
       })) || []
@@ -239,7 +239,7 @@ export const OrderProvider = ({ children }) => {
     try {
       // Search for questionnaires with order-set-type code
       const searchParams = {
-        code: 'http://wintehr.com/order-set-type|',
+        code: 'http://wintehr.local/fhir/order-set-type|',
         _count: 50
       };
       
@@ -451,7 +451,7 @@ export const OrderProvider = ({ children }) => {
       // Add extension for discontinuation reason
       if (!fhirRequest.extension) fhirRequest.extension = [];
       fhirRequest.extension.push({
-        url: 'http://wintehr.com/discontinuation-reason',
+        url: 'http://wintehr.local/fhir/discontinuation-reason',
         valueString: reason
       });
       
@@ -510,7 +510,7 @@ export const OrderProvider = ({ children }) => {
         // Add order set reference
         if (!fhirRequest.extension) fhirRequest.extension = [];
         fhirRequest.extension.push({
-          url: 'http://wintehr.com/order-set-reference',
+          url: 'http://wintehr.local/fhir/order-set-reference',
           valueReference: {
             reference: `Questionnaire/${orderSetId}`,
             display: orderSet.name

--- a/frontend/src/core/fhir/services/fhirClient.ts
+++ b/frontend/src/core/fhir/services/fhirClient.ts
@@ -13,6 +13,7 @@
  */
 
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse, AxiosError } from 'axios';
+import { getFhirUrl } from '../../../config/apiConfig';
 import type {
   FHIRResource,
   Patient,
@@ -182,7 +183,7 @@ class FHIRClient {
 
   constructor(config: FHIRClientConfig = {}) {
     // Configure base URL
-    this.baseUrl = config.baseUrl || process.env.REACT_APP_FHIR_ENDPOINT || '/fhir/R4';
+    this.baseUrl = config.baseUrl || getFhirUrl();
     
     // Configure cache with optimized TTLs for better performance
     this.cache = new Map();
@@ -1803,7 +1804,7 @@ class FHIRClient {
 
 // Create a function to ensure environment variables are loaded
 function createSingletonClient() {
-  const baseUrl = process.env.REACT_APP_FHIR_ENDPOINT || '/fhir/R4';
+  const baseUrl = getFhirUrl();
   return new FHIRClient({
     baseUrl: baseUrl
   });

--- a/frontend/src/modules/cds-studio/components/builders/DisplayConfigPanel.jsx
+++ b/frontend/src/modules/cds-studio/components/builders/DisplayConfigPanel.jsx
@@ -62,7 +62,7 @@ const OverrideReasonEditor = ({ reasons, onChange }) => {
   const handleAddReason = () => {
     if (!customReason.code || !customReason.display) return;
 
-    onChange([...reasons, { ...customReason, system: 'https://wintehr.com/cds-hooks/override-reasons' }]);
+    onChange([...reasons, { ...customReason, system: 'http://wintehr.local/fhir/cds-hooks/override-reasons' }]);
     setCustomReason({ code: '', display: '', category: 'clinical' });
   };
 

--- a/frontend/src/modules/cds-studio/types/displayModes.js
+++ b/frontend/src/modules/cds-studio/types/displayModes.js
@@ -225,49 +225,49 @@ export const PRESENTATION_MODES = {
 export const DEFAULT_OVERRIDE_REASONS = [
   {
     code: 'patient-preference',
-    system: 'https://wintehr.com/cds-hooks/override-reasons',
+    system: 'http://wintehr.local/fhir/cds-hooks/override-reasons',
     display: 'Patient preference or contraindication',
     category: 'clinical'
   },
   {
     code: 'clinical-judgment',
-    system: 'https://wintehr.com/cds-hooks/override-reasons',
+    system: 'http://wintehr.local/fhir/cds-hooks/override-reasons',
     display: 'Clinical judgment based on patient context',
     category: 'clinical'
   },
   {
     code: 'alternative-treatment',
-    system: 'https://wintehr.com/cds-hooks/override-reasons',
+    system: 'http://wintehr.local/fhir/cds-hooks/override-reasons',
     display: 'Alternative treatment selected',
     category: 'clinical'
   },
   {
     code: 'risk-benefit',
-    system: 'https://wintehr.com/cds-hooks/override-reasons',
+    system: 'http://wintehr.local/fhir/cds-hooks/override-reasons',
     display: 'Risk-benefit analysis favors override',
     category: 'clinical'
   },
   {
     code: 'false-positive',
-    system: 'https://wintehr.com/cds-hooks/override-reasons',
+    system: 'http://wintehr.local/fhir/cds-hooks/override-reasons',
     display: 'Alert appears to be false positive',
     category: 'system'
   },
   {
     code: 'not-applicable',
-    system: 'https://wintehr.com/cds-hooks/override-reasons',
+    system: 'http://wintehr.local/fhir/cds-hooks/override-reasons',
     display: 'Alert not applicable to this patient',
     category: 'system'
   },
   {
     code: 'emergency',
-    system: 'https://wintehr.com/cds-hooks/override-reasons',
+    system: 'http://wintehr.local/fhir/cds-hooks/override-reasons',
     display: 'Emergency situation requires override',
     category: 'clinical'
   },
   {
     code: 'other',
-    system: 'https://wintehr.com/cds-hooks/override-reasons',
+    system: 'http://wintehr.local/fhir/cds-hooks/override-reasons',
     display: 'Other reason (see comments)',
     category: 'other'
   }

--- a/frontend/src/services/HttpClientFactory.js
+++ b/frontend/src/services/HttpClientFactory.js
@@ -13,6 +13,7 @@
  */
 
 import axios from 'axios';
+import { getFhirUrl, getEmrUrl } from '../config/apiConfig';
 
 class HttpClientFactory {
   constructor() {
@@ -49,7 +50,7 @@ class HttpClientFactory {
   static createFhirClient(config = {}) {
     const factory = new HttpClientFactory();
     return factory.createClient('fhir', {
-      baseURL: config.baseURL || process.env.REACT_APP_FHIR_ENDPOINT || '/fhir/R4',
+      baseURL: config.baseURL || getFhirUrl(),
       headers: {
         'Content-Type': 'application/fhir+json',
         'Accept': 'application/fhir+json',
@@ -82,7 +83,7 @@ class HttpClientFactory {
     }
 
     return factory.createClient('emr', {
-      baseURL: config.baseURL || process.env.REACT_APP_EMR_API || '/api/emr',
+      baseURL: config.baseURL || getEmrUrl(),
       headers: {
         'Content-Type': 'application/json',
         'Accept': 'application/json',

--- a/frontend/src/services/MedicationWorkflowService.js
+++ b/frontend/src/services/MedicationWorkflowService.js
@@ -1062,7 +1062,7 @@ class MedicationWorkflowService {
   determineMedicationSource(medicationRequest) {
     // Check extensions for source information
     const sourceExtension = medicationRequest.extension?.find(
-      ext => ext.url === 'http://wintehr.com/fhir/medication-source'
+      ext => ext.url === 'http://wintehr.local/fhir/fhir/medication-source'
     );
     if (sourceExtension) {
       return sourceExtension.valueString;

--- a/frontend/src/services/__tests__/HttpClientFactory.test.js
+++ b/frontend/src/services/__tests__/HttpClientFactory.test.js
@@ -90,18 +90,20 @@ describe('HttpClientFactory', () => {
         );
       });
 
-      it('should use FHIR endpoint from environment', () => {
-        process.env.REACT_APP_FHIR_ENDPOINT = '/custom/fhir';
-        
+      it('should use the FHIR endpoint from apiConfig', () => {
+        // URL resolution is consolidated onto config/apiConfig (E4), which
+        // reads REACT_APP_FHIR_ENDPOINT once at module init — setting the
+        // env var mid-test can no longer change it. Assert the factory uses
+        // whatever apiConfig resolves.
+        const { getFhirUrl } = require('../../config/apiConfig');
+
         createFhirClient();
-        
+
         expect(axios.create).toHaveBeenCalledWith(
           expect.objectContaining({
-            baseURL: '/custom/fhir'
+            baseURL: getFhirUrl()
           })
         );
-        
-        delete process.env.REACT_APP_FHIR_ENDPOINT;
       });
     });
 

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,7 +1,9 @@
 import axios from 'axios';
 
 // Use relative URL to work with proxy in development and direct routing in production
-const API_BASE_URL = process.env.REACT_APP_API_URL || '';
+import { getBackendUrl } from '../config/apiConfig';
+
+const API_BASE_URL = getBackendUrl();
 
 const api = axios.create({
   baseURL: API_BASE_URL,

--- a/frontend/src/services/cdsFeedbackService.js
+++ b/frontend/src/services/cdsFeedbackService.js
@@ -185,42 +185,42 @@ class CDSFeedbackService {
     const OVERRIDE_REASONS = {
       'patient-preference': {
         code: 'patient-preference',
-        system: 'https://wintehr.com/cds-hooks/override-reasons',
+        system: 'http://wintehr.local/fhir/cds-hooks/override-reasons',
         display: 'Patient preference or contraindication'
       },
       'clinical-judgment': {
         code: 'clinical-judgment',
-        system: 'https://wintehr.com/cds-hooks/override-reasons',
+        system: 'http://wintehr.local/fhir/cds-hooks/override-reasons',
         display: 'Clinical judgment based on patient context'
       },
       'alternative-treatment': {
         code: 'alternative-treatment',
-        system: 'https://wintehr.com/cds-hooks/override-reasons',
+        system: 'http://wintehr.local/fhir/cds-hooks/override-reasons',
         display: 'Alternative treatment selected'
       },
       'risk-benefit': {
         code: 'risk-benefit',
-        system: 'https://wintehr.com/cds-hooks/override-reasons',
+        system: 'http://wintehr.local/fhir/cds-hooks/override-reasons',
         display: 'Risk-benefit analysis favors override'
       },
       'false-positive': {
         code: 'false-positive',
-        system: 'https://wintehr.com/cds-hooks/override-reasons',
+        system: 'http://wintehr.local/fhir/cds-hooks/override-reasons',
         display: 'Alert appears to be false positive'
       },
       'not-applicable': {
         code: 'not-applicable',
-        system: 'https://wintehr.com/cds-hooks/override-reasons',
+        system: 'http://wintehr.local/fhir/cds-hooks/override-reasons',
         display: 'Alert not applicable to this patient'
       },
       'emergency': {
         code: 'emergency',
-        system: 'https://wintehr.com/cds-hooks/override-reasons',
+        system: 'http://wintehr.local/fhir/cds-hooks/override-reasons',
         display: 'Emergency situation requires override'
       },
       'other': {
         code: 'other',
-        system: 'https://wintehr.com/cds-hooks/override-reasons',
+        system: 'http://wintehr.local/fhir/cds-hooks/override-reasons',
         display: 'Other reason (see comments)'
       }
     };

--- a/frontend/src/services/clinicalCrossReferenceService.js
+++ b/frontend/src/services/clinicalCrossReferenceService.js
@@ -26,11 +26,11 @@ export class ClinicalCrossReferenceService {
           resourceType: 'Basic',
           id: `crossref-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
           meta: {
-            profile: ['http://wintehr.com/fhir/StructureDefinition/clinical-cross-reference']
+            profile: ['http://wintehr.local/fhir/fhir/StructureDefinition/clinical-cross-reference']
           },
           code: {
             coding: [{
-              system: 'http://wintehr.com/fhir/CodeSystem/cross-reference-type',
+              system: 'http://wintehr.local/fhir/fhir/CodeSystem/cross-reference-type',
               code: 'clinical-documentation-link',
               display: 'Clinical Documentation Link'
             }]
@@ -41,25 +41,25 @@ export class ClinicalCrossReferenceService {
           created: new Date().toISOString(),
           extension: [
             {
-              url: 'http://wintehr.com/fhir/StructureDefinition/source-document',
+              url: 'http://wintehr.local/fhir/fhir/StructureDefinition/source-document',
               valueReference: {
                 reference: `DocumentReference/${documentRef.id}`,
                 display: documentRef.description
               }
             },
             {
-              url: 'http://wintehr.com/fhir/StructureDefinition/target-resource',
+              url: 'http://wintehr.local/fhir/fhir/StructureDefinition/target-resource',
               valueReference: {
                 reference: resourceRef.reference,
                 display: resourceRef.display
               }
             },
             {
-              url: 'http://wintehr.com/fhir/StructureDefinition/link-type',
+              url: 'http://wintehr.local/fhir/fhir/StructureDefinition/link-type',
               valueString: this.determineLinkType(resourceRef)
             },
             {
-              url: 'http://wintehr.com/fhir/StructureDefinition/link-strength',
+              url: 'http://wintehr.local/fhir/fhir/StructureDefinition/link-strength',
               valueString: this.determineLinkStrength(documentRef, resourceRef)
             }
           ]
@@ -92,7 +92,7 @@ export class ClinicalCrossReferenceService {
       // Search for cross-references pointing to this resource
       const crossRefs = await fhirClient.search('Basic', {
         'code': 'clinical-documentation-link',
-        '_profile': 'http://wintehr.com/fhir/StructureDefinition/clinical-cross-reference'
+        '_profile': 'http://wintehr.local/fhir/fhir/StructureDefinition/clinical-cross-reference'
       });
 
       const linkedNotes = [];
@@ -103,13 +103,13 @@ export class ClinicalCrossReferenceService {
           
           // Check if this cross-reference targets our resource
           const targetExtension = crossRef.extension?.find(ext => 
-            ext.url === 'http://wintehr.com/fhir/StructureDefinition/target-resource'
+            ext.url === 'http://wintehr.local/fhir/fhir/StructureDefinition/target-resource'
           );
           
           if (targetExtension?.valueReference?.reference === resourceRef) {
             // Get the source document
             const sourceExtension = crossRef.extension?.find(ext => 
-              ext.url === 'http://wintehr.com/fhir/StructureDefinition/source-document'
+              ext.url === 'http://wintehr.local/fhir/fhir/StructureDefinition/source-document'
             );
             
             if (sourceExtension?.valueReference?.reference) {
@@ -122,10 +122,10 @@ export class ClinicalCrossReferenceService {
                   ...document,
                   crossReference: {
                     linkType: crossRef.extension?.find(ext => 
-                      ext.url === 'http://wintehr.com/fhir/StructureDefinition/link-type'
+                      ext.url === 'http://wintehr.local/fhir/fhir/StructureDefinition/link-type'
                     )?.valueString,
                     linkStrength: crossRef.extension?.find(ext => 
-                      ext.url === 'http://wintehr.com/fhir/StructureDefinition/link-strength'
+                      ext.url === 'http://wintehr.local/fhir/fhir/StructureDefinition/link-strength'
                     )?.valueString,
                     created: crossRef.created
                   }
@@ -166,7 +166,7 @@ export class ClinicalCrossReferenceService {
       // Search for cross-references from this document
       const crossRefs = await fhirClient.search('Basic', {
         'code': 'clinical-documentation-link',
-        '_profile': 'http://wintehr.com/fhir/StructureDefinition/clinical-cross-reference'
+        '_profile': 'http://wintehr.local/fhir/fhir/StructureDefinition/clinical-cross-reference'
       });
 
       const linkedData = {
@@ -186,13 +186,13 @@ export class ClinicalCrossReferenceService {
           
           // Check if this cross-reference originates from our document
           const sourceExtension = crossRef.extension?.find(ext => 
-            ext.url === 'http://wintehr.com/fhir/StructureDefinition/source-document'
+            ext.url === 'http://wintehr.local/fhir/fhir/StructureDefinition/source-document'
           );
           
           if (sourceExtension?.valueReference?.reference === `DocumentReference/${documentId}`) {
             // Get the target resource
             const targetExtension = crossRef.extension?.find(ext => 
-              ext.url === 'http://wintehr.com/fhir/StructureDefinition/target-resource'
+              ext.url === 'http://wintehr.local/fhir/fhir/StructureDefinition/target-resource'
             );
             
             if (targetExtension?.valueReference?.reference) {
@@ -206,10 +206,10 @@ export class ClinicalCrossReferenceService {
                   ...resource,
                   crossReference: {
                     linkType: crossRef.extension?.find(ext => 
-                      ext.url === 'http://wintehr.com/fhir/StructureDefinition/link-type'
+                      ext.url === 'http://wintehr.local/fhir/fhir/StructureDefinition/link-type'
                     )?.valueString,
                     linkStrength: crossRef.extension?.find(ext => 
-                      ext.url === 'http://wintehr.com/fhir/StructureDefinition/link-strength'
+                      ext.url === 'http://wintehr.local/fhir/fhir/StructureDefinition/link-strength'
                     )?.valueString,
                     created: crossRef.created
                   }
@@ -293,7 +293,7 @@ export class ClinicalCrossReferenceService {
       const crossRefs = await fhirClient.search('Basic', {
         'subject': `Patient/${patientId}`,
         'code': 'clinical-documentation-link',
-        '_profile': 'http://wintehr.com/fhir/StructureDefinition/clinical-cross-reference'
+        '_profile': 'http://wintehr.local/fhir/fhir/StructureDefinition/clinical-cross-reference'
       });
 
       const reverseIndex = new Map();
@@ -303,10 +303,10 @@ export class ClinicalCrossReferenceService {
           const crossRef = entry.resource;
           
           const sourceExtension = crossRef.extension?.find(ext => 
-            ext.url === 'http://wintehr.com/fhir/StructureDefinition/source-document'
+            ext.url === 'http://wintehr.local/fhir/fhir/StructureDefinition/source-document'
           );
           const targetExtension = crossRef.extension?.find(ext => 
-            ext.url === 'http://wintehr.com/fhir/StructureDefinition/target-resource'
+            ext.url === 'http://wintehr.local/fhir/fhir/StructureDefinition/target-resource'
           );
           
           if (sourceExtension && targetExtension) {
@@ -324,20 +324,20 @@ export class ClinicalCrossReferenceService {
             reverseIndex.get(sourceRef).linkedTo.push({
               reference: targetRef,
               linkType: crossRef.extension?.find(ext => 
-                ext.url === 'http://wintehr.com/fhir/StructureDefinition/link-type'
+                ext.url === 'http://wintehr.local/fhir/fhir/StructureDefinition/link-type'
               )?.valueString,
               linkStrength: crossRef.extension?.find(ext => 
-                ext.url === 'http://wintehr.com/fhir/StructureDefinition/link-strength'
+                ext.url === 'http://wintehr.local/fhir/fhir/StructureDefinition/link-strength'
               )?.valueString
             });
             
             reverseIndex.get(targetRef).linkedFrom.push({
               reference: sourceRef,
               linkType: crossRef.extension?.find(ext => 
-                ext.url === 'http://wintehr.com/fhir/StructureDefinition/link-type'
+                ext.url === 'http://wintehr.local/fhir/fhir/StructureDefinition/link-type'
               )?.valueString,
               linkStrength: crossRef.extension?.find(ext => 
-                ext.url === 'http://wintehr.com/fhir/StructureDefinition/link-strength'
+                ext.url === 'http://wintehr.local/fhir/fhir/StructureDefinition/link-strength'
               )?.valueString
             });
           }
@@ -531,7 +531,7 @@ export class ClinicalCrossReferenceService {
       // Find all cross-references for this document
       const crossRefs = await fhirClient.search('Basic', {
         'code': 'clinical-documentation-link',
-        '_profile': 'http://wintehr.com/fhir/StructureDefinition/clinical-cross-reference'
+        '_profile': 'http://wintehr.local/fhir/fhir/StructureDefinition/clinical-cross-reference'
       });
 
       const toDelete = [];
@@ -541,7 +541,7 @@ export class ClinicalCrossReferenceService {
           const crossRef = entry.resource;
           
           const sourceExtension = crossRef.extension?.find(ext => 
-            ext.url === 'http://wintehr.com/fhir/StructureDefinition/source-document'
+            ext.url === 'http://wintehr.local/fhir/fhir/StructureDefinition/source-document'
           );
           
           if (sourceExtension?.valueReference?.reference === `DocumentReference/${documentId}`) {

--- a/frontend/src/services/clinicalDocumentationLinkingService.js
+++ b/frontend/src/services/clinicalDocumentationLinkingService.js
@@ -160,7 +160,7 @@ export class ClinicalDocumentationLinkingService {
         },
         // Custom extension for problem linking
         extension: [{
-          url: 'http://wintehr.com/fhir/StructureDefinition/linked-condition',
+          url: 'http://wintehr.local/fhir/fhir/StructureDefinition/linked-condition',
           valueReference: {
             reference: `Condition/${conditionId}`,
             display: 'Linked Clinical Problem'
@@ -235,7 +235,7 @@ export class ClinicalDocumentationLinkingService {
         },
         // Custom extension for medication linking
         extension: [{
-          url: 'http://wintehr.com/fhir/StructureDefinition/linked-medication',
+          url: 'http://wintehr.local/fhir/fhir/StructureDefinition/linked-medication',
           valueReference: {
             reference: `MedicationRequest/${medicationId}`,
             display: 'Linked Medication'

--- a/frontend/src/services/emrClient.js
+++ b/frontend/src/services/emrClient.js
@@ -6,10 +6,11 @@
  */
 
 import axios from 'axios';
+import { getFhirUrl, getEmrUrl } from '../config/apiConfig';
 
 class EMRClient {
   constructor(config = {}) {
-    this.baseUrl = config.baseUrl || process.env.REACT_APP_EMR_API || '/api/emr';
+    this.baseUrl = config.baseUrl || getEmrUrl();
     this.enabled = config.enabled !== false && process.env.REACT_APP_EMR_FEATURES !== 'false';
     // Disable EMR features by default if not explicitly enabled
     if (process.env.REACT_APP_EMR_FEATURES === undefined) {
@@ -321,7 +322,7 @@ class EMRClient {
     const response = await axios.post('/api/clinical-canvas/generate', {
       prompt,
       context,
-      fhirBaseUrl: process.env.REACT_APP_FHIR_ENDPOINT
+      fhirBaseUrl: getFhirUrl()
     });
     return response.data;
   }

--- a/frontend/src/services/resultDocumentationService.js
+++ b/frontend/src/services/resultDocumentationService.js
@@ -127,18 +127,18 @@ export class ResultDocumentationService {
         // Custom extensions for result linking
         extension: [
           {
-            url: 'http://wintehr.com/fhir/StructureDefinition/linked-result',
+            url: 'http://wintehr.local/fhir/fhir/StructureDefinition/linked-result',
             valueReference: {
               reference: `${noteData.linkedResources.primary.resourceType}/${noteData.resultId}`,
               display: 'Linked Result'
             }
           },
           {
-            url: 'http://wintehr.com/fhir/StructureDefinition/auto-generated',
+            url: 'http://wintehr.local/fhir/fhir/StructureDefinition/auto-generated',
             valueBoolean: true
           },
           {
-            url: 'http://wintehr.com/fhir/StructureDefinition/result-urgency',
+            url: 'http://wintehr.local/fhir/fhir/StructureDefinition/result-urgency',
             valueString: noteData.urgency
           }
         ]


### PR DESCRIPTION
## Hygiene E4 + E6 + H6

- **E4** — `fhirClient.ts`, `HttpClientFactory`, `emrClient`, `api.js` no longer read `process.env.REACT_APP_*` directly; they resolve through `config/apiConfig` (which also handles the `/R4` normalization the copies lacked). ServiceSelector's reads stay — they're feature flags, not URLs. One test updated to match the single-reader design (env is read once at module init). `useNotifications.js` deletion deferred to the notification-bell reconciliation.
- **E6** — custom FHIR system URIs normalized to `http://wintehr.local/fhir/*` across 14 files (`wintehr.com` / `emr.local` / https variants; paths preserved). Stored-data caveat noted in the commit: old-domain extensions in previously-stored resources aren't readable by the new readers — acceptable for a synthetic-data platform; deliberately skipped `TaskContext.js` (deleted on #204) and `CDSPresentation.js` (edited on the R38-R40 branch).
- **H6** — audience map added to `docs/DEPLOYMENT.md` (the canonical operator guide) cross-linking README quick-start / CLIENT_DEPLOYMENT / AZURE_DEPLOYMENT and warning off the historical `AUTOMATED_DEPLOYMENT.md`; commands audited against `deploy.sh`.

### Verification
- 500 tests / 84 failed — identical to baseline except the one intentional test rename (same statuses)
- eslint 0 errors on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)