### PR TITLE
chore(deploy,security): dcm4chee profile + named volumes, CI, SSRF guard, hardening (Task 10)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+# Minimal CI: both test suites run on every PR, gated against the known
+# baseline failure counts rather than zero — the suites carry documented
+# pre-existing failures (backend: CDS-hooks test-infra issues; frontend:
+# legacy suites), so "no NEW failures" is the honest, enforceable bar.
+# Ratchet the numbers DOWN as suites get fixed; never up without a PR that
+# explains why.
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: backend/requirements.txt
+      - run: pip install -r requirements.txt
+      - name: "pytest (gated on baseline: 44 failed / 29 errors)"
+        run: |
+          python -m pytest tests/ -q --tb=no > pytest.out 2>&1 || true
+          tail -3 pytest.out
+          FAILED=$(grep -oE '[0-9]+ failed' pytest.out | grep -oE '[0-9]+' | head -1)
+          ERRORS=$(grep -oE '[0-9]+ error' pytest.out | grep -oE '[0-9]+' | head -1)
+          PASSED=$(grep -oE '[0-9]+ passed' pytest.out | grep -oE '[0-9]+' | head -1)
+          FAILED=${FAILED:-0}; ERRORS=${ERRORS:-0}; PASSED=${PASSED:-0}
+          echo "passed=$PASSED failed=$FAILED errors=$ERRORS (baseline: 44/29, passed >= 360)"
+          if [ "$FAILED" -gt 44 ] || [ "$ERRORS" -gt 29 ] || [ "$PASSED" -lt 360 ]; then
+            echo "::error::Test results regressed past the baseline (failed<=44, errors<=29, passed>=360)"
+            exit 1
+          fi
+
+  frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci --legacy-peer-deps
+      - name: eslint (report-only)
+        # The repo's own `npm run lint` is `--max-warnings 0` and already
+        # fails on master's large pre-existing warning backlog, so this can't
+        # be a hard gate yet. Report the count; the test baseline below is the
+        # enforced bar. Ratchet toward a hard gate as the backlog shrinks.
+        run: npx eslint src -f compact 2>&1 | tail -1 || true
+      - name: "jest (gated on baseline: 84 failed)"
+        run: |
+          CI=true npx craco test --watchAll=false --json --outputFile=jest.json > jest.out 2>&1 || true
+          node -e "
+            const r = require('./jest.json');
+            console.log(r.numTotalTests + ' tests, ' + r.numFailedTests + ' failed (baseline: 84, total >= 500)');
+            if (r.numFailedTests > 84 || r.numTotalTests < 500) {
+              console.error('::error::Test results regressed past the baseline (failed<=84, total>=500)');
+              process.exit(1);
+            }"

--- a/.gitignore
+++ b/.gitignore
@@ -309,3 +309,6 @@ backend/api/cds_studio/IMPLEMENTATION_SUMMARY.md
 frontend/frontend-build.tar.gz
 .serena/project.yml
 test-cds-studio.mjs
+
+# Host-rendered configs (from deploy/nginx-prod.conf.template)
+deploy/rendered/

--- a/backend/api/auth/config.py
+++ b/backend/api/auth/config.py
@@ -7,7 +7,10 @@ from datetime import timedelta
 
 # JWT Configuration
 JWT_ENABLED = os.getenv("JWT_ENABLED", "false").lower() == "true"
-JWT_SECRET_KEY = os.getenv("JWT_SECRET_KEY", "training-secret-key-change-in-production")
+# Canonical name is JWT_SECRET_KEY; JWT_SECRET is accepted as a fallback
+# because compose files and .env templates historically used it (the two
+# names silently diverging meant the env var was ignored entirely).
+JWT_SECRET_KEY = os.getenv("JWT_SECRET_KEY") or os.getenv("JWT_SECRET") or "training-secret-key-change-in-production"
 JWT_ALGORITHM = "HS256"
 JWT_ACCESS_TOKEN_EXPIRE_MINUTES = int(os.getenv("JWT_ACCESS_TOKEN_EXPIRE_MINUTES", "1440"))  # 24 hours default
 JWT_ACCESS_TOKEN_EXPIRE_DELTA = timedelta(minutes=JWT_ACCESS_TOKEN_EXPIRE_MINUTES)

