### PR TITLE
fix(backend): declare the sqlalchemy asyncio extra; clears all 29 test errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           cache: pip
           cache-dependency-path: backend/requirements.txt
       - run: pip install -r requirements.txt
-      - name: "pytest (baseline: 44 failed / 29 errors / 396 passed / 445 outcomes)"
+      - name: "pytest (baseline: 40 failed / 0 errors / 400 passed / 445 outcomes)"
         run: |
           python -m pytest tests/ -q --tb=no > pytest.out 2>&1 || true
           tail -3 pytest.out
@@ -42,7 +42,7 @@ jobs:
           FAILED=${FAILED:-0}; ERRORS=${ERRORS:-0}; PASSED=${PASSED:-0}; SKIPPED=${SKIPPED:-0}
           OUTCOMES=$((FAILED + PASSED + SKIPPED))
           echo "passed=$PASSED failed=$FAILED errors=$ERRORS skipped=$SKIPPED outcomes=$OUTCOMES"
-          echo "baseline: failed<=44, errors<=29, passed>=396, outcomes>=445"
+          echo "baseline: failed<=40, errors<=0, passed>=400, outcomes>=445"
           # OUTCOMES is the load-bearing check. A test that stops RUNNING
           # reports nothing — not a failure, not an error, not a skip — so a
           # failure-count gate reads the loss as an improvement.
@@ -53,10 +53,14 @@ jobs:
           # (failed<=44, errors<=29, passed>=360) passed it while coverage
           # shrank. Counting outcomes catches that; counting failures cannot.
           #
+          # The error budget is now ZERO. All 29 previous errors were async
+          # fixture teardown failing on a missing greenlet; declaring the
+          # sqlalchemy[asyncio] extra fixed them. Keep it at zero.
+          #
           # Never lower these to make a build green. If tests are legitimately
           # removed, lower them in that same PR and say why.
-          if [ "$FAILED" -gt 44 ] || [ "$ERRORS" -gt 29 ] || [ "$PASSED" -lt 396 ] || [ "$OUTCOMES" -lt 445 ]; then
-            echo "::error::Test results regressed past the baseline (failed<=44, errors<=29, passed>=396, outcomes>=445)"
+          if [ "$FAILED" -gt 40 ] || [ "$ERRORS" -gt 0 ] || [ "$PASSED" -lt 400 ] || [ "$OUTCOMES" -lt 445 ]; then
+            echo "::error::Test results regressed past the baseline (failed<=40, errors<=0, passed>=400, outcomes>=445)"
             exit 1
           fi
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,7 +6,7 @@ pydantic>=2.5.0
 # fhir.resources, which was an unused shim and has been removed — so the
 # dependency is now declared where it is actually used.
 email-validator>=2.3.0
-sqlalchemy>=2.0.23
+sqlalchemy[asyncio]>=2.0.23
 
 # WebSocket support
 websockets==16.1.1


### PR DESCRIPTION
`greenlet` is not a hard dependency of SQLAlchemy — it arrives through the `[asyncio]` extra, which `requirements.txt` never declared. Every async fixture teardown was failing on it:

```
ValueError: the greenlet library is required to use this function
```

## Effect

From a clean, requirements-only install:

| | failed | passed | skipped | errors |
|---|---|---|---|---|
| before | 44 | 396 | 5 | **29** |
| after | 40 | 400 | 5 | **0** |

Every error gone and 4 tests recovered, from `sqlalchemy` → `sqlalchemy[asyncio]`.

This is the same class of bug as the missing `email-validator` found in #244: a package we depend on was quietly supplying something we never declared. Worth noting these errors were async fixture **teardown** failures, not collection errors — the tests ran and reported results, then errored on cleanup.

Ratchets the gate down in the same change, per its own policy: `failed<=40, errors<=0, passed>=400`. The error budget is now **zero** and should stay there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)