### PR TITLE
fix(security): path traversal in UI-composer sessions, uuid patch, sha256 cache key

### DIFF
--- a/backend/api/ui_composer/claude_integration_service.py
+++ b/backend/api/ui_composer/claude_integration_service.py
@@ -101,7 +101,9 @@ class ClaudeIntegrationService:
     def _get_cache_key(self, prompt: str, options: Dict[str, Any]) -> str:
         """Generate cache key for prompt and options"""
         key_data = json.dumps({'prompt': prompt, 'options': options}, sort_keys=True)
-        return hashlib.md5(key_data.encode()).hexdigest()
+        # sha256, not md5: this is only a cache key, but MD5 trips security
+        # scanners and there is no reason to prefer a broken digest here.
+        return hashlib.sha256(key_data.encode()).hexdigest()
         
     def _get_from_cache(self, key: str) -> Optional[str]:
         """Get value from cache if not expired"""

--- a/backend/api/ui_composer/session_manager.py
+++ b/backend/api/ui_composer/session_manager.py
@@ -4,6 +4,7 @@ Manages conversation sessions and state
 """
 
 import json
+import os
 import re
 import uuid
 from datetime import datetime
@@ -47,8 +48,13 @@ class SessionManager:
             logger.warning(f"Rejected unsafe session id: {session_id!r}")
             return None
 
+        # basename() is a no-op given the charset check above, but it is the
+        # canonical strip-any-directory-component idiom and static analysers
+        # recognise it as a path-injection barrier.
+        safe_name = os.path.basename(f"{session_id}.json")
+
         sessions_dir = self.sessions_dir.resolve()
-        candidate = (sessions_dir / f"{session_id}.json").resolve()
+        candidate = (sessions_dir / safe_name).resolve()
         try:
             candidate.relative_to(sessions_dir)
         except ValueError:

--- a/backend/api/ui_composer/session_manager.py
+++ b/backend/api/ui_composer/session_manager.py
@@ -37,11 +37,24 @@ class SessionManager:
         self._sessions: Dict[str, SessionInfo] = {}
 
     def _session_file(self, session_id: str) -> Optional[Path]:
-        """Resolve a session id to its file, or None if the id is unsafe."""
+        """Resolve a session id to its file, or None if the id is unsafe.
+
+        Two independent barriers: the id must match the safe charset, and the
+        resolved path must still sit inside sessions_dir (this second check
+        also defeats symlink tricks a charset check can't see).
+        """
         if not _is_safe_session_id(session_id):
             logger.warning(f"Rejected unsafe session id: {session_id!r}")
             return None
-        return self.sessions_dir / f"{session_id}.json"
+
+        sessions_dir = self.sessions_dir.resolve()
+        candidate = (sessions_dir / f"{session_id}.json").resolve()
+        try:
+            candidate.relative_to(sessions_dir)
+        except ValueError:
+            logger.warning(f"Rejected session id escaping sessions dir: {session_id!r}")
+            return None
+        return candidate
 
     async def get_session(self, session_id: str) -> Optional[SessionInfo]:
         """Get session by ID"""

--- a/backend/api/ui_composer/session_manager.py
+++ b/backend/api/ui_composer/session_manager.py
@@ -4,6 +4,7 @@ Manages conversation sessions and state
 """
 
 import json
+import re
 import uuid
 from datetime import datetime
 from pathlib import Path
@@ -14,24 +15,43 @@ from .models import SessionInfo, UISpecification
 
 logger = logging.getLogger(__name__)
 
+# Session ids are generated as UUID4s; accept only that shape when one is
+# supplied by a caller. Session ids arrive from request bodies and are used to
+# build filesystem paths, so an unvalidated id like "../../etc/passwd" would
+# escape the sessions directory (arbitrary file read in get_session, arbitrary
+# file DELETE in delete_session).
+_SAFE_SESSION_ID = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+
+
+def _is_safe_session_id(session_id: str) -> bool:
+    return bool(session_id) and bool(_SAFE_SESSION_ID.match(session_id))
+
+
 class SessionManager:
     def __init__(self, base_dir: str = ".claude/sessions/ui-composer"):
         self.base_dir = Path(base_dir)
         self.sessions_dir = self.base_dir / "sessions"
         self.sessions_dir.mkdir(parents=True, exist_ok=True)
-        
+
         # In-memory cache
         self._sessions: Dict[str, SessionInfo] = {}
-    
+
+    def _session_file(self, session_id: str) -> Optional[Path]:
+        """Resolve a session id to its file, or None if the id is unsafe."""
+        if not _is_safe_session_id(session_id):
+            logger.warning(f"Rejected unsafe session id: {session_id!r}")
+            return None
+        return self.sessions_dir / f"{session_id}.json"
+
     async def get_session(self, session_id: str) -> Optional[SessionInfo]:
         """Get session by ID"""
         # Check cache first
         if session_id in self._sessions:
             return self._sessions[session_id]
-        
+
         # Try to load from file
-        session_file = self.sessions_dir / f"{session_id}.json"
-        if session_file.exists():
+        session_file = self._session_file(session_id)
+        if session_file and session_file.exists():
             try:
                 data = json.loads(session_file.read_text())
                 session = SessionInfo(
@@ -92,7 +112,9 @@ class SessionManager:
         }
         
         # Save to file
-        session_file = self.sessions_dir / f"{session.session_id}.json"
+        session_file = self._session_file(session.session_id)
+        if not session_file:
+            return
         try:
             session_file.write_text(json.dumps(session_data, indent=2))
             logger.debug(f"Saved session {session.session_id}")
@@ -106,8 +128,8 @@ class SessionManager:
             del self._sessions[session_id]
         
         # Delete file
-        session_file = self.sessions_dir / f"{session_id}.json"
-        if session_file.exists():
+        session_file = self._session_file(session_id)
+        if session_file and session_file.exists():
             try:
                 session_file.unlink()
                 return True

--- a/backend/tests/api/ui_composer/test_session_path_safety.py
+++ b/backend/tests/api/ui_composer/test_session_path_safety.py
@@ -1,0 +1,75 @@
+"""Session ids must not be able to escape the sessions directory.
+
+Session ids arrive from request bodies and were interpolated straight into a
+filesystem path, so a crafted id could read (get_session) or DELETE
+(delete_session) files outside the sessions directory.
+"""
+
+import pytest
+
+from api.ui_composer.session_manager import SessionManager, _is_safe_session_id
+
+
+TRAVERSAL_IDS = [
+    "../../etc/passwd",
+    "../secrets",
+    "a/../../b",
+    "foo/bar",
+    "/absolute/path",
+    "..",
+    "",
+    "with space",
+    "semi;colon",
+    "null\x00byte",
+]
+
+
+@pytest.mark.parametrize("bad_id", TRAVERSAL_IDS)
+def test_unsafe_ids_rejected(bad_id):
+    assert not _is_safe_session_id(bad_id)
+
+
+@pytest.mark.parametrize("good_id", [
+    "550e8400-e29b-41d4-a716-446655440000",  # uuid4, the generated shape
+    "abc123",
+    "A_B-c",
+])
+def test_safe_ids_accepted(good_id):
+    assert _is_safe_session_id(good_id)
+
+
+def test_session_file_returns_none_for_traversal(tmp_path):
+    mgr = SessionManager(base_dir=str(tmp_path))
+    for bad_id in TRAVERSAL_IDS:
+        assert mgr._session_file(bad_id) is None
+
+
+def test_session_file_stays_inside_sessions_dir(tmp_path):
+    mgr = SessionManager(base_dir=str(tmp_path))
+    path = mgr._session_file("550e8400-e29b-41d4-a716-446655440000")
+    assert path is not None
+    assert path.resolve().parent == mgr.sessions_dir.resolve()
+
+
+@pytest.mark.asyncio
+async def test_delete_session_cannot_unlink_outside(tmp_path):
+    """The traversal that mattered most: delete_session unlinks the path."""
+    victim = tmp_path / "victim.json"
+    victim.write_text("{}")
+
+    mgr = SessionManager(base_dir=str(tmp_path))
+    # sessions_dir is tmp_path/sessions, so ../victim escapes to the victim
+    deleted = await mgr.delete_session("../victim")
+
+    assert deleted is False
+    assert victim.exists(), "traversal id deleted a file outside sessions_dir"
+
+
+@pytest.mark.asyncio
+async def test_get_session_cannot_read_outside(tmp_path):
+    secret = tmp_path / "secret.json"
+    secret.write_text('{"session_id": "x", "created_at": "2026-01-01T00:00:00", '
+                      '"updated_at": "2026-01-01T00:00:00"}')
+
+    mgr = SessionManager(base_dir=str(tmp_path))
+    assert await mgr.get_session("../secret") is None

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -45,7 +45,7 @@
         "react-syntax-highlighter": "^15.6.1",
         "react-transition-group": "^4.4.5",
         "recharts": "^3.0.2",
-        "uuid": "^11.1.0",
+        "uuid": "^11.1.1",
         "vis-data": "^8.0.1",
         "vis-timeline": "^8.2.1",
         "web-vitals": "^2.1.4"
@@ -2213,7 +2213,7 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
@@ -2226,7 +2226,7 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -2527,19 +2527,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/@egjs/hammerjs": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
-      "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/hammerjs": "^2.0.36"
-      },
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/@emotion/babel-plugin": {
@@ -4672,26 +4659,6 @@
         "url": "https://github.com/sponsors/gregberge"
       }
     },
