### PR TITLE
build(deps): override js-yaml and postcss to clear transitive advisories

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9310,10 +9310,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -10369,9 +10379,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -10856,10 +10866,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -10876,7 +10885,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -12290,34 +12299,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
       "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==",
       "license": "MIT"
-    },
-    "node_modules/styled-components/node_modules/postcss": {
-      "version": "8.4.49",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
-      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.7",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
     },
     "node_modules/styled-components/node_modules/stylis": {
       "version": "4.3.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -99,5 +99,9 @@
     "typescript": "^4.9.5",
     "vite": "^7.3.6",
     "vitest": "^3.2.7"
+  },
+  "overrides": {
+    "js-yaml": "^4.3.0",
+    "postcss": "^8.5.18"
   }
 }


### PR DESCRIPTION
Both reach the tree only via build tooling, so there is no direct dependency to bump — `overrides` is the mechanism that applies.

| package | before | after |
|---|---|---|
| js-yaml | 4.1.0 | 4.3.0 |
| postcss | 8.4.49 | 8.5.23 |

`npm audit`: **10 vulnerabilities (3 high) → 7 (1 high)**.

## Why brace-expansion is deliberately excluded

Dependabot reports it as high with "fix: 1.1.16". That is misleading — the advisory's vulnerable range is `<=5.0.7`, i.e. every published version including the suggested fix. Overriding it keeps it inside the range, and npm then attributes the advisory to each package in the eslint dev tree individually (`eslint`, `eslint-plugin-*`, `minimatch`, `glob`, `rimraf`, `flat-cache`, …), taking the reported count from 10 to **19**. I tried it and backed it out.

Clearing it genuinely means moving off eslint 8, which is its own migration. It is dev-only tooling and never reaches the production bundle.

`uuid` is also excluded: the vulnerable copy is 9.0.1 nested under `cornerstone-wado-image-loader`, and forcing it to 11.x across a DICOM dependency risks a real API break for a bounds-check issue that only triggers when the caller passes its own buffer.

## Verification

- `vite build` succeeds.
- 561 tests / 104 failed — failing-test-name set **byte-identical** to master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)