### PR TITLE
fix(pharmacy): MedicationDispense search-param typo — every dispense query was 400ing

### DIFF
--- a/frontend/src/hooks/medication/useMedicationDispense.js
+++ b/frontend/src/hooks/medication/useMedicationDispense.js
@@ -17,7 +17,7 @@ export const useMedicationDispense = (patientId, options = {}) => {
   
   const searchParams = useMemo(() => ({
     subject: patientId,
-    _sort: '-whenhandover',
+    _sort: '-whenhandedover',
     _count: options.limit || 50,
     ...options.searchParams
   }), [patientId, options.limit, options.searchParams]);
@@ -133,7 +133,7 @@ export const useMedicationDispense = (patientId, options = {}) => {
     try {
       const response = await fhirClient.search('MedicationDispense', {
         prescription: prescriptionId,
-        _sort: '-whenhandover'
+        _sort: '-whenhandedover'
       });
       return response.entry?.map(entry => entry.resource) || [];
     } catch (err) {
@@ -223,7 +223,7 @@ export const useMedicationWorkflow = (prescriptionId) => {
       // Load related dispenses
       const dispensesResponse = await fhirClient.search('MedicationDispense', {
         prescription: prescriptionId,
-        _sort: '-whenhandover'
+        _sort: '-whenhandedover'
       });
       const dispenses = dispensesResponse.entry?.map(e => e.resource) || [];
       

--- a/frontend/src/services/medicationDispenseService.js
+++ b/frontend/src/services/medicationDispenseService.js
@@ -91,7 +91,7 @@ class MedicationDispenseService {
   async getDispensesByPrescription(prescriptionId) {
     const searchParams = {
       prescription: prescriptionId,
-      _sort: '-whenhandover'
+      _sort: '-whenhandedover'
     };
     
     const response = await this.searchMedicationDispenses(searchParams);
@@ -104,19 +104,24 @@ class MedicationDispenseService {
   async getDispensesByPatient(patientId, options = {}) {
     const searchParams = {
       subject: patientId,
-      _sort: options.sort || '-whenhandover',
+      _sort: options.sort || '-whenhandedover',
       _count: options.limit || 50,
       ...options.additionalParams
     };
     
     // Add date range if specified
+    // A FHIR AND-ed date range is two repeated params. Concatenating
+    // '&whenhandedover=le..' into one value gets percent-encoded by
+    // URLSearchParams into a single malformed param, so the upper bound never
+    // reaches HAPI. fhirClient serializes array values as repeated keys.
     if (options.startDate) {
-      searchParams['whenhandover'] = `ge${options.startDate}`;
+      searchParams['whenhandedover'] = `ge${options.startDate}`;
     }
     if (options.endDate) {
-      searchParams['whenhandover'] = searchParams['whenhandover'] ? 
-        `${searchParams['whenhandover']}&whenhandover=le${options.endDate}` :
-        `le${options.endDate}`;
+      const le = `le${options.endDate}`;
+      searchParams['whenhandedover'] = searchParams['whenhandedover']
+        ? [searchParams['whenhandedover'], le]
+        : le;
     }
     
     const response = await this.searchMedicationDispenses(searchParams);
@@ -129,7 +134,7 @@ class MedicationDispenseService {
   async getDispensesByStatus(status, patientId = null) {
     const searchParams = {
       status: status,
-      _sort: '-whenhandover'
+      _sort: '-whenhandedover'
     };
     
     if (patientId) {
@@ -188,7 +193,7 @@ class MedicationDispenseService {
    */
   async getDispensingMetrics(patientId = null, dateRange = null) {
     const searchParams = {
-      _sort: '-whenhandover',
+      _sort: '-whenhandedover',
       _count: 100 // Reasonable limit for metrics
     };
     
@@ -206,9 +211,9 @@ class MedicationDispenseService {
         dateFilters.push(`le${dateRange.end}`);
       }
       if (dateFilters.length === 1) {
-        searchParams['whenhandover'] = dateFilters[0];
+        searchParams['whenhandedover'] = dateFilters[0];
       } else if (dateFilters.length > 1) {
-        searchParams['whenhandover'] = dateFilters; // Array becomes multiple query params
+        searchParams['whenhandedover'] = dateFilters; // Array becomes multiple query params
       }
     }
     


### PR DESCRIPTION
## A real, live bug — found during the Vite trial smoke, but unrelated to it

`whenhandover` is not a FHIR R4 search parameter. The correct name is **`whenhandedover`**. HAPI rejected every query outright:

```
HAPI-1194: Unknown _sort parameter value "whenhandover"
           for resource type "MedicationDispense"
```

Verified against the live wintehrdev server:
- `_sort=-whenhandover` → **400**
- `_sort=-whenhandedover` → **200**

So **every MedicationDispense search in the app has been failing silently** — dispense history and pharmacy dispense views were returning nothing. 14 occurrences across `medicationDispenseService.js` and `useMedicationDispense.js`.

## Also: the same date-range smuggling bug as #216

```js
searchParams['whenhandover'] =   // ✗
```
That concatenates a second param *inside a single value*, which `URLSearchParams` percent-encodes into one malformed param — so the range's upper bound never reached HAPI. Same class of defect I fixed for imaging search in #216. `fhirClient` already serializes array values as repeated keys, so the fix is an array.

## How it was found
I was monitoring failed network requests while smoking the Vite branch and saw a consistent 400. It reproduced on the tab tour, so I chased it rather than writing it off as transient. **The bug is pre-existing on master and has nothing to do with the bundler** — which is why this PR targets master independently of the Vite decision.

## Verification
- Full frontend suite: **519 tests / 103 failed — exactly the master baseline**, no regression
- eslint: 0 errors on both touched files
- Live query check against wintehrdev (above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)