### PR TITLE
polish(frontend): one feedback dialect via notistack; token tidy-ups (R41, R45)

### DIFF
--- a/frontend/src/components/clinical/ClinicalWorkspaceEnhanced.js
+++ b/frontend/src/components/clinical/ClinicalWorkspaceEnhanced.js
@@ -11,12 +11,12 @@ import {
   Alert,
   AlertTitle,
   Button,
-  Snackbar,
   Typography
 } from '@mui/material';
 import {
   ChevronLeft as ChevronLeftIcon
 } from '@mui/icons-material';
+import { useSnackbar } from 'notistack';
 
 // Contexts
 import { useAuth } from '../../contexts/AuthContext';
@@ -68,7 +68,7 @@ const ClinicalWorkspaceEnhanced = ({
   const { publish } = useClinicalWorkflow();
   
   // State
-  const [snackbar, setSnackbar] = useState({ open: false, message: '' });
+  const { enqueueSnackbar } = useSnackbar();
   const [showKeyboardHelp, setShowKeyboardHelp] = useState(false);
   
   // Use parent's activeModule directly
@@ -130,12 +130,12 @@ const ClinicalWorkspaceEnhanced = ({
     if (onRefresh && activePatient) {
       try {
         await onRefresh();
-        setSnackbar({ open: true, message: 'Patient data refreshed successfully' });
+        enqueueSnackbar('Patient data refreshed successfully', { variant: 'success' });
       } catch (error) {
-        setSnackbar({ open: true, message: 'Failed to refresh data' });
+        enqueueSnackbar('Failed to refresh data', { variant: 'error' });
       }
     }
-  }, [activePatient, onRefresh]);
+  }, [activePatient, onRefresh, enqueueSnackbar]);
 
   // Handle keyboard navigation actions
   const handleKeyboardAction = useCallback((action) => {
@@ -343,15 +343,6 @@ const ClinicalWorkspaceEnhanced = ({
         </TabErrorBoundary>
       </Box>
 
-      {/* Snackbar for notifications */}
-      <Snackbar
-        open={snackbar.open}
-        autoHideDuration={4000}
-        onClose={() => setSnackbar({ open: false, message: '' })}
-        message={snackbar.message}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-      />
-      
       {/* Keyboard shortcuts help dialog */}
       <KeyboardShortcutsDialog
         open={showKeyboardHelp}

--- a/frontend/src/components/clinical/documentation/DocumentationTab.js
+++ b/frontend/src/components/clinical/documentation/DocumentationTab.js
@@ -41,12 +41,14 @@ import {
   ContentPaste as TemplateIcon
 } from '@mui/icons-material';
 import { format } from 'date-fns';
+import { useSnackbar } from 'notistack';
 import { useDocumentation } from '../../../contexts/DocumentationContext';
 import { useClinical } from '../../../contexts/ClinicalContext';
 import SOAPEditor from './SOAPEditor';
 import fhirClient from '../../../core/fhir/services/fhirClient';
 
 const DocumentationTab = () => {
+  const { enqueueSnackbar } = useSnackbar();
   const { currentPatient } = useClinical();
   const {
     recentNotes,
@@ -288,8 +290,8 @@ const DocumentationTab = () => {
         setAddendumContent(originalContent + noteContent + '\n\n=== ADDENDUM ===\n\n');
         setShowAddendumDialog(true);
       } catch (error) {
-        
-        alert('Error loading note content');
+
+        enqueueSnackbar('Error loading note content', { variant: 'error' });
       }
     }
     handleMenuClose();
@@ -313,7 +315,7 @@ const DocumentationTab = () => {
           status: 'draft'
         });
         
-        alert('Created a new progress note based on the encounter note. You can now edit and sign it.');
+        enqueueSnackbar('Created a new progress note based on the encounter note. You can now edit and sign it.', { variant: 'success' });
       } else {
         // For clinical notes, create an addendum
         await createAddendum(addendumNoteId, addendumContent);
@@ -328,8 +330,8 @@ const DocumentationTab = () => {
         loadRecentNotes(currentPatient.id);
       }
     } catch (error) {
-      
-      alert(`Error creating addendum: ${error.response?.data?.detail || error.message}`);
+
+      enqueueSnackbar(`Error creating addendum: ${error.response?.data?.detail || error.message}`, { variant: 'error' });
     }
   };
 

--- a/frontend/src/components/clinical/shared/dialogs/BatchOperationsDialog.js
+++ b/frontend/src/components/clinical/shared/dialogs/BatchOperationsDialog.js
@@ -96,6 +96,7 @@ import {
   IndeterminateCheckBox as IndeterminateCheckBoxIcon
 } from '@mui/icons-material';
 import { format } from 'date-fns';
+import { useSnackbar } from 'notistack';
 import { fhirClient } from '../../../../core/fhir/services/fhirClient';
 import { useClinical as useClinicalContext } from '../../../../contexts/ClinicalContext';
 import { useAuth } from '../../../../contexts/AuthContext';
@@ -186,6 +187,7 @@ const BatchOperationsDialog = ({
   maxBatchSize = 50
 }) => {
   const theme = useTheme();
+  const { enqueueSnackbar } = useSnackbar();
   const { user } = useAuth();
   const { publish } = useClinicalContext();
   
@@ -317,7 +319,7 @@ const BatchOperationsDialog = ({
   const executeBatchOperation = useCallback(async () => {
     const validation = validateOperation();
     if (!validation.valid) {
-      alert(validation.error);
+      enqueueSnackbar(validation.error, { variant: 'warning' });
       return;
     }
 
@@ -463,11 +465,11 @@ const BatchOperationsDialog = ({
       setActiveStep(3);
     } catch (error) {
       console.error('Batch operation error:', error);
-      alert(`Batch operation failed: ${error.message}`);
+      enqueueSnackbar(`Batch operation failed: ${error.message}`, { variant: 'error' });
     } finally {
       setProcessing(false);
     }
-  }, [selectedResources, operationType, updateFields, resourceType, user, publish, onOperationComplete, validateOperation]);
+  }, [selectedResources, operationType, updateFields, resourceType, user, publish, onOperationComplete, validateOperation, enqueueSnackbar]);
 
   // Render resource row
   const renderResourceRow = useCallback((resource) => {

--- a/frontend/src/components/clinical/workspace/WorkspaceErrorBoundary.js
+++ b/frontend/src/components/clinical/workspace/WorkspaceErrorBoundary.js
@@ -23,6 +23,7 @@ import {
   Home as HomeIcon,
   BugReport as BugReportIcon
 } from '@mui/icons-material';
+import { enqueueSnackbar } from 'notistack';
 
 class WorkspaceErrorBoundary extends React.Component {
   constructor(props) {
@@ -123,7 +124,7 @@ Component Stack: ${this.state.errorInfo?.componentStack}
       `.trim();
       
       navigator.clipboard.writeText(errorDetails).then(() => {
-        alert('Error details copied to clipboard. Please include them in your bug report.');
+        enqueueSnackbar('Error details copied to clipboard. Please include them in your bug report.', { variant: 'success' });
       });
     }
   };

--- a/frontend/src/components/clinical/workspace/cds/CDSHooksVerifier.js
+++ b/frontend/src/components/clinical/workspace/cds/CDSHooksVerifier.js
@@ -59,6 +59,7 @@ import {
   Psychology as CDSIcon
 } from '@mui/icons-material';
 import { format } from 'date-fns';
+import { useSnackbar } from 'notistack';
 import { cdsHooksClient } from '../../../../services/cdsHooksClient';
 import { fhirClient } from '../../../../core/fhir/services/fhirClient';
 import { useFHIRResource } from '../../../../contexts/FHIRResourceContext';
@@ -66,6 +67,7 @@ import { cdsHooksTester } from '../../../../core/cds/cdsHooksTester';
 
 const CDSHooksVerifier = () => {
   const theme = useTheme();
+  const { enqueueSnackbar } = useSnackbar();
   const { searchResources } = useFHIRResource();
   
   const [loading, setLoading] = useState(false);
@@ -109,7 +111,7 @@ const CDSHooksVerifier = () => {
 
   const executeHookTest = async () => {
     if (!selectedPatient || !selectedService) {
-      alert('Please select both a patient and a service');
+      enqueueSnackbar('Please select both a patient and a service', { variant: 'warning' });
       return;
     }
 
@@ -186,7 +188,7 @@ const CDSHooksVerifier = () => {
 
   const testAllPatientViewHooks = async () => {
     if (!selectedPatient) {
-      alert('Please select a patient');
+      enqueueSnackbar('Please select a patient', { variant: 'warning' });
       return;
     }
 
@@ -250,13 +252,13 @@ const CDSHooksVerifier = () => {
       const results = await cdsHooksTester.runTestSuite();
       
       if (results) {
-        alert(`Test suite completed!\n\nTotal tests: ${results.totalTests}\nSuccessful: ${results.successful}\nFailed: ${results.failed}\nCards generated: ${results.totalCards}\n\nCheck browser console for detailed results.`);
+        enqueueSnackbar(`Test suite completed!\n\nTotal tests: ${results.totalTests}\nSuccessful: ${results.successful}\nFailed: ${results.failed}\nCards generated: ${results.totalCards}\n\nCheck browser console for detailed results.`, { variant: 'success' });
       } else {
-        alert('Test suite failed. Check browser console for details.');
+        enqueueSnackbar('Test suite failed. Check browser console for details.', { variant: 'error' });
       }
     } catch (error) {
-      
-      alert(`Test failed: ${error.message}`);
+
+      enqueueSnackbar(`Test failed: ${error.message}`, { variant: 'error' });
     } finally {
       setLoading(false);
     }

--- a/frontend/src/components/clinical/workspace/tabs/CDSHooksTab.js
+++ b/frontend/src/components/clinical/workspace/tabs/CDSHooksTab.js
@@ -41,7 +41,6 @@ import {
   DialogTitle,
   DialogContent,
   DialogActions,
-  Snackbar,
   useTheme
 } from '@mui/material';
 import {
@@ -63,6 +62,7 @@ import {
   School as TrainingIcon,
   Close as CloseIcon
 } from '@mui/icons-material';
+import { useSnackbar } from 'notistack';
 import { format } from 'date-fns';
 // CDSHookBuilder removed - use CDS Studio for building hooks
 import CDSHooksVerifier from '../cds/CDSHooksVerifier';
@@ -110,7 +110,7 @@ const CDSHooksTab = ({ patientId }) => {
   const [executionHistory, setExecutionHistory] = useState([]);
   const [serviceSettings, setServiceSettings] = useState({});
   const [customHooks, setCustomHooks] = useState([]);
-  const [snackbar, setSnackbar] = useState({ open: false, message: '', severity: 'success' });
+  const { enqueueSnackbar } = useSnackbar();
   const [displayBehavior, setDisplayBehavior] = useState({
     displayMode: 'immediate',
     position: 'top',
@@ -400,11 +400,7 @@ const CDSHooksTab = ({ patientId }) => {
         setCustomHooks(result.data);
       }
     } catch (error) {
-      setSnackbar({
-        open: true,
-        message: `Failed to load custom hooks: ${error.message}`,
-        severity: 'error'
-      });
+      enqueueSnackbar(`Failed to load custom hooks: ${error.message}`, { variant: 'error' });
       setCustomHooks([]);
     }
   };
@@ -479,11 +475,7 @@ const CDSHooksTab = ({ patientId }) => {
 
   const handleDismissCard = (cardIndex) => {
     setCards(prevCards => prevCards.filter((_, index) => index !== cardIndex));
-    setSnackbar({
-      open: true,
-      message: 'Alert dismissed',
-      severity: 'info'
-    });
+    enqueueSnackbar('Alert dismissed', { variant: 'info' });
   };
 
   const getCardIcon = (indicator) => {
@@ -523,11 +515,7 @@ const CDSHooksTab = ({ patientId }) => {
         const executableActions = suggestion.actions.filter(isActionExecutable);
         
         if (executableActions.length === 0) {
-          setSnackbar({
-            open: true,
-            message: 'No executable actions found in this suggestion',
-            severity: 'warning'
-          });
+          enqueueSnackbar('No executable actions found in this suggestion', { variant: 'warning' });
           return;
         }
 
@@ -568,23 +556,11 @@ const CDSHooksTab = ({ patientId }) => {
 
         // Show appropriate feedback
         if (successCount > 0 && errorCount === 0) {
-          setSnackbar({
-            open: true,
-            message: `Successfully executed ${successCount} action(s)`,
-            severity: 'success'
-          });
+          enqueueSnackbar(`Successfully executed ${successCount} action(s)`, { variant: 'success' });
         } else if (successCount > 0 && errorCount > 0) {
-          setSnackbar({
-            open: true,
-            message: `Executed ${successCount} action(s), ${errorCount} failed`,
-            severity: 'warning'
-          });
+          enqueueSnackbar(`Executed ${successCount} action(s), ${errorCount} failed`, { variant: 'warning' });
         } else {
-          setSnackbar({
-            open: true,
-            message: `All actions failed: ${errors.join('; ')}`,
-            severity: 'error'
-          });
+          enqueueSnackbar(`All actions failed: ${errors.join('; ')}`, { variant: 'error' });
         }
       }
 
@@ -618,11 +594,7 @@ const CDSHooksTab = ({ patientId }) => {
         }
 
         if (operationCount > 0) {
-          setSnackbar({
-            open: true,
-            message: `Successfully executed ${operationCount} operation(s)`,
-            severity: 'success'
-          });
+          enqueueSnackbar(`Successfully executed ${operationCount} operation(s)`, { variant: 'success' });
         }
       }
 
@@ -655,11 +627,7 @@ const CDSHooksTab = ({ patientId }) => {
     } catch (error) {
       console.error('Suggestion action failed:', error);
       setError(`Failed to execute action: ${error.message}`);
-      setSnackbar({
-        open: true,
-        message: `Action execution failed: ${error.message}`,
-        severity: 'error'
-      });
+      enqueueSnackbar(`Action execution failed: ${error.message}`, { variant: 'error' });
     }
   };
 
@@ -676,11 +644,7 @@ const CDSHooksTab = ({ patientId }) => {
         
       } catch (error) {
         
-        setSnackbar({
-          open: true,
-          message: `Failed to delete hook: ${error.message}`,
-          severity: 'error'
-        });
+        enqueueSnackbar(`Failed to delete hook: ${error.message}`, { variant: 'error' });
       }
     }
   };
@@ -753,11 +717,7 @@ const CDSHooksTab = ({ patientId }) => {
                         size="small"
                         onClick={() => {
                           setCards([]);
-                          setSnackbar({
-                            open: true,
-                            message: 'All alerts cleared',
-                            severity: 'info'
-                          });
+                          enqueueSnackbar('All alerts cleared', { variant: 'info' });
                         }}
                         disabled={loading}
                       >
@@ -1461,20 +1421,6 @@ const CDSHooksTab = ({ patientId }) => {
       </TabPanel>
 
       {/* Snackbar for notifications */}
-      <Snackbar
-        open={snackbar.open}
-        autoHideDuration={6000}
-        onClose={() => setSnackbar({ ...snackbar, open: false })}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
-      >
-        <Alert 
-          onClose={() => setSnackbar({ ...snackbar, open: false })} 
-          severity={snackbar.severity}
-          sx={{ width: '100%' }}
-        >
-          {snackbar.message}
-        </Alert>
-      </Snackbar>
     </Box>
   );
 };

--- a/frontend/src/components/clinical/workspace/tabs/CarePlanTabEnhanced.js
+++ b/frontend/src/components/clinical/workspace/tabs/CarePlanTabEnhanced.js
@@ -39,7 +39,6 @@ import {
   InputAdornment,
   ToggleButton,
   ToggleButtonGroup,
-  Snackbar,
   Grid,
   Avatar,
   AvatarGroup,
@@ -92,6 +91,7 @@ import {
   ArrowDownward as DownIcon,
   Remove as NoChangeIcon
 } from '@mui/icons-material';
+import { useSnackbar } from 'notistack';
 import { format, parseISO, formatDistanceToNow, isPast, isFuture, differenceInDays, addDays, isWithinInterval, startOfDay, endOfDay } from 'date-fns';
 import { formatClinicalDate } from '../../../../core/fhir/utils/dateFormatUtils';
 import { useFHIRResource } from '../../../../contexts/FHIRResourceContext';
@@ -414,7 +414,7 @@ const CarePlanTabEnhanced = ({
   const [activityDialogOpen, setActivityDialogOpen] = useState(false);
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [createForm, setCreateForm] = useState({ title: '', category: 'assess-plan', description: '' });
-  const [snackbar, setSnackbar] = useState({ open: false, message: '', severity: 'success' });
+  const { enqueueSnackbar } = useSnackbar();
   const [isSaving, setIsSaving] = useState(false);
 
   // Form refs for Goal dialog
@@ -672,11 +672,7 @@ const CarePlanTabEnhanced = ({
 
     const description = goalDescriptionRef.current?.value?.trim();
     if (!description) {
-      setSnackbar({
-        open: true,
-        message: 'Goal description is required',
-        severity: 'error'
-      });
+      enqueueSnackbar('Goal description is required', { variant: 'error' });
       return;
     }
 
@@ -756,25 +752,17 @@ const CarePlanTabEnhanced = ({
         action: selectedGoal?.id ? 'updated' : 'created'
       });
 
-      setSnackbar({
-        open: true,
-        message: selectedGoal ? 'Goal updated successfully' : 'Goal created successfully',
-        severity: 'success'
-      });
+      enqueueSnackbar(selectedGoal ? 'Goal updated successfully' : 'Goal created successfully', { variant: 'success' });
       setGoalDialogOpen(false);
       setSelectedGoal(null);
 
     } catch (error) {
       console.error('Error saving goal:', error);
-      setSnackbar({
-        open: true,
-        message: `Failed to save goal: ${error.message}`,
-        severity: 'error'
-      });
+      enqueueSnackbar(`Failed to save goal: ${error.message}`, { variant: 'error' });
     } finally {
       setIsSaving(false);
     }
-  }, [patientId, selectedGoal, refreshPatientResources, publish]);
+  }, [patientId, selectedGoal, refreshPatientResources, publish, enqueueSnackbar]);
 
   /**
    * Save Activity to CarePlan
@@ -782,21 +770,13 @@ const CarePlanTabEnhanced = ({
    */
   const handleSaveActivity = useCallback(async () => {
     if (!patientId || !activeCarePlan) {
-      setSnackbar({
-        open: true,
-        message: 'No active care plan found',
-        severity: 'error'
-      });
+      enqueueSnackbar('No active care plan found', { variant: 'error' });
       return;
     }
 
     const description = activityDescriptionRef.current?.value?.trim();
     if (!description) {
-      setSnackbar({
-        open: true,
-        message: 'Activity description is required',
-        severity: 'error'
-      });
+      enqueueSnackbar('Activity description is required', { variant: 'error' });
       return;
     }
 
@@ -881,25 +861,17 @@ const CarePlanTabEnhanced = ({
         action: 'activity_updated'
       });
 
-      setSnackbar({
-        open: true,
-        message: selectedActivity ? 'Activity updated successfully' : 'Activity added successfully',
-        severity: 'success'
-      });
+      enqueueSnackbar(selectedActivity ? 'Activity updated successfully' : 'Activity added successfully', { variant: 'success' });
       setActivityDialogOpen(false);
       setSelectedActivity(null);
 
     } catch (error) {
       console.error('Error saving activity:', error);
-      setSnackbar({
-        open: true,
-        message: `Failed to save activity: ${error.message}`,
-        severity: 'error'
-      });
+      enqueueSnackbar(`Failed to save activity: ${error.message}`, { variant: 'error' });
     } finally {
       setIsSaving(false);
     }
-  }, [patientId, activeCarePlan, selectedActivity, refreshPatientResources, publish]);
+  }, [patientId, activeCarePlan, selectedActivity, refreshPatientResources, publish, enqueueSnackbar]);
 
   /**
    * Save Team Member to CareTeam
@@ -910,11 +882,7 @@ const CarePlanTabEnhanced = ({
 
     const memberName = teamMemberNameRef.current?.value?.trim();
     if (!memberName) {
-      setSnackbar({
-        open: true,
-        message: 'Team member name is required',
-        severity: 'error'
-      });
+      enqueueSnackbar('Team member name is required', { variant: 'error' });
       return;
     }
 
@@ -999,25 +967,17 @@ const CarePlanTabEnhanced = ({
         action: selectedParticipant ? 'participant_updated' : 'participant_added'
       });
 
-      setSnackbar({
-        open: true,
-        message: selectedParticipant ? 'Team member updated successfully' : 'Team member added successfully',
-        severity: 'success'
-      });
+      enqueueSnackbar(selectedParticipant ? 'Team member updated successfully' : 'Team member added successfully', { variant: 'success' });
       setTeamDialogOpen(false);
       setSelectedParticipant(null);
 
     } catch (error) {
       console.error('Error saving team member:', error);
-      setSnackbar({
-        open: true,
-        message: `Failed to save team member: ${error.message}`,
-        severity: 'error'
-      });
+      enqueueSnackbar(`Failed to save team member: ${error.message}`, { variant: 'error' });
     } finally {
       setIsSaving(false);
     }
-  }, [patientId, careTeam, selectedParticipant, refreshPatientResources, publish]);
+  }, [patientId, careTeam, selectedParticipant, refreshPatientResources, publish, enqueueSnackbar]);
 
   // Quick actions for FAB
   const quickActions = [
@@ -1861,11 +1821,7 @@ const CarePlanTabEnhanced = ({
           <Button
             variant="contained"
             onClick={() => {
-              setSnackbar({
-                open: true,
-                message: 'Progress updated successfully',
-                severity: 'success'
-              });
+              enqueueSnackbar('Progress updated successfully', { variant: 'success' });
               setProgressDialogOpen(false);
             }}
           >
@@ -2155,10 +2111,10 @@ const CarePlanTabEnhanced = ({
                 loadAttemptedRef.current = null;
                 await refreshPatientResources(patientId, ['CarePlan']);
                 setCreateDialogOpen(false);
-                setSnackbar({ open: true, message: 'Care plan created successfully', severity: 'success' });
+                enqueueSnackbar('Care plan created successfully', { variant: 'success' });
               } catch (err) {
                 console.error('Failed to create care plan:', err);
-                setSnackbar({ open: true, message: 'Failed to create care plan', severity: 'error' });
+                enqueueSnackbar('Failed to create care plan', { variant: 'error' });
               } finally {
                 setIsSaving(false);
               }
@@ -2170,20 +2126,6 @@ const CarePlanTabEnhanced = ({
       </Dialog>
 
       {/* Snackbar */}
-      <Snackbar
-        open={snackbar.open}
-        autoHideDuration={6000}
-        onClose={() => setSnackbar({ ...snackbar, open: false })}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
-      >
-        <Alert
-          onClose={() => setSnackbar({ ...snackbar, open: false })}
-          severity={snackbar.severity}
-          sx={{ width: '100%' }}
-        >
-          {snackbar.message}
-        </Alert>
-      </Snackbar>
     </Box>
   );
 };

--- a/frontend/src/components/clinical/workspace/tabs/DocumentationTabEnhanced.js
+++ b/frontend/src/components/clinical/workspace/tabs/DocumentationTabEnhanced.js
@@ -43,7 +43,6 @@ import {
   ToggleButtonGroup,
   useTheme,
   alpha,
-  Snackbar,
   Collapse,
   Badge,
   Avatar,
@@ -96,6 +95,7 @@ import {
   Group as CollaboratorsIcon,
   Close as CloseIcon
 } from '@mui/icons-material';
+import { useSnackbar } from 'notistack';
 // Removed framer-motion for better performance
 import { parseISO, formatDistanceToNow, isWithinInterval, subDays, subMonths, startOfWeek, startOfMonth, endOfWeek, endOfMonth } from 'date-fns';
 import { formatClinicalDate } from '../../../../core/fhir/utils/dateFormatUtils';
@@ -467,7 +467,7 @@ const DocumentationTabEnhanced = ({
   const [filterAuthor, setFilterAuthor] = useState('all');
   const [searchTerm, setSearchTerm] = useState('');
   const [loading, setLoading] = useState(true);
-  const [snackbar, setSnackbar] = useState({ open: false, message: '', severity: 'success' });
+  const { enqueueSnackbar } = useSnackbar();
   const [enhancedEditorOpen, setEnhancedEditorOpen] = useState(false);
   const [templateWizardOpen, setTemplateWizardOpen] = useState(false);
   const [amendmentMode, setAmendmentMode] = useState(false);
@@ -529,54 +529,30 @@ const DocumentationTabEnhanced = ({
     // Show notification based on event type
     switch (eventType) {
       case CLINICAL_EVENTS.NOTE_CREATED:
-        setSnackbar({
-          open: true,
-          message: `New note created: ${document.type?.text || 'Clinical Note'}`,
-          severity: 'info'
-        });
+        enqueueSnackbar(`New note created: ${document.type?.text || 'Clinical Note'}`, { variant: 'info' });
         break;
         
       case CLINICAL_EVENTS.NOTE_SIGNED:
-        setSnackbar({
-          open: true,
-          message: 'Note has been signed',
-          severity: 'success'
-        });
+        enqueueSnackbar('Note has been signed', { variant: 'success' });
         break;
         
       case CLINICAL_EVENTS.NOTE_UPDATED:
-        setSnackbar({
-          open: true,
-          message: 'Note has been updated',
-          severity: 'info'
-        });
+        enqueueSnackbar('Note has been updated', { variant: 'info' });
         break;
         
       case CLINICAL_EVENTS.NOTE_AMENDED:
-        setSnackbar({
-          open: true,
-          message: 'Note has been amended',
-          severity: 'warning'
-        });
+        enqueueSnackbar('Note has been amended', { variant: 'warning' });
         break;
         
       case CLINICAL_EVENTS.NOTE_ADDENDUM:
-        setSnackbar({
-          open: true,
-          message: 'Addendum added to note',
-          severity: 'info'
-        });
+        enqueueSnackbar('Addendum added to note', { variant: 'info' });
         break;
         
       case CLINICAL_EVENTS.DOCUMENT_UPLOADED:
-        setSnackbar({
-          open: true,
-          message: 'New document uploaded',
-          severity: 'info'
-        });
+        enqueueSnackbar('New document uploaded', { variant: 'info' });
         break;
     }
-  }, [patientId, searchResources]);
+  }, [patientId, searchResources, enqueueSnackbar]);
 
   // Real-time updates subscription
   useEffect(() => {
@@ -1047,11 +1023,7 @@ const DocumentationTabEnhanced = ({
       const result = await fhirClient.update('DocumentReference', resourceId, updatedResource);
       
       if (result) {
-        setSnackbar({
-          open: true,
-          message: 'Note signed successfully',
-          severity: 'success'
-        });
+        enqueueSnackbar('Note signed successfully', { variant: 'success' });
 
         // Force a refresh of DocumentReference resources to show updated status immediately
         try {
@@ -1076,32 +1048,20 @@ const DocumentationTabEnhanced = ({
         });
       }
     } catch (error) {
-      setSnackbar({
-        open: true,
-        message: 'Failed to sign note: ' + error.message,
-        severity: 'error'
-      });
+      enqueueSnackbar('Failed to sign note: ' + error.message, { variant: 'error' });
     }
   };
 
   const handleFavoriteNote = (note) => {
     // Toggle favorite status (would normally update in backend)
     note.isFavorite = !note.isFavorite;
-    setSnackbar({
-      open: true,
-      message: note.isFavorite ? 'Note added to favorites' : 'Note removed from favorites',
-      severity: 'success'
-    });
+    enqueueSnackbar(note.isFavorite ? 'Note added to favorites' : 'Note removed from favorites', { variant: 'success' });
   };
 
   const handlePinNote = (note) => {
     // Toggle pin status (would normally update in backend)
     note.isPinned = !note.isPinned;
-    setSnackbar({
-      open: true,
-      message: note.isPinned ? 'Note pinned' : 'Note unpinned',
-      severity: 'success'
-    });
+    enqueueSnackbar(note.isPinned ? 'Note pinned' : 'Note unpinned', { variant: 'success' });
   };
 
   const handlePrintNote = (note) => {
@@ -1147,17 +1107,9 @@ const DocumentationTabEnhanced = ({
       document.body.removeChild(a);
       URL.revokeObjectURL(url);
 
-      setSnackbar({
-        open: true,
-        message: 'Note exported successfully',
-        severity: 'success'
-      });
+      enqueueSnackbar('Note exported successfully', { variant: 'success' });
     } catch (error) {
-      setSnackbar({
-        open: true,
-        message: 'Error exporting note: ' + error.message,
-        severity: 'error'
-      });
+      enqueueSnackbar('Error exporting note: ' + error.message, { variant: 'error' });
     }
   };
 
@@ -1745,11 +1697,7 @@ const DocumentationTabEnhanced = ({
               <Button 
                 variant="contained"
                 onClick={() => {
-                  setSnackbar({
-                    open: true,
-                    message: selectedNote ? 'Note updated successfully' : 'Note created successfully',
-                    severity: 'success'
-                  });
+                  enqueueSnackbar(selectedNote ? 'Note updated successfully' : 'Note created successfully', { variant: 'success' });
                   setEnhancedEditorOpen(false);
                 }}
               >
@@ -1827,20 +1775,6 @@ const DocumentationTabEnhanced = ({
       </Dialog>
 
       {/* Snackbar for notifications */}
-      <Snackbar
-        open={snackbar.open}
-        autoHideDuration={6000}
-        onClose={() => setSnackbar({ ...snackbar, open: false })}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
-      >
-        <Alert 
-          onClose={() => setSnackbar({ ...snackbar, open: false })} 
-          severity={snackbar.severity}
-          sx={{ width: '100%' }}
-        >
-          {snackbar.message}
-        </Alert>
-      </Snackbar>
       
       {/* Floating Action Button */}
       {ContextualFAB ? (
@@ -1877,11 +1811,7 @@ const DocumentationTabEnhanced = ({
               icon: <UploadIcon />,
               name: 'Import Document',
               onClick: () => {
-                setSnackbar({
-                  open: true,
-                  message: 'Document import feature is not yet implemented',
-                  severity: 'info'
-                });
+                enqueueSnackbar('Document import feature is not yet implemented', { variant: 'info' });
               }
             }
           ]}

--- a/frontend/src/components/clinical/workspace/tabs/EncountersTab.js
+++ b/frontend/src/components/clinical/workspace/tabs/EncountersTab.js
@@ -16,7 +16,6 @@ import {
   Divider,
   InputAdornment,
   Alert,
-  Snackbar,
   Badge,
   Grid,
   ToggleButton,
@@ -39,7 +38,8 @@ import {
   Assignment as AssignmentIcon,
   Science as LabIcon
 } from '@mui/icons-material';
-import { format, parseISO, isWithinInterval, subMonths } from 'date-fns';
+import { useSnackbar } from 'notistack';
+import { parseISO, isWithinInterval, subMonths } from 'date-fns';
 import { formatClinicalDate } from '../../../../core/fhir/utils/dateFormatUtils';
 import { useFHIRResource } from '../../../../contexts/FHIRResourceContext';
 import { navigateToTab, TAB_IDS } from '../../utils/navigationHelper';
@@ -122,7 +122,7 @@ const EncountersTab = ({
   const scrollContainerRef = useRef(null);
   const [selectedEncounter, setSelectedEncounter] = useState(null);
   const [density, setDensity] = useDensity('comfortable');
-  const [snackbar, setSnackbar] = useState({ open: false, message: '', severity: 'success' });
+  const { enqueueSnackbar } = useSnackbar();
   const [summaryDialogOpen, setSummaryDialogOpen] = useState(false);
   const [encounterCreationDialogOpen, setEncounterCreationDialogOpen] = useState(false);
   const [editEncounterDialogOpen, setEditEncounterDialogOpen] = useState(false);
@@ -205,11 +205,7 @@ const EncountersTab = ({
   };
 
   const handleEncounterCreated = (newEncounter) => {
-    setSnackbar({
-      open: true,
-      message: 'Encounter created successfully',
-      severity: 'success'
-    });
+    enqueueSnackbar('Encounter created successfully', { variant: 'success' });
     
     // Refresh encounter data
     window.dispatchEvent(new CustomEvent('fhir-resources-updated', { 
@@ -247,10 +243,8 @@ const EncountersTab = ({
       formatForPrint: (data) => {
         let html = '<h2>Encounter History</h2>';
         data.forEach(encounter => {
-          const startDate = encounter.actualPeriod?.start || encounter.period?.start ? 
-            format(parseISO(encounter.actualPeriod?.start || encounter.period.start), 'MMM d, yyyy h:mm a') : 'Unknown';
-          const endDate = encounter.actualPeriod?.end || encounter.period?.end ? 
-            format(parseISO(encounter.actualPeriod?.end || encounter.period.end), 'MMM d, yyyy h:mm a') : 'Ongoing';
+          const startDate = formatClinicalDate(encounter.actualPeriod?.start || encounter.period?.start, 'withTime', 'Unknown');
+          const endDate = formatClinicalDate(encounter.actualPeriod?.end || encounter.period?.end, 'withTime', 'Ongoing');
           
           html += `
             <div class="section">
@@ -788,20 +782,6 @@ const EncountersTab = ({
 
 
       {/* Snackbar for notifications */}
-      <Snackbar
-        open={snackbar.open}
-        autoHideDuration={6000}
-        onClose={() => setSnackbar({ ...snackbar, open: false })}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
-      >
-        <Alert 
-          onClose={() => setSnackbar({ ...snackbar, open: false })} 
-          severity={snackbar.severity}
-          sx={{ width: '100%' }}
-        >
-          {snackbar.message}
-        </Alert>
-      </Snackbar>
     </>
   );
 };

--- a/frontend/src/components/clinical/workspace/tabs/EnhancedOrdersTab.js
+++ b/frontend/src/components/clinical/workspace/tabs/EnhancedOrdersTab.js
@@ -18,7 +18,6 @@ import {
   SpeedDial,
   SpeedDialIcon,
   SpeedDialAction,
-  Snackbar,
   FormControl,
   Select,
   MenuItem,
@@ -54,6 +53,7 @@ import {
   ViewAgenda as CompactIcon,
   ViewStream as StandardIcon
 } from '@mui/icons-material';
+import { useSnackbar } from 'notistack';
 
 // Enhanced components and hooks
 import { useAdvancedOrderSearch } from '../../../../hooks/useAdvancedOrderSearch';
@@ -510,7 +510,7 @@ const EnhancedOrdersTab = ({
   // UI State
   const [tabValue, setTabValue] = useState(0);
   const [selectedOrders, setSelectedOrders] = useState(new Set());
-  const [snackbar, setSnackbar] = useState({ open: false, message: '', severity: 'success' });
+  const { enqueueSnackbar } = useSnackbar();
   const [speedDialOpen, setSpeedDialOpen] = useState(false);
   // Phase 4.4 (#116): the universal new-order surface is the composer.
   // `composerInitialTab` carries which tab to land on when a caller has
@@ -786,38 +786,22 @@ const EnhancedOrdersTab = ({
     switch (eventType) {
       case CLINICAL_EVENTS.ORDER_PLACED:
       case CLINICAL_EVENTS.MEDICATION_PRESCRIBED:
-        setSnackbar({
-          open: true,
-          message: `New order placed: ${order.code?.text || order.medicationCodeableConcept?.text || 'Order'}`,
-          severity: 'info'
-        });
+        enqueueSnackbar(`New order placed: ${order.code?.text || order.medicationCodeableConcept?.text || 'Order'}`, { variant: 'info' });
         break;
         
       case CLINICAL_EVENTS.ORDER_CANCELLED:
-        setSnackbar({
-          open: true,
-          message: `Order cancelled: ${order.code?.text || order.medicationCodeableConcept?.text || 'Order'}`,
-          severity: 'warning'
-        });
+        enqueueSnackbar(`Order cancelled: ${order.code?.text || order.medicationCodeableConcept?.text || 'Order'}`, { variant: 'warning' });
         break;
         
       case CLINICAL_EVENTS.ORDER_COMPLETED:
-        setSnackbar({
-          open: true,
-          message: `Order completed: ${order.code?.text || order.medicationCodeableConcept?.text || 'Order'}`,
-          severity: 'success'
-        });
+        enqueueSnackbar(`Order completed: ${order.code?.text || order.medicationCodeableConcept?.text || 'Order'}`, { variant: 'success' });
         break;
         
       case CLINICAL_EVENTS.ORDER_SIGNED:
-        setSnackbar({
-          open: true,
-          message: `Order signed: ${order.code?.text || order.medicationCodeableConcept?.text || 'Order'}`,
-          severity: 'success'
-        });
+        enqueueSnackbar(`Order signed: ${order.code?.text || order.medicationCodeableConcept?.text || 'Order'}`, { variant: 'success' });
         break;
     }
-  }, [refreshSearch]);
+  }, [refreshSearch, enqueueSnackbar]);
 
   // Filter preset management
   const handleSaveFilterPreset = (name, filterData) => {
@@ -829,18 +813,10 @@ const EnhancedOrdersTab = ({
       };
       localStorage.setItem('orderFilterPresets', JSON.stringify(presets));
       
-      setSnackbar({
-        open: true,
-        message: `Filter preset "${name}" saved successfully`,
-        severity: 'success'
-      });
+      enqueueSnackbar(`Filter preset "${name}" saved successfully`, { variant: 'success' });
     } catch (error) {
       // Error saving filter preset - showing user notification
-      setSnackbar({
-        open: true,
-        message: 'Failed to save filter preset',
-        severity: 'error'
-      });
+      enqueueSnackbar('Failed to save filter preset', { variant: 'error' });
     }
   };
 
@@ -891,11 +867,7 @@ const EnhancedOrdersTab = ({
               });
               
               refreshSearch();
-              setSnackbar({
-                open: true,
-                message: 'Order cancelled successfully',
-                severity: 'success'
-              });
+              enqueueSnackbar('Order cancelled successfully', { variant: 'success' });
             } catch (cancelError) {
               console.error('Error cancelling order:', cancelError);
               throw cancelError;
@@ -918,21 +890,13 @@ const EnhancedOrdersTab = ({
       }
     } catch (error) {
       console.error(`Error handling order action ${action}:`, error);
-      setSnackbar({
-        open: true,
-        message: `Failed to ${action} order: ${error.message || 'Unknown error'}`,
-        severity: 'error'
-      });
+      enqueueSnackbar(`Failed to ${action} order: ${error.message || 'Unknown error'}`, { variant: 'error' });
     }
   };
 
   const handleSendToPharmacy = async (order) => {
     if (order.resourceType !== 'MedicationRequest') {
-      setSnackbar({
-        open: true,
-        message: 'Only medication orders can be sent to pharmacy',
-        severity: 'error'
-      });
+      enqueueSnackbar('Only medication orders can be sent to pharmacy', { variant: 'error' });
       return;
     }
 
@@ -957,17 +921,9 @@ const EnhancedOrdersTab = ({
         prescriberId: order.requester?.reference
       });
 
-      setSnackbar({
-        open: true,
-        message: `${getMedicationName(order)} sent to pharmacy queue`,
-        severity: 'success'
-      });
+      enqueueSnackbar(`${getMedicationName(order)} sent to pharmacy queue`, { variant: 'success' });
     } catch (error) {
-      setSnackbar({
-        open: true,
-        message: 'Failed to send to pharmacy: ' + error.message,
-        severity: 'error'
-      });
+      enqueueSnackbar('Failed to send to pharmacy: ' + error.message, { variant: 'error' });
     }
   };
 
@@ -1479,25 +1435,16 @@ const EnhancedOrdersTab = ({
           setCpoeMode('add');
 
           if (failed.length > 0 && persisted.length === 0) {
-            setSnackbar({
-              open: true,
-              message: `Failed to ${isEdit ? 'update' : 'create'} order: ${failed[0].error?.message || 'unknown error'}`,
-              severity: 'error',
-            });
+            enqueueSnackbar(`Failed to ${isEdit ? 'update' : 'create'} order: ${failed[0].error?.message || 'unknown error'}`, { variant: 'error' });
           } else if (failed.length > 0) {
-            setSnackbar({
-              open: true,
-              message: `${persisted.length} of ${orderList.length} order(s) saved; ${failed.length} failed`,
-              severity: 'warning',
-            });
+            enqueueSnackbar(`${persisted.length} of ${orderList.length} order(s) saved; ${failed.length} failed`, { variant: 'warning' });
           } else {
-            setSnackbar({
-              open: true,
-              message: isEdit
+            enqueueSnackbar(
+              isEdit
                 ? 'Order updated successfully'
                 : `${persisted.length} order(s) created successfully`,
-              severity: 'success'
-            });
+              { variant: 'success' }
+            );
           }
         }}
       />
@@ -1601,18 +1548,10 @@ const EnhancedOrdersTab = ({
             });
 
             if (failed.length === 0) {
-              setSnackbar({
-                open: true,
-                message: `${succeeded.length} order(s) signed successfully`,
-                severity: 'success',
-              });
+              enqueueSnackbar(`${succeeded.length} order(s) signed successfully`, { variant: 'success' });
               setSignOrdersDialog({ open: false, orders: [] });
             } else {
-              setSnackbar({
-                open: true,
-                message: `${succeeded.length} signed, ${failed.length} failed — retry the remaining`,
-                severity: 'warning',
-              });
+              enqueueSnackbar(`${succeeded.length} signed, ${failed.length} failed — retry the remaining`, { variant: 'warning' });
               // Keep the dialog open with only the failures
               setSignOrdersDialog({ open: true, orders: failed });
             }
@@ -1622,22 +1561,6 @@ const EnhancedOrdersTab = ({
         }}
         loading={signingInProgress}
       />
-
-      {/* Snackbar for notifications */}
-      <Snackbar
-        open={snackbar.open}
-        autoHideDuration={6000}
-        onClose={() => setSnackbar({ ...snackbar, open: false })}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
-      >
-        <Alert 
-          onClose={() => setSnackbar({ ...snackbar, open: false })} 
-          severity={snackbar.severity}
-          sx={{ width: '100%', borderRadius: 0 }}
-        >
-          {snackbar.message}
-        </Alert>
-      </Snackbar>
 
       {/* Order Details Dialog */}
       <Dialog

--- a/frontend/src/components/clinical/workspace/tabs/ImagingTab.js
+++ b/frontend/src/components/clinical/workspace/tabs/ImagingTab.js
@@ -25,13 +25,11 @@ import {
   Select,
   InputLabel,
   CircularProgress,
-  Alert,
   Badge,
   Dialog,
   DialogTitle,
   DialogContent,
   DialogActions,
-  Snackbar,
   ToggleButton,
   ToggleButtonGroup,
   useTheme,
@@ -69,6 +67,7 @@ import {
   AccessTime as RecentIcon,
   Collections as CollectionsIcon
 } from '@mui/icons-material';
+import { useSnackbar } from 'notistack';
 import { format, parseISO, formatDistanceToNow, isWithinInterval, subDays, subMonths } from 'date-fns';
 import { formatClinicalDate } from '../../../../core/fhir/utils/dateFormatUtils';
 import { useFHIRResource } from '../../../../contexts/FHIRResourceContext';
@@ -507,7 +506,7 @@ const ImagingTab = ({
   const [downloadDialog, setDownloadDialog] = useState({ open: false, study: null });
   const [shareDialog, setShareDialog] = useState({ open: false, study: null });
   const [studies, setStudies] = useState([]);
-  const [snackbar, setSnackbar] = useState({ open: false, message: '', severity: 'success' });
+  const { enqueueSnackbar } = useSnackbar();
 
   // Load imaging studies function with useCallback
   const loadImagingStudies = useCallback(async () => {
@@ -612,16 +611,12 @@ const ImagingTab = ({
       setStudies(enrichedStudies);
     } catch (error) {
       console.error('[ImagingTab] Failed to load imaging studies:', error);
-      setSnackbar({
-        open: true,
-        message: 'Failed to load imaging studies',
-        severity: 'error'
-      });
+      enqueueSnackbar('Failed to load imaging studies', { variant: 'error' });
       setStudies([]);
     } finally {
       setLoading(false);
     }
-  }, [patientId]);
+  }, [patientId, enqueueSnackbar]);
 
   // Load imaging studies when patient changes (removed separate useEffect to avoid circular dependency)
   useEffect(() => {
@@ -644,50 +639,30 @@ const ImagingTab = ({
     // Show notification based on event type
     switch (eventType) {
       case CLINICAL_EVENTS.IMAGING_STUDY_AVAILABLE:
-        setSnackbar({
-          open: true,
-          message: `New imaging study available: ${study.description || 'Imaging Study'}`,
-          severity: 'success'
-        });
+        enqueueSnackbar(`New imaging study available: ${study.description || 'Imaging Study'}`, { variant: 'success' });
         break;
         
       case CLINICAL_EVENTS.IMAGING_REPORT_READY:
-        setSnackbar({
-          open: true,
-          message: `Report ready for: ${study.description || 'Imaging Study'}`,
-          severity: 'info'
-        });
+        enqueueSnackbar(`Report ready for: ${study.description || 'Imaging Study'}`, { variant: 'info' });
         break;
         
       case CLINICAL_EVENTS.IMAGING_STUDY_UPDATED:
-        setSnackbar({
-          open: true,
-          message: `Imaging study updated: ${study.description || 'Imaging Study'}`,
-          severity: 'info'
-        });
+        enqueueSnackbar(`Imaging study updated: ${study.description || 'Imaging Study'}`, { variant: 'info' });
         break;
         
       case CLINICAL_EVENTS.ORDER_PLACED:
         if (eventData.type === 'imaging') {
-          setSnackbar({
-            open: true,
-            message: 'New imaging order placed',
-            severity: 'info'
-          });
+          enqueueSnackbar('New imaging order placed', { variant: 'info' });
         }
         break;
         
       case CLINICAL_EVENTS.RESULT_RECEIVED:
         if (eventData.type === 'imaging') {
-          setSnackbar({
-            open: true,
-            message: 'New imaging results available',
-            severity: 'success'
-          });
+          enqueueSnackbar('New imaging results available', { variant: 'success' });
         }
         break;
     }
-  }, [loadImagingStudies]);
+  }, [loadImagingStudies, enqueueSnackbar]);
 
   // Subscribe to imaging-related events
   useEffect(() => {
@@ -1002,11 +977,7 @@ const ImagingTab = ({
       console.log(study)
       if (!studyDir) {
         // Unable to determine study directory
-        setSnackbar({
-          open: true,
-          message: 'Unable to download study - missing directory information',
-          severity: 'error'
-        });
+        enqueueSnackbar('Unable to download study - missing directory information', { variant: 'error' });
         return;
       }
 
@@ -1026,11 +997,7 @@ const ImagingTab = ({
 
     } catch (error) {
       // Handle download error
-      setSnackbar({
-        open: true,
-        message: 'Failed to download study: ' + error.message,
-        severity: 'error'
-      });
+      enqueueSnackbar('Failed to download study: ' + error.message, { variant: 'error' });
     }
   };
 
@@ -1526,20 +1493,6 @@ const ImagingTab = ({
       />
 
       {/* Snackbar for notifications */}
-      <Snackbar
-        open={snackbar.open}
-        autoHideDuration={6000}
-        onClose={() => setSnackbar({ ...snackbar, open: false })}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
-      >
-        <Alert 
-          onClose={() => setSnackbar({ ...snackbar, open: false })} 
-          severity={snackbar.severity}
-          sx={{ width: '100%' }}
-        >
-          {snackbar.message}
-        </Alert>
-      </Snackbar>
     </Box>
   );
 };

--- a/frontend/src/components/clinical/workspace/tabs/PharmacyTab.js
+++ b/frontend/src/components/clinical/workspace/tabs/PharmacyTab.js
@@ -31,7 +31,6 @@ import {
   Select,
   InputLabel,
   CircularProgress,
-  Alert,
   Dialog,
   DialogTitle,
   DialogContent,
@@ -40,7 +39,6 @@ import {
   useTheme,
   Tabs,
   Tab,
-  Snackbar,
   ToggleButton,
   ToggleButtonGroup,
   Collapse,
@@ -76,6 +74,7 @@ import {
   ViewModule as ViewModuleIcon,
   ViewList as ViewListIcon
 } from '@mui/icons-material';
+import { useSnackbar } from 'notistack';
 import { format, parseISO, isWithinInterval, subDays, addDays, subMonths } from 'date-fns';
 import { useFHIRResource } from '../../../../contexts/FHIRResourceContext';
 import { printDocument } from '../../../../core/export/printUtils';
@@ -343,7 +342,7 @@ const PharmacyTab = ({
   const [dispenseDialogOpen, setDispenseDialogOpen] = useState(false);
   const [detailsDialogOpen, setDetailsDialogOpen] = useState(false);
   const [patientFilter, setPatientFilter] = useState('current'); // 'all' or 'current'
-  const [snackbar, setSnackbar] = useState({ open: false, message: '', severity: 'success' });
+  const { enqueueSnackbar } = useSnackbar();
   const [pendingRefills, setPendingRefills] = useState([]);
 
   // Load pending refill Tasks when component mounts or patient changes
@@ -643,20 +642,12 @@ const PharmacyTab = ({
         resourceType: 'MedicationRequest'
       });
       
-      setSnackbar({
-        open: true,
-        message: `Medication request status updated to ${newStatus}`,
-        severity: 'success'
-      });
+      enqueueSnackbar(`Medication request status updated to ${newStatus}`, { variant: 'success' });
     } catch (error) {
       console.error('PharmacyTab: status update failed:', error);
-      setSnackbar({
-        open: true,
-        message: `Failed to update status: ${error.response?.data?.detail || error.message}`,
-        severity: 'error'
-      });
+      enqueueSnackbar(`Failed to update status: ${error.response?.data?.detail || error.message}`, { variant: 'error' });
     }
-  }, [medicationRequests, refreshPatientResources, publish, patientId, user]);
+  }, [medicationRequests, refreshPatientResources, publish, patientId, user, enqueueSnackbar]);
 
   // Enhanced dispensing with MedicationDispense service
   const handleDispense = useCallback(async (medicationDispenseData) => {
@@ -710,11 +701,7 @@ const PharmacyTab = ({
         }
       });
       
-      setSnackbar({
-        open: true,
-        message: 'Medication dispensed successfully and recorded in FHIR',
-        severity: 'success'
-      });
+      enqueueSnackbar('Medication dispensed successfully and recorded in FHIR', { variant: 'success' });
       
       setSelectedRequest(null);
       setDispenseDialogOpen(false);
@@ -723,13 +710,9 @@ const PharmacyTab = ({
       // Surface the backend's reason — a 409 here means the signing gate
       // refused an unsigned order, which the pharmacist needs to see.
       const detail = error.response?.data?.detail;
-      setSnackbar({
-        open: true,
-        message: `Failed to dispense medication: ${detail || error.message}`,
-        severity: 'error'
-      });
+      enqueueSnackbar(`Failed to dispense medication: ${detail || error.message}`, { variant: 'error' });
     }
-  }, [patientId, medicationRequests, publish, refreshPatientResources, refreshDispenses, user]);
+  }, [patientId, medicationRequests, publish, refreshPatientResources, refreshDispenses, user, enqueueSnackbar]);
 
   // Handle medication administration
   const handleAdminister = useCallback(async (medicationRequest, mode = 'administer') => {
@@ -743,38 +726,22 @@ const PharmacyTab = ({
       await recordAdministration(administrationData);
       await refreshAdministrations();
       
-      setSnackbar({
-        open: true,
-        message: 'Medication administration recorded successfully',
-        severity: 'success'
-      });
+      enqueueSnackbar('Medication administration recorded successfully', { variant: 'success' });
     } catch (error) {
-      setSnackbar({
-        open: true,
-        message: `Failed to record administration: ${error.message}`,
-        severity: 'error'
-      });
+      enqueueSnackbar(`Failed to record administration: ${error.message}`, { variant: 'error' });
     }
-  }, [recordAdministration, refreshAdministrations]);
+  }, [recordAdministration, refreshAdministrations, enqueueSnackbar]);
 
   const handleRecordMissedDose = useCallback(async (missedDoseData) => {
     try {
       await recordAdministration(missedDoseData);
       await refreshAdministrations();
       
-      setSnackbar({
-        open: true,
-        message: 'Missed dose recorded successfully',
-        severity: 'info'
-      });
+      enqueueSnackbar('Missed dose recorded successfully', { variant: 'info' });
     } catch (error) {
-      setSnackbar({
-        open: true,
-        message: `Failed to record missed dose: ${error.message}`,
-        severity: 'error'
-      });
+      enqueueSnackbar(`Failed to record missed dose: ${error.message}`, { variant: 'error' });
     }
-  }, [recordAdministration, refreshAdministrations]);
+  }, [recordAdministration, refreshAdministrations, enqueueSnackbar]);
 
   // Handle refill request approval (backend completes the Task and creates
   // the refill MedicationRequest)
@@ -801,21 +768,13 @@ const PharmacyTab = ({
         }
       });
 
-      setSnackbar({
-        open: true,
-        message: 'Refill request approved successfully',
-        severity: 'success'
-      });
+      enqueueSnackbar('Refill request approved successfully', { variant: 'success' });
 
     } catch (error) {
       // Error approving refill request - handle silently
-      setSnackbar({
-        open: true,
-        message: 'Failed to approve refill request',
-        severity: 'error'
-      });
+      enqueueSnackbar('Failed to approve refill request', { variant: 'error' });
     }
-  }, [patientId, publish, user]);
+  }, [patientId, publish, user, enqueueSnackbar]);
 
   // Handle refill request rejection (backend sets the Task to 'rejected')
   const handleRejectRefill = useCallback(async (refillTaskId, rejectionData) => {
@@ -842,21 +801,13 @@ const PharmacyTab = ({
         }
       });
 
-      setSnackbar({
-        open: true,
-        message: 'Refill request rejected',
-        severity: 'info'
-      });
+      enqueueSnackbar('Refill request rejected', { variant: 'info' });
 
     } catch (error) {
       // Error rejecting refill request - handle silently
-      setSnackbar({
-        open: true,
-        message: 'Failed to reject refill request',
-        severity: 'error'
-      });
+      enqueueSnackbar('Failed to reject refill request', { variant: 'error' });
     }
-  }, [patientId, publish, user]);
+  }, [patientId, publish, user, enqueueSnackbar]);
 
   // Handle opening dispense dialog
   const handleOpenDispenseDialog = useCallback((medicationRequest) => {
@@ -1504,20 +1455,6 @@ const PharmacyTab = ({
       />
 
       {/* Snackbar for notifications */}
-      <Snackbar
-        open={snackbar.open}
-        autoHideDuration={6000}
-        onClose={() => setSnackbar({ ...snackbar, open: false })}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
-      >
-        <Alert 
-          onClose={() => setSnackbar({ ...snackbar, open: false })} 
-          severity={snackbar.severity}
-          sx={{ width: '100%' }}
-        >
-          {snackbar.message}
-        </Alert>
-      </Snackbar>
     </Box>
   );
 };

--- a/frontend/src/components/clinical/workspace/tabs/ResultsTabOptimized.js
+++ b/frontend/src/components/clinical/workspace/tabs/ResultsTabOptimized.js
@@ -684,6 +684,27 @@ const ResultsTabOptimized = ({
     setDetailsDialogOpen(true);
   };
 
+  // Print the currently filtered results via the shared print pipeline
+  const handlePrint = () => {
+    const tabTitles = ['Lab Results', 'Vital Signs', 'Diagnostic Reports'];
+
+    const patientInfo = {
+      name: currentPatient?.name?.[0] ?
+        `${currentPatient.name[0].given?.join(' ') || ''} ${currentPatient.name[0].family || ''}`.trim() :
+        'Unknown Patient',
+      mrn: currentPatient?.identifier?.find(id => id.type?.coding?.[0]?.code === 'MR')?.value || currentPatient?.id,
+      birthDate: currentPatient?.birthDate,
+      gender: currentPatient?.gender,
+      phone: currentPatient?.telecom?.find(t => t.system === 'phone')?.value
+    };
+
+    printDocument({
+      title: tabTitles[tabValue] || 'Results',
+      patient: patientInfo,
+      content: formatLabResultsForPrint(filteredData)
+    });
+  };
+
   // Render content based on view mode
   const renderContent = () => {
     if (allData.loading) {
@@ -995,7 +1016,7 @@ const ResultsTabOptimized = ({
             <Divider orientation="vertical" flexItem />
             <IconButton
               size="small"
-              onClick={() => window.print()}
+              onClick={handlePrint}
               title="Print"
             >
               <PrintIcon />
@@ -1106,7 +1127,7 @@ const ResultsTabOptimized = ({
                 {selectedResult.effectiveDateTime && (
                   <Grid item xs={6}>
                     <Typography variant="caption" color="text.secondary">Date</Typography>
-                    <Typography variant="body2">{new Date(selectedResult.effectiveDateTime).toLocaleString()}</Typography>
+                    <Typography variant="body2">{formatClinicalDate(selectedResult.effectiveDateTime, 'withTime')}</Typography>
                   </Grid>
                 )}
                 {selectedResult.valueQuantity && (

--- a/frontend/src/components/clinical/workspace/tabs/TimelineTabModern.js
+++ b/frontend/src/components/clinical/workspace/tabs/TimelineTabModern.js
@@ -32,7 +32,6 @@ import {
   Tooltip,
   useTheme,
   alpha,
-  Snackbar,
   Paper,
   useMediaQuery,
   FormGroup,
@@ -163,6 +162,7 @@ import {
   CalendarViewWeek as MonthViewIcon,
   CalendarViewDay as YearViewIcon
 } from '@mui/icons-material';
+import { useSnackbar } from 'notistack';
 
 // Import animation libraries
 import { motion, AnimatePresence, useScroll, useTransform, useSpring, useAnimation, useInView } from 'framer-motion';
@@ -847,7 +847,7 @@ const TimelineTabModern = ({ patientId, patient, onNavigateToTab }) => {
   const [selectedMilestone, setSelectedMilestone] = useState(null);
   const [selectedCategories, setSelectedCategories] = useState(new Set(['clinical', 'treatment', 'diagnostic', 'prevention', 'planning', 'documentation', 'administrative']));
   const [heatmapView, setHeatmapView] = useState('activity'); // 'activity', 'severity', 'category'
-  const [snackbar, setSnackbar] = useState({ open: false, message: '', severity: 'success' });
+  const { enqueueSnackbar } = useSnackbar();
   const [hasLoadedInitialData, setHasLoadedInitialData] = useState(false);
   const [loadingError, setLoadingError] = useState(null);
   const [reloadTrigger, setReloadTrigger] = useState(0);
@@ -935,11 +935,7 @@ const TimelineTabModern = ({ patientId, patient, onNavigateToTab }) => {
       } catch (error) {
         console.error('Timeline: Error loading data', error);
         setLoadingError(error.message || 'Failed to load timeline data');
-        setSnackbar({
-          open: true,
-          message: `Error loading timeline data: ${error.message || 'Unknown error'}`,
-          severity: 'error'
-        });
+        enqueueSnackbar(`Error loading timeline data: ${error.message || 'Unknown error'}`, { variant: 'error' });
       }
     };
     
@@ -1416,12 +1412,12 @@ const TimelineTabModern = ({ patientId, patient, onNavigateToTab }) => {
   
   const handleExport = () => {
     if (!processedEvents || processedEvents.length === 0) {
-      setSnackbar({ open: true, message: 'No timeline events to export', severity: 'info' });
+      enqueueSnackbar('No timeline events to export', { variant: 'info' });
       return;
     }
     try {
       const data = processedEvents.map(event => ({
-        Date: event._date ? new Date(event._date).toLocaleDateString() : '',
+        Date: formatClinicalDate(event._date),
         Type: event.resourceType || '',
         Category: event._type?.category || '',
         Title: event._title || '',
@@ -1440,26 +1436,26 @@ const TimelineTabModern = ({ patientId, patient, onNavigateToTab }) => {
       a.download = `patient-timeline-${patientId}-${new Date().toISOString().split('T')[0]}.csv`;
       a.click();
       URL.revokeObjectURL(url);
-      setSnackbar({ open: true, message: `Exported ${data.length} timeline events`, severity: 'success' });
+      enqueueSnackbar(`Exported ${data.length} timeline events`, { variant: 'success' });
     } catch (err) {
-      setSnackbar({ open: true, message: 'Failed to export timeline', severity: 'error' });
+      enqueueSnackbar('Failed to export timeline', { variant: 'error' });
     }
   };
 
   const handleShare = () => {
     if (!processedEvents || processedEvents.length === 0) {
-      setSnackbar({ open: true, message: 'No timeline events to copy', severity: 'info' });
+      enqueueSnackbar('No timeline events to copy', { variant: 'info' });
       return;
     }
     try {
       const text = processedEvents.map(event => {
-        const date = event._date ? new Date(event._date).toLocaleDateString() : 'Unknown date';
+        const date = formatClinicalDate(event._date, 'standard', 'Unknown date');
         return `${date} - [${event.resourceType}] ${event._title || 'Untitled'}`;
       }).join('\n');
       navigator.clipboard.writeText(text);
-      setSnackbar({ open: true, message: 'Timeline copied to clipboard', severity: 'success' });
+      enqueueSnackbar('Timeline copied to clipboard', { variant: 'success' });
     } catch (err) {
-      setSnackbar({ open: true, message: 'Failed to copy timeline', severity: 'error' });
+      enqueueSnackbar('Failed to copy timeline', { variant: 'error' });
     }
   };
   
@@ -2444,20 +2440,6 @@ const TimelineTabModern = ({ patientId, patient, onNavigateToTab }) => {
         </Dialog>
 
         {/* Snackbar */}
-        <Snackbar
-          open={snackbar.open}
-          autoHideDuration={6000}
-          onClose={() => setSnackbar({ ...snackbar, open: false })}
-          anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
-        >
-          <Alert 
-            onClose={() => setSnackbar({ ...snackbar, open: false })} 
-            severity={snackbar.severity}
-            sx={{ width: '100%' }}
-          >
-            {snackbar.message}
-          </Alert>
-        </Snackbar>
       </motion.div>
     </Box>
   );

--- a/frontend/src/components/fhir-explorer-v4/workspace/QueryWorkspace.jsx
+++ b/frontend/src/components/fhir-explorer-v4/workspace/QueryWorkspace.jsx
@@ -73,6 +73,7 @@ import {
   Share as ShareIcon,
   LocalOffer as TagIcon
 } from '@mui/icons-material';
+import { useSnackbar } from 'notistack';
 import { useQueryHistory } from '../hooks/useQueryHistory';
 
 // Query categories
@@ -86,6 +87,7 @@ const QUERY_CATEGORIES = [
 ];
 
 function QueryWorkspace({ onNavigate, onLoadQuery }) {
+  const { enqueueSnackbar } = useSnackbar();
   const {
     queryHistory,
     savedQueries,
@@ -256,15 +258,15 @@ function QueryWorkspace({ onNavigate, onLoadQuery }) {
         if (success) {
           setImportDialogOpen(false);
         } else {
-          alert('Failed to import queries. Please check the file format.');
+          enqueueSnackbar('Failed to import queries. Please check the file format.', { variant: 'error' });
         }
       } catch (error) {
         console.error('Import error:', error);
-        alert('Invalid file format. Please select a valid query export file.');
+        enqueueSnackbar('Invalid file format. Please select a valid query export file.', { variant: 'error' });
       }
     };
     reader.readAsText(file);
-  }, [importData]);
+  }, [importData, enqueueSnackbar]);
 
   // Render query item
   const renderQueryItem = (query, isHistory = false) => {

--- a/frontend/src/components/migration/MigrationDashboard.js
+++ b/frontend/src/components/migration/MigrationDashboard.js
@@ -63,6 +63,7 @@ import {
   Storage as DataIcon,
   Security as IntegrityIcon
 } from '@mui/icons-material';
+import { useSnackbar } from 'notistack';
 import { useMigrations, useMigrationProgress } from '../../hooks/useMigrations';
 import { useFHIRResource } from '../../contexts/FHIRResourceContext';
 
@@ -306,6 +307,7 @@ const MigrationDashboard = () => {
   } = useMigrations();
 
   const { searchResources } = useFHIRResource();
+  const { enqueueSnackbar } = useSnackbar();
 
   const [selectedResourceType, setSelectedResourceType] = useState('all');
   const [migrationOptions, setMigrationOptions] = useState({
@@ -362,14 +364,14 @@ const MigrationDashboard = () => {
       const resources = searchResult.resources || [];
 
       if (resources.length === 0) {
-        alert('No resources found to migrate');
+        enqueueSnackbar('No resources found to migrate', { variant: 'warning' });
         return;
       }
 
       await migrateResources(resources, migrationOptions);
     } catch (error) {
-      
-      alert(`Migration failed: ${error.message}`);
+
+      enqueueSnackbar(`Migration failed: ${error.message}`, { variant: 'error' });
     } finally {
       setLoading(false);
     }

--- a/frontend/src/hooks/patient/useChartReviewResources.js
+++ b/frontend/src/hooks/patient/useChartReviewResources.js
@@ -79,18 +79,11 @@ const useChartReviewResources = (patientId, options = {}) => {
 
   // Load all resources
   const loadResources = useCallback(async () => {
-    console.log('[useChartReviewResources] loadResources called with:', { 
-      patientId, 
-      loading: loadingRef.current,
-      loadedPatient: loadedPatientRef.current
-    });
     
     if (!patientId || loadingRef.current) {
-      console.log('[useChartReviewResources] Skipping load:', { patientId, loading: loadingRef.current });
       return;
     }
 
-    console.log('[useChartReviewResources] Starting resource load for patient:', patientId);
 
     try {
       loadingRef.current = true;
@@ -422,13 +415,6 @@ const useChartReviewResources = (patientId, options = {}) => {
   const processProcedures = (data, filters, sortOrder) => {
     let processed = data;
 
-    // Debug logging (disabled)
-    // console.log('[useChartReviewResources] Processing procedures:', {
-    //   inputCount: data.length,
-    //   filters,
-    //   sortOrder
-    // });
-
     // Filter by status - procedures use 'completed', 'in-progress', etc.
     if (filters.status !== 'all') {
       if (filters.status === 'active') {
@@ -469,10 +455,6 @@ const useChartReviewResources = (patientId, options = {}) => {
       return dateComparison !== 0 ? dateComparison : a.id.localeCompare(b.id);
     });
 
-    // console.log('[useChartReviewResources] Processed procedures:', {
-    //   outputCount: processed.length,
-    //   firstFewIds: processed.slice(0, 5).map(p => p.id)
-    // });
 
     return processed;
   };
@@ -516,13 +498,6 @@ const useChartReviewResources = (patientId, options = {}) => {
   const processCarePlans = (data, filters, sortOrder) => {
     let processed = data;
 
-    // Debug logging (disabled)
-    // console.log('[useChartReviewResources] Processing care plans:', {
-    //   inputCount: data.length,
-    //   filters,
-    //   sortOrder
-    // });
-
     // Filter by status - care plans use 'active', 'completed', 'draft', etc.
     if (filters.status !== 'all') {
       // CarePlan status values align well with 'active' filter
@@ -559,10 +534,6 @@ const useChartReviewResources = (patientId, options = {}) => {
       return dateComparison !== 0 ? dateComparison : a.id.localeCompare(b.id);
     });
 
-    // console.log('[useChartReviewResources] Processed care plans:', {
-    //   outputCount: processed.length,
-    //   firstFewIds: processed.slice(0, 5).map(cp => cp.id)
-    // });
 
     return processed;
   };
@@ -665,7 +636,6 @@ const useChartReviewResources = (patientId, options = {}) => {
 
   // Refresh data - reset and reload with debounce
   const refresh = useCallback(() => {
-    console.log('[useChartReviewResources] Refresh called');
     
     // Clear any pending refresh
     if (refreshTimerRef.current) {
@@ -674,7 +644,6 @@ const useChartReviewResources = (patientId, options = {}) => {
     
     // Debounce refresh to prevent rapid reloads
     refreshTimerRef.current = setTimeout(async () => {
-      console.log('[useChartReviewResources] Executing refresh after debounce');
       
       // Reset loading state in case it's stuck
       loadingRef.current = false;
@@ -682,7 +651,6 @@ const useChartReviewResources = (patientId, options = {}) => {
       // Clear the FHIRResourceContext cache for this patient
       if (patientId && contextRefs.current.refreshPatientResources) {
         try {
-          console.log('[useChartReviewResources] Clearing FHIR context cache for patient:', patientId);
           await contextRefs.current.refreshPatientResources(patientId);
         } catch (error) {
           console.error('[useChartReviewResources] Error clearing cache:', error);
@@ -757,7 +725,6 @@ const useChartReviewResources = (patientId, options = {}) => {
 
   // Handle incremental updates for specific resources
   const handleResourceUpdate = useCallback((eventType, eventData) => {
-    console.log('[useChartReviewResources] Handling resource update:', eventType, eventData);
     
     // Extract the resource from the event data
     const resource = eventData.condition || eventData.medication || eventData.allergy || 
@@ -913,7 +880,6 @@ const useChartReviewResources = (patientId, options = {}) => {
   useEffect(() => {
     if (!realTimeUpdates || !patientId) return;
 
-    console.log('[useChartReviewResources] Setting up real-time subscriptions for patient:', patientId);
 
     const subscriptions = [];
 
@@ -947,15 +913,8 @@ const useChartReviewResources = (patientId, options = {}) => {
         const unsubscribe = subscribe(
           eventType,
           (event) => {
-            console.log('[useChartReviewResources] Clinical event received:', {
-              eventType,
-              eventPatientId: event.patientId,
-              currentPatientId: patientId,
-              event
-            });
             // Handle update if the event is for the current patient
             if (event.patientId === patientId) {
-              console.log('[useChartReviewResources] Updating resource for event:', eventType);
               handleResourceUpdate(eventType, event);
             }
           }
@@ -965,7 +924,6 @@ const useChartReviewResources = (patientId, options = {}) => {
     });
 
     return () => {
-      console.log('[useChartReviewResources] Cleaning up subscriptions');
       subscriptions.forEach(unsub => unsub());
     };
   }, [patientId, realTimeUpdates, subscribe, handleResourceUpdate]);
@@ -974,7 +932,6 @@ const useChartReviewResources = (patientId, options = {}) => {
   useEffect(() => {
     if (!realTimeUpdates || !patientId || !websocketService.isConnected) return;
 
-    console.log('[useChartReviewResources] Setting up WebSocket patient room subscription for:', patientId);
 
     // Track subscription ID to clean up later
     let subscriptionId = null;
@@ -997,7 +954,6 @@ const useChartReviewResources = (patientId, options = {}) => {
 
         // Subscribe to patient room with specific resource types
         subscriptionId = await websocketService.subscribeToPatient(patientId, resourceTypes);
-        console.log('[useChartReviewResources] Successfully subscribed to patient room:', subscriptionId);
       } catch (error) {
         console.error('[useChartReviewResources] Failed to subscribe to patient room:', error);
       }
@@ -1009,17 +965,14 @@ const useChartReviewResources = (patientId, options = {}) => {
     // Clean up subscription on unmount or when patient changes
     return () => {
       if (subscriptionId) {
-        console.log('[useChartReviewResources] Unsubscribing from patient room:', subscriptionId);
         websocketService.unsubscribeFromPatient(subscriptionId);
       }
     };
   }, [patientId, realTimeUpdates]);
 
-  // Add debug logging for hook creation and cleanup refresh timer
+  // Clear the debounced-refresh timer on unmount
   useEffect(() => {
-    console.log('[useChartReviewResources] Hook initialized/re-created at:', new Date().toISOString());
     return () => {
-      console.log('[useChartReviewResources] Hook cleanup at:', new Date().toISOString());
       // Clear refresh timer on unmount
       if (refreshTimerRef.current) {
         clearTimeout(refreshTimerRef.current);
@@ -1032,13 +985,6 @@ const useChartReviewResources = (patientId, options = {}) => {
 
   // Load data when patient changes
   useEffect(() => {
-    console.log('[useChartReviewResources] Load effect triggered:', {
-      patientId,
-      loadedPatient: loadedPatientRef.current,
-      hasLoaded: hasLoadedRef.current,
-      loading: loadingRef.current,
-      timestamp: new Date().toISOString()
-    });
 
     if (!patientId) {
       hasLoadedRef.current = false;
@@ -1048,7 +994,6 @@ const useChartReviewResources = (patientId, options = {}) => {
 
     // Skip if already loaded for this specific patient
     if (loadingRef.current || loadedPatientRef.current === patientId) {
-      console.log('[useChartReviewResources] Skipping - already loaded for patient:', patientId);
       return;
     }
 
@@ -1056,7 +1001,6 @@ const useChartReviewResources = (patientId, options = {}) => {
     loadedPatientRef.current = patientId;
 
     // Load resources directly without timeout
-    console.log('[useChartReviewResources] Calling loadResources for patient:', patientId);
     loadResources();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [patientId]); // Only depend on patientId, loadResources is stable due to refs

--- a/frontend/src/modules/cds-studio/components/VersionHistory.jsx
+++ b/frontend/src/modules/cds-studio/components/VersionHistory.jsx
@@ -29,9 +29,11 @@ import {
   Update as VersionIcon,
   Restore as RestoreIcon
 } from '@mui/icons-material';
+import { useSnackbar } from 'notistack';
 import cdsStudioApi from '../services/cdsStudioApi';
 
 const VersionHistory = ({ serviceId }) => {
+  const { enqueueSnackbar } = useSnackbar();
   const [versions, setVersions] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
@@ -86,7 +88,7 @@ const VersionHistory = ({ serviceId }) => {
       await loadVersionHistory();
 
       // Notify user to refresh the page
-      alert('Service rolled back successfully. Please refresh the page to see changes.');
+      enqueueSnackbar('Service rolled back successfully. Please refresh the page to see changes.', { variant: 'success' });
     } catch (err) {
       console.error('Rollback failed:', err);
       setError(err.message);

--- a/frontend/src/modules/ui-composer/components/NaturalLanguageInput.js
+++ b/frontend/src/modules/ui-composer/components/NaturalLanguageInput.js
@@ -29,6 +29,7 @@ import {
   Lightbulb as LightbulbIcon,
   Clear as ClearIcon
 } from '@mui/icons-material';
+import { useSnackbar } from 'notistack';
 import { useUIComposer } from '../contexts/UIComposerContext';
 import useClaudeStatus from '../hooks/useClaudeStatus';
 
@@ -68,6 +69,7 @@ const EXAMPLE_REQUESTS = [
 ];
 
 const NaturalLanguageInput = () => {
+  const { enqueueSnackbar } = useSnackbar();
   const {
     currentRequest,
     setCurrentRequest,
@@ -153,9 +155,9 @@ const NaturalLanguageInput = () => {
       recognition.start();
     } else {
       // Fallback for browsers without speech recognition
-      alert('Speech recognition not supported in this browser');
+      enqueueSnackbar('Speech recognition not supported in this browser', { variant: 'warning' });
     }
-  }, []);
+  }, [enqueueSnackbar]);
   
   // Get recent history items
   const recentHistory = conversation

--- a/frontend/src/themes/clinicalTheme.js
+++ b/frontend/src/themes/clinicalTheme.js
@@ -83,19 +83,19 @@ export const clinicalTokens = {
       iconSize: 16,
       borderRadius: 4
     },
-    comfortable: { 
-      padding: 8, 
+    comfortable: {
+      padding: 8,
       rowHeight: 48,
       fontSize: '0.875rem',
       iconSize: 20,
-      borderRadius: 8
+      borderRadius: 4
     },
-    spacious: { 
-      padding: 16, 
+    spacious: {
+      padding: 16,
       rowHeight: 64,
       fontSize: '1rem',
       iconSize: 24,
-      borderRadius: 12
+      borderRadius: 4
     }
   },
   


### PR DESCRIPTION
## Refinement Phase 7 (R41, R45)

- **R41** — 17 `window.alert()` calls across 8 files and ~83 `setSnackbar` sites across 8 workspace tabs (plus the severity-less ClinicalWorkspaceEnhanced snackbar) all converge onto `enqueueSnackbar(msg, {variant})`. notistack is already mounted app-wide (#197). Message text and severity preserved exactly; dead `<Snackbar>` state/JSX/imports removed. Net −628/+192.
- **R45** — density radii 8/12→4 (sharp-corner rule); three raw `format()` date stragglers → `formatClinicalDate`; ResultsTab Print → `printDocument`; 19 `console.log` (+ 4 commented blocks) stripped from `useChartReviewResources` (error/warn with context kept).

### Verification
- Frontend: identical failing-suite set vs master baseline (84 failed / 500) — zero new failures
- eslint 0 errors on all 20 touched files; no `alert(`/`setSnackbar` remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)