### PR TITLE
ci: gate on test outcomes, not just failure counts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,17 +31,32 @@ jobs:
           cache: pip
           cache-dependency-path: backend/requirements.txt
       - run: pip install -r requirements.txt
-      - name: "pytest (gated on baseline: 44 failed / 29 errors)"
+      - name: "pytest (baseline: 44 failed / 29 errors / 396 passed / 445 outcomes)"
         run: |
           python -m pytest tests/ -q --tb=no > pytest.out 2>&1 || true
           tail -3 pytest.out
           FAILED=$(grep -oE '[0-9]+ failed' pytest.out | grep -oE '[0-9]+' | head -1)
           ERRORS=$(grep -oE '[0-9]+ error' pytest.out | grep -oE '[0-9]+' | head -1)
           PASSED=$(grep -oE '[0-9]+ passed' pytest.out | grep -oE '[0-9]+' | head -1)
-          FAILED=${FAILED:-0}; ERRORS=${ERRORS:-0}; PASSED=${PASSED:-0}
-          echo "passed=$PASSED failed=$FAILED errors=$ERRORS (baseline: 44/29, passed >= 360)"
-          if [ "$FAILED" -gt 44 ] || [ "$ERRORS" -gt 29 ] || [ "$PASSED" -lt 360 ]; then
-            echo "::error::Test results regressed past the baseline (failed<=44, errors<=29, passed>=360)"
+          SKIPPED=$(grep -oE '[0-9]+ skipped' pytest.out | grep -oE '[0-9]+' | head -1)
+          FAILED=${FAILED:-0}; ERRORS=${ERRORS:-0}; PASSED=${PASSED:-0}; SKIPPED=${SKIPPED:-0}
+          OUTCOMES=$((FAILED + PASSED + SKIPPED))
+          echo "passed=$PASSED failed=$FAILED errors=$ERRORS skipped=$SKIPPED outcomes=$OUTCOMES"
+          echo "baseline: failed<=44, errors<=29, passed>=396, outcomes>=445"
+          # OUTCOMES is the load-bearing check. A test that stops RUNNING
+          # reports nothing — not a failure, not an error, not a skip — so a
+          # failure-count gate reads the loss as an improvement.
+          #
+          # PR #256 (pytest 7 -> 9) did exactly that: pytest-asyncio 0.21.1
+          # pins pytest<8, and under pytest 9 it silently no-op'd 29 async
+          # CDS-Hooks tests. Failures "improved" 44 -> 22 and the old gate
+          # (failed<=44, errors<=29, passed>=360) passed it while coverage
+          # shrank. Counting outcomes catches that; counting failures cannot.
+          #
+          # Never lower these to make a build green. If tests are legitimately
+          # removed, lower them in that same PR and say why.
+          if [ "$FAILED" -gt 44 ] || [ "$ERRORS" -gt 29 ] || [ "$PASSED" -lt 396 ] || [ "$OUTCOMES" -lt 445 ]; then
+            echo "::error::Test results regressed past the baseline (failed<=44, errors<=29, passed>=396, outcomes>=445)"
             exit 1
           fi
 
@@ -64,22 +79,24 @@ jobs:
         # be a hard gate yet. Report the count; the test baseline below is the
         # enforced bar. Ratchet toward a hard gate as the backlog shrinks.
         run: npx eslint src -f compact 2>&1 | tail -1 || true
-      - name: "vitest (gated on baseline: 104 failed)"
+      - name: "vitest (baseline: 104 failed / 561 total)"
         run: |
-          # Baseline 104 failed of 552 under Vitest. Vitest collects 33 MORE
-          # tests than CRA/jest did (552 vs 519) because two suites that jest
-          # could not even collect now run — cdsHooksClient.parallel (6, all
-          # pass) and QueryStudioEnhanced (19, a known-broken suite tracked for
-          # fix/removal). Passing tests went UP (416 -> 448); the failure count
-          # rose only because more tests execute. Ratchet DOWN as suites get
-          # fixed; never up without a PR that explains why.
-          # Vitest's json reporter emits jest-compatible numTotalTests/
-          # numFailedTests, so the gate logic is unchanged.
+          # Baseline 104 failed of 561 under Vitest. Vitest collects more than
+          # CRA/jest did because two suites jest could not even collect now run
+          # — cdsHooksClient.parallel (6, all pass) and QueryStudioEnhanced
+          # (19, a known-broken suite tracked for fix/removal). The failure
+          # count rose only because more tests execute.
+          #
+          # numTotalTests is the counterpart to the backend's OUTCOMES check:
+          # it catches tests that stop running, which a failure-count gate
+          # reads as an improvement. See the backend job for the concrete case
+          # (PR #256). Ratchet DOWN as suites get fixed; never up without a PR
+          # that explains why.
           npx vitest run --reporter=json --outputFile=vitest.json > vitest.out 2>&1 || true
           node -e "
             const r = require('./vitest.json');
-            console.log(r.numTotalTests + ' tests, ' + r.numFailedTests + ' failed (baseline: 104, total >= 540)');
-            if (r.numFailedTests > 104 || r.numTotalTests < 540) {
-              console.error('::error::Test results regressed past the baseline (failed<=104, total>=540)');
+            console.log(r.numTotalTests + ' tests, ' + r.numFailedTests + ' failed, ' + r.numPassedTests + ' passed (baseline: failed<=104, total>=561, passed>=448)');
+            if (r.numFailedTests > 104 || r.numTotalTests < 561 || r.numPassedTests < 448) {
+              console.error('::error::Test results regressed past the baseline (failed<=104, total>=561, passed>=448)');
               process.exit(1);
             }"


### PR DESCRIPTION
A test that stops **running** reports nothing — not a failure, not an error, not a skip. A gate built on failure counts therefore reads lost coverage as an *improvement*.

## The case that motivated this

#256 (pytest 7 → 9) hit it exactly. `pytest-asyncio` 0.21.1 pins `pytest<8`; under pytest 9 it silently no-op'd 29 async CDS-Hooks tests.

| | failed | passed | skipped | outcomes | collected |
|---|---|---|---|---|---|
| 7.4.3 | 44 | 388 | 5 | **437** | 437 |
| 9.1.1 | 22 | 381 | 5 | **408** | 437 |

Failures *improved* 44 → 22 and the old gate (`failed<=44, errors<=29, passed>=360`) passed it — while the suite quietly stopped covering 29 tests.

## Change

**Backend** — also sums `failed+passed+skipped` and requires **>= 445**; raises the passed floor 360 → **396** to match reality.

**Frontend** — the counterpart checks: `numTotalTests >= 561` (exact — headroom would defeat the purpose) and `numPassedTests >= 448` (actual 457, small headroom for the known flip-flopping suite).

## Verification

Ran the gate logic against both scenarios:

- pytest-9 numbers (22/381/5) → **rejected**, outcomes 408 < 445
- master baseline (44/396/5) → **accepted**, outcomes 445

🤖 Generated with [Claude Code](https://claude.com/claude-code)