-    "node_modules/@testing-library/dom": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.3.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "picocolors": "1.1.1",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@testing-library/jest-dom": {
       "version": "5.17.0",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.17.0.tgz",
@@ -4811,28 +4778,28 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
       "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/aria-query": {
@@ -5084,13 +5051,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/hammerjs": {
-      "version": "2.0.46",
-      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.46.tgz",
-      "integrity": "sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/@types/hast": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
@@ -5243,6 +5203,7 @@
       "version": "18.3.23",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -7473,16 +7434,6 @@
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "license": "MIT"
     },
-    "node_modules/component-emitter": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
-      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/compressible": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
@@ -7782,7 +7733,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
@@ -8997,7 +8948,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -13832,13 +13783,6 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/keycharm": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/keycharm/-/keycharm-0.4.0.tgz",
-      "integrity": "sha512-TyQTtsabOVv3MeOpR92sIKk/br9wxS+zGj4BG7CR8YbK4jM3tyIBaF0zhzeBUMx36/Q/iQLOKKOT+3jOQtemRQ==",
-      "license": "(Apache-2.0 OR MIT)",
-      "peer": true
-    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -14114,7 +14058,7 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/makeerror": {
@@ -14124,19 +14068,6 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "tmpl": "1.0.5"
-      }
-    },
-    "node_modules/marked": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
-      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 18"
       }
     },
     "node_modules/math-intrinsics": {
@@ -14951,37 +14882,6 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/moment": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
-      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/monaco-editor": {
-      "version": "0.55.1",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
-      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "dompurify": "3.2.7",
-        "marked": "14.0.0"
-      }
-    },
-    "node_modules/monaco-editor/node_modules/dompurify": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
-      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "peer": true,
-      "optionalDependencies": {
-        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/motion-dom": {
@@ -17310,16 +17210,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
-    },
-    "node_modules/propagating-hammerjs": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/propagating-hammerjs/-/propagating-hammerjs-3.0.0.tgz",
-      "integrity": "sha512-FJTclGll0ysatpF9rKO4jwobyaVDitPb0g/bGlufqqtXPQX8mxf8IXilnIK2iYRMPkVlYeFNhPTrspF9CM1stg==",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@egjs/hammerjs": "^2.0.17"
-      }
     },
     "node_modules/property-information": {
       "version": "7.1.0",
@@ -20552,7 +20442,7 @@
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
@@ -20596,7 +20486,7 @@
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
       "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.11.0"
@@ -20609,7 +20499,7 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tsconfig-paths": {
@@ -20805,6 +20695,7 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -21118,9 +21009,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -21134,7 +21025,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
@@ -21252,24 +21143,6 @@
         "vis-data": ">=8.0.0",
         "vis-util": ">=6.0.0",
         "xss": "^1.0.0"
-      }
-    },
-    "node_modules/vis-util": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/vis-util/-/vis-util-6.0.0.tgz",
-      "integrity": "sha512-qtpts3HRma0zPe4bO7t9A2uejkRNj8Z2Tb6do6lN85iPNWExFkUiVhdAq5uLGIUqBFduyYeqWJKv/jMkxX0R5g==",
-      "license": "(Apache-2.0 OR MIT)",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/visjs"
-      },
-      "peerDependencies": {
-        "@egjs/hammerjs": "^2.0.0",
-        "component-emitter": "^1.3.0 || ^2.0.0"
       }
     },
     "node_modules/w3c-hr-time": {
@@ -22310,7 +22183,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,7 +40,7 @@
     "react-syntax-highlighter": "^15.6.1",
     "react-transition-group": "^4.4.5",
     "recharts": "^3.0.2",
-    "uuid": "^11.1.0",
+    "uuid": "^11.1.1",
     "vis-data": "^8.0.1",
     "vis-timeline": "^8.2.1",
     "web-vitals": "^2.1.4"


### PR DESCRIPTION
From reviewing the open Dependabot + CodeQL findings.

## 1. Path traversal — genuine bug (CodeQL `error`)
UI-composer session ids arrive from request bodies and were interpolated straight into a filesystem path:
```python
session_file = self.sessions_dir / f"{session_id}.json"
```
A crafted id (`../../etc/passwd`) escaped the sessions directory — **arbitrary file read** in `get_session`, and **arbitrary file delete** in `delete_session` (it calls `.unlink()`). `save_session` had the same shape.

All three sites now go through a validated `_session_file()`; ids must match `^[A-Za-z0-9_-]{1,64}$` (the generated shape is a uuid4). **17 regression tests** cover the traversal shapes and assert a file outside the directory survives a `delete_session("../victim")`.

## 2. uuid — patch, not a 3-major jump
The advisory is fixed in **11.1.1**; the open dependabot PR #70 proposes **14.0.0**, which crosses three majors and needs a jest `transformIgnorePatterns` change for its ESM repackaging. Patch-bumped instead — same alert closed, no migration risk. #70 can be closed.

npm also pruned 11 stale/extraneous lockfile entries as a side effect (`monaco-editor`, `marked`, `moment`, `vis-util`, hammerjs helpers…). Verified these are genuinely unreferenced: `@monaco-editor/react` loads monaco from CDN, and `vis-timeline/standalone` bundles its deps. **Build passes** and the suite is within the CI gate after.

## 3. MD5 → SHA256
A UI-composer cache key. Not a real vulnerability (cache key, not a credential), but no reason to keep a broken digest.

## Verification
- Backend: **44 failed / 29 errors — identical to baseline**; 388 passed (371 + 17 new)
- Frontend: `npm ci` + `npm run build` OK; suite within the gate
- `py_compile` clean

## Not changed (reviewed, false positives)
The other CodeQL "clear-text logging of sensitive information" hits log **`len(secret)`**, not values (`validate_config.py`), or log warning strings / debug room names — no secret or value is emitted. Left alone rather than adding redaction machinery the platform's no-PHI rule says not to build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)