--- a/backend/api/external_services/service.py
+++ b/backend/api/external_services/service.py
@@ -27,6 +27,7 @@ from shared.exceptions import (
 )
 from api.cds_hooks.constants import ExtensionURLs
 
+from .url_policy import validate_external_url
 from .models import (
     ExternalServiceCreate,
     ExternalServiceUpdate,
@@ -94,6 +95,15 @@ class ExternalServiceRegistry:
             Tuple of (service_id, fhir_resource_id)
         """
         try:
+            # SSRF guard: registered URLs are fetched server-side later
+            validate_external_url(getattr(service_data, "base_url", None))
+            sub = getattr(service_data, "subscription_config", None)
+            if sub is not None:
+                validate_external_url(getattr(sub, "webhook_url", None))
+            cql = getattr(service_data, "cql_config", None)
+            if cql is not None:
+                validate_external_url(getattr(cql, "library_url", None))
+
             # Encrypt credentials if provided
             credentials_encrypted = None
             if service_data.credentials:

--- a/backend/api/external_services/url_policy.py
+++ b/backend/api/external_services/url_policy.py
@@ -1,0 +1,56 @@
+"""URL policy for externally-registered service endpoints.
+
+Registered base URLs (CDS Hooks services, webhooks, CQL libraries) are later
+fetched **server-side** by the backend — an unvalidated registration is a
+server-side request forgery vector (register http://169.254.169.254/ or an
+internal service and let the CDS engine call it).
+
+Policy: the EXTERNAL_SERVICES_URL_ALLOWLIST env var holds a comma-separated
+list of allowed host suffixes (e.g. "cds.example.com,.trusted.org").
+
+- When set (non-empty): a registered URL's host must match one of the
+  suffixes exactly or as a dot-suffix, or registration is rejected.
+- When unset: any URL is accepted — the educational default, since demo
+  boxes register ad-hoc services (e.g. a locally-hosted CDS service) — but
+  a warning is logged so operators of exposed hosts know to set it.
+"""
+
+import logging
+import os
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+_warned_once = False
+
+
+def _allowlist():
+    raw = os.getenv("EXTERNAL_SERVICES_URL_ALLOWLIST", "")
+    return [h.strip().lower() for h in raw.split(",") if h.strip()]
+
+
+def validate_external_url(url) -> None:
+    """Raise ValueError if `url` violates the configured allow-list."""
+    global _warned_once
+    if url is None:
+        return
+
+    allowlist = _allowlist()
+    if not allowlist:
+        if not _warned_once:
+            logger.warning(
+                "EXTERNAL_SERVICES_URL_ALLOWLIST is not set — external service "
+                "registration accepts any URL. Set it on internet-exposed hosts."
+            )
+            _warned_once = True
+        return
+
+    host = (urlparse(str(url)).hostname or "").lower()
+    for allowed in allowlist:
+        suffix = allowed.lstrip(".")
+        if host == suffix or host.endswith("." + suffix):
+            return
+
+    raise ValueError(
+        f"URL host '{host}' is not in EXTERNAL_SERVICES_URL_ALLOWLIST"
+    )

--- a/backend/scripts/synthea_to_hapi_pipeline.py
+++ b/backend/scripts/synthea_to_hapi_pipeline.py
@@ -158,7 +158,7 @@ def load_bundles_to_hapi(output_dir: Path):
 
     if not json_files:
         print("✗ No FHIR bundles found!")
-        return
+        return (0, 0)
 
     print(f"Found {len(json_files)} bundle files\n")
 
@@ -210,6 +210,8 @@ def load_bundles_to_hapi(output_dir: Path):
     print(f"Successful: {success_count}")
     print(f"Failed: {total_count - success_count}")
     print()
+
+    return (success_count, total_count)
 
 
 def verify_data():
@@ -281,7 +283,17 @@ def main():
         output_dir = run_synthea(num_patients, state)
 
         # Step 2: Load to HAPI FHIR
-        load_bundles_to_hapi(output_dir)
+        success_count, total_count = load_bundles_to_hapi(output_dir)
+
+        # The deploy script keys off this exit code — a load where nothing
+        # (or almost nothing) made it into HAPI must not report success.
+        if total_count == 0 or success_count == 0:
+            print("✗ Pipeline failed: no bundles were loaded")
+            sys.exit(1)
+        failed = total_count - success_count
+        if failed / total_count > 0.2:
+            print(f"✗ Pipeline failed: {failed}/{total_count} bundles failed to load")
+            sys.exit(1)
 
         # Step 3: Verify
         verify_data()

--- a/backend/tests/api/external_services/test_url_policy.py
+++ b/backend/tests/api/external_services/test_url_policy.py
@@ -1,0 +1,39 @@
+"""Tests for the external-service URL allow-list (SSRF guard)."""
+
+import pytest
+
+from api.external_services.url_policy import validate_external_url
+
+
+@pytest.fixture(autouse=True)
+def _clear_allowlist(monkeypatch):
+    monkeypatch.delenv("EXTERNAL_SERVICES_URL_ALLOWLIST", raising=False)
+
+
+def test_unset_allowlist_accepts_anything():
+    validate_external_url("http://169.254.169.254/latest/meta-data")
+    validate_external_url("https://anything.example")
+    validate_external_url(None)
+
+
+def test_allowlist_accepts_exact_and_subdomain(monkeypatch):
+    monkeypatch.setenv("EXTERNAL_SERVICES_URL_ALLOWLIST", "cds.example.com,.trusted.org")
+    validate_external_url("https://cds.example.com/cds-services")
+    validate_external_url("https://svc.trusted.org/hooks")
+    validate_external_url("https://trusted.org/hooks")
+
+
+def test_allowlist_rejects_other_hosts(monkeypatch):
+    monkeypatch.setenv("EXTERNAL_SERVICES_URL_ALLOWLIST", "cds.example.com")
+    with pytest.raises(ValueError):
+        validate_external_url("http://169.254.169.254/")
+    with pytest.raises(ValueError):
+        validate_external_url("https://evilcds.example.com.attacker.net/")
+    # suffix must match on a dot boundary, not substring
+    with pytest.raises(ValueError):
+        validate_external_url("https://notcds.example.com.evil.io/")
+
+
+def test_allowlist_none_url_passes(monkeypatch):
+    monkeypatch.setenv("EXTERNAL_SERVICES_URL_ALLOWLIST", "cds.example.com")
+    validate_external_url(None)

--- a/deploy.sh
+++ b/deploy.sh
@@ -38,10 +38,17 @@ fi
 
 # Default profile (now respects config.yaml)
 PROFILE="${ENVIRONMENT:-dev}"
+SKIP_DICOM=false
 
-# Docker compose command with profile
+# Docker compose command with profile. The DICOM (dcm4chee VNA) stack lives
+# behind its own 'dicom' profile — included by default, omitted with
+# --skip-dicom for hosts that don't need imaging.
 docker_compose() {
-    docker compose --profile "$PROFILE" "$@"
+    if [ "$SKIP_DICOM" = "true" ]; then
+        docker compose --profile "$PROFILE" "$@"
+    else
+        docker compose --profile "$PROFILE" --profile dicom "$@"
+    fi
 }
 
 # Handle special commands first
@@ -49,13 +56,13 @@ case "$1" in
     stop)
         echo -e "${YELLOW}Stopping WintEHR services...${NC}"
         # Stop all profiles
-        docker compose --profile dev --profile prod down 2>/dev/null || docker compose down
+        docker compose --profile dev --profile prod --profile dicom down 2>/dev/null || docker compose down
         echo -e "${GREEN}✓ Services stopped${NC}"
         exit 0
         ;;
     clean)
         echo -e "${YELLOW}Cleaning WintEHR deployment (removing all data)...${NC}"
-        docker compose --profile dev --profile prod down -v 2>/dev/null || docker compose down -v
+        docker compose --profile dev --profile prod --profile dicom down -v 2>/dev/null || docker compose down -v
         docker system prune -f
         echo -e "${GREEN}✓ Clean complete${NC}"
         exit 0
@@ -121,6 +128,10 @@ while [[ $# -gt 0 ]]; do
             CLEAN_FIRST=true
             shift
             ;;
+        --skip-dicom)
+            SKIP_DICOM=true
+            shift
+            ;;
         --base-url)
             BASE_URL="$2"
             shift 2
@@ -149,6 +160,7 @@ Options:
   --validate-only          Validate configuration without deploying
   --skip-build             Skip Docker image builds
   --skip-data              Skip patient data generation
+  --skip-dicom             Omit the DICOM/dcm4chee (VNA) imaging stack
   --clean-first            Wipe server completely before deployment
   --base-url URL           Base URL for DICOM endpoints (e.g., https://server.com)
   --help, -h               Show this help message
@@ -217,7 +229,7 @@ if [ "$CLEAN_FIRST" = true ]; then
         echo ""
     else
         echo -e "${YELLOW}⚠️  No cleanup script found, using docker compose clean${NC}"
-        docker compose --profile dev --profile prod down -v
+        docker compose --profile dev --profile prod --profile dicom down -v
         docker system prune -f
         echo -e "${GREEN}✅ Server wiped - ready for fresh deployment${NC}"
         echo ""
@@ -321,14 +333,10 @@ if [ "$PROFILE" = "prod" ]; then
             .env
         rm -f .env.bak
 
-        # Update nginx-prod.conf SSL certificate paths
-        if [ -f "nginx-prod.conf" ]; then
-            sed -i.bak \
-                -e "s|/etc/letsencrypt/live/[^/]*/fullchain.pem|/etc/letsencrypt/live/$CURRENT_DOMAIN/fullchain.pem|g" \
-                -e "s|/etc/letsencrypt/live/[^/]*/privkey.pem|/etc/letsencrypt/live/$CURRENT_DOMAIN/privkey.pem|g" \
-                nginx-prod.conf
-            rm -f nginx-prod.conf.bak
-        fi
+        # Render nginx config from the tracked template (the old in-place
+        # sed left every server's checkout permanently dirty)
+        mkdir -p deploy/rendered
+        sed "s|\${DOMAIN}|$CURRENT_DOMAIN|g" deploy/nginx-prod.conf.template > deploy/rendered/nginx.conf
 
         # Reload .env with updated values
         set -a

--- a/deploy/nginx-prod.conf.template
+++ b/deploy/nginx-prod.conf.template
@@ -89,8 +89,8 @@ http {
         server_name _;
 
         # SSL configuration
-        ssl_certificate /etc/letsencrypt/live/wintehr.eastus2.cloudapp.azure.com/fullchain.pem;
-        ssl_certificate_key /etc/letsencrypt/live/wintehr.eastus2.cloudapp.azure.com/privkey.pem;
+        ssl_certificate /etc/letsencrypt/live/${DOMAIN}/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/${DOMAIN}/privkey.pem;
 
         # SSL parameters
         ssl_protocols TLSv1.2 TLSv1.3;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -179,6 +179,10 @@ services:
   ldap:
     image: dcm4che/slapd-dcm4chee:2.6.10-34.2
     container_name: vna-ldap
+    # DICOM stack is optional: deploy.sh includes --profile dicom by default,
+    # pass --skip-dicom to omit the whole VNA (dcm4chee) stack.
+    profiles: ["dicom"]
+    restart: ${RESTART_POLICY:-no}
     networks:
       vna:
         aliases:
@@ -191,15 +195,21 @@ services:
       options:
         max-size: "10m"
     ports:
-      - "389:389"
+      - "127.0.0.1:389:389"
     environment:
       STORAGE_DIR: /storage/fs1
     volumes:
-      - /var/local/dcm4chee-arc/ldap:/var/lib/openldap/openldap-data
-      - /var/local/dcm4chee-arc/slapd.d:/etc/openldap/slapd.d
+      # Named volumes (portable — the old /var/local/dcm4chee-arc/* host
+      # binds broke macOS deploys and left root-owned dirs on Linux hosts).
+      # Existing deployments keeping bind-mount data can override these in
+      # an untracked docker-compose.override.yml.
+      - vna-ldap-data:/var/lib/openldap/openldap-data
+      - vna-ldap-config:/etc/openldap/slapd.d
   db:
     image: dcm4che/postgres-dcm4chee:17.4-34
     container_name: vna-db
+    profiles: ["dicom"]
+    restart: ${RESTART_POLICY:-no}
     networks:
       vna:
         aliases:
@@ -212,7 +222,7 @@ services:
       options:
         max-size: "10m"
     ports:
-     - "5433:5432"
+     - "127.0.0.1:5433:5432"
     environment:
       POSTGRES_DB: pacsdb
       POSTGRES_USER: pacs
@@ -220,10 +230,12 @@ services:
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - /etc/timezone:/etc/timezone:ro
-      - /var/local/dcm4chee-arc/db:/var/lib/postgresql/data
+      - vna-db-data:/var/lib/postgresql/data
   arc:
     image: dcm4che/dcm4chee-arc-psql:5.34.2
     container_name: vna-arc
+    profiles: ["dicom"]
+    restart: ${RESTART_POLICY:-no}
     networks:
       vna:
         aliases:
@@ -236,14 +248,17 @@ services:
       options:
         max-size: "10m"
     ports:
-      - "8080:8080"
-      - "8443:8443"
-      - "9990:9990"
-      - "9993:9993"
-      - "11112:11112"
-      - "2762:2762"
-      - "2575:2575"
-      - "12575:12575"
+      # Loopback-only: the app reaches dcm4chee over the compose network
+      # (http://arc:8080); host ports exist for local debugging and must not
+      # expose the WildFly admin console / DIMSE ports publicly.
+      - "127.0.0.1:8080:8080"
+      - "127.0.0.1:8443:8443"
+      - "127.0.0.1:9990:9990"
+      - "127.0.0.1:9993:9993"
+      - "127.0.0.1:11112:11112"
+      - "127.0.0.1:2762:2762"
+      - "127.0.0.1:2575:2575"
+      - "127.0.0.1:12575:12575"
     environment:
       POSTGRES_DB: pacsdb
       POSTGRES_USER: pacs
@@ -256,8 +271,8 @@ services:
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - /etc/timezone:/etc/timezone:ro
-      - /var/local/dcm4chee-arc/wildfly:/opt/wildfly/standalone
-      - /var/local/dcm4chee-arc/storage:/storage
+      - vna-arc-wildfly:/opt/wildfly/standalone
+      - vna-arc-storage:/storage
 
   # ============================================================
   # HAPI FHIR SERVER
@@ -312,7 +327,7 @@ services:
       - DATABASE_URL=postgresql+asyncpg://${POSTGRES_USER:-emr_user}:${POSTGRES_PASSWORD:-emr_password}@postgres:5432/${POSTGRES_DB:-emr_db}
       - JWT_ENABLED=${JWT_ENABLED:-false}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
-      - JWT_SECRET=${JWT_SECRET:-dev-secret-key}
+      - JWT_SECRET_KEY=${JWT_SECRET_KEY:-${JWT_SECRET:-dev-secret-key}}
       - REDIS_URL=redis://redis:6379/0
       - USE_REDIS_CACHE=true
       - HAPI_FHIR_URL=http://hapi-fhir:8080/fhir
@@ -340,7 +355,7 @@ services:
       dockerfile: Dockerfile
     container_name: emr-backend
     profiles: ["prod"]
-    restart: unless-stopped
+    restart: ${RESTART_POLICY:-unless-stopped}
     volumes:
       - ./data:/app/data
       - ./logs:/app/logs
@@ -353,7 +368,7 @@ services:
       - POSTGRES_DB=${POSTGRES_DB:-emr_db}
       - JWT_ENABLED=${JWT_ENABLED:-false}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
-      - JWT_SECRET=${JWT_SECRET:-change-this-in-production}
+      - JWT_SECRET_KEY=${JWT_SECRET_KEY:-${JWT_SECRET:-change-this-in-production}}
       - REDIS_URL=redis://redis:6379/0
       - USE_REDIS_CACHE=true
       - HAPI_FHIR_URL=http://hapi-fhir:8080/fhir
@@ -414,7 +429,7 @@ services:
         - REACT_APP_WS_URL=${REACT_APP_WS_URL:-wss://${DOMAIN:-localhost}/ws}
     container_name: emr-frontend
     profiles: ["prod"]
-    restart: unless-stopped
+    restart: ${RESTART_POLICY:-unless-stopped}
     networks:
       - emr-network
     depends_on:
@@ -429,12 +444,16 @@ services:
     image: nginx:1.25-alpine
     container_name: emr-nginx
     profiles: ["prod"]
-    restart: unless-stopped
+    restart: ${RESTART_POLICY:-unless-stopped}
     ports:
       - "${HTTP_PORT:-80}:80"
       - "${HTTPS_PORT:-443}:443"
     volumes:
-      - ./nginx-prod.conf:/etc/nginx/nginx.conf:ro
+      # Rendered by deploy.sh from deploy/nginx-prod.conf.template — the
+      # template is tracked, the rendered copy is not, so per-host domains
+      # no longer dirty the checkout (raw `docker compose` users: render once
+      # with: sed "s|\${DOMAIN}|your.domain|g" deploy/nginx-prod.conf.template > deploy/rendered/nginx.conf)
+      - ./deploy/rendered/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./certbot/conf:/etc/letsencrypt:ro
       - ./certbot/www:/var/www/certbot:ro
     networks:
@@ -450,7 +469,7 @@ services:
     image: certbot/certbot
     container_name: emr-certbot
     profiles: ["prod"]
-    restart: unless-stopped
+    restart: ${RESTART_POLICY:-unless-stopped}
     volumes:
       - ./certbot/conf:/etc/letsencrypt
       - ./certbot/www:/var/www/certbot
@@ -468,3 +487,8 @@ networks:
 
 volumes:
   postgres_data:
+  vna-ldap-data:
+  vna-ldap-config:
+  vna-db-data:
+  vna-arc-wildfly:
+  vna-arc-storage:

--- a/frontend/Dockerfile.production
+++ b/frontend/Dockerfile.production
@@ -109,7 +109,7 @@ RUN adduser -D -H -s /sbin/nologin nginx-user && \
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=40s --retries=3 \
-    CMD curl -f http://localhost/health || exit 1
+    CMD curl -f http://127.0.0.1/health || exit 1  # 127.0.0.1: 'localhost' resolves to ::1 but internal nginx binds IPv4 only
 
 # Switch to non-root user
 USER nginx-user


### PR DESCRIPTION
## Deploy/security track — long-deferred hardening, one PR

### Deploy
- **dcm4chee VNA stack behind a `dicom` compose profile** (on by default; `--skip-dicom` omits it) with **named volumes** replacing the `/var/local/dcm4chee-arc/*` host binds — this is what broke `./deploy.sh` on macOS and left root-owned dirs on Linux. Host ports bound to `127.0.0.1` (the WildFly admin console + DIMSE ports were world-exposed).
- **nginx-prod.conf → `deploy/nginx-prod.conf.template`** (`${DOMAIN}`); deploy.sh renders to `deploy/rendered/nginx.conf` (gitignored) instead of `sed`-editing the tracked file — which left every server's checkout permanently dirty and had hardcoded the wrong domain.
- **RESTART_POLICY** applied to the VNA + previously-hardcoded `unless-stopped` services.
- **Synthea pipeline exits non-zero** when nothing loads or >20% of bundles fail — deploy.sh keyed off an exit code the script never set.

### Security
- **JWT_SECRET_KEY** is canonical; backend + compose accept the historical `JWT_SECRET` as a fallback (the names had silently diverged, so the configured secret was ignored).
- **SSRF guard** on external-service registration: base/webhook/library URLs (fetched server-side by the CDS engine) validated against `EXTERNAL_SERVICES_URL_ALLOWLIST`; unset = accept-all + warn (educational default). New `url_policy` module + 4 tests.
- **frontend prod healthcheck** probes `127.0.0.1` not `localhost` (resolved to `::1`; internal nginx is IPv4-only → container perpetually 'unhealthy').

### CI
Minimal GitHub Actions workflow: both suites on every PR, gated at the known baselines (backend 44F/29E, frontend 84F) so 'no NEW failures' is enforceable; eslint report-only until the warning backlog shrinks.

### Verification
- Backend: 371 passed (367 + 4 new SSRF tests), failure set identical to baseline
- docker-compose.yml + ci.yml parse; deploy.sh `bash -n` clean
- **Runtime**: needs a wintehrdev redeploy with the new profile/volumes — the box currently runs bind-mount VNA data, so this one needs care (migrate or keep an override). Recommend merging last and redeploying deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)