### PR TITLE
fix(cds-hooks): clear the 40-test failure cluster; fix 4 live CDS bugs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,8 @@
-# Minimal CI: both test suites run on every PR, gated against the known
-# baseline failure counts rather than zero — the suites carry documented
-# pre-existing failures (backend: CDS-hooks test-infra issues; frontend:
-# legacy suites), so "no NEW failures" is the honest, enforceable bar.
-# Ratchet the numbers DOWN as suites get fixed; never up without a PR that
-# explains why.
+# Minimal CI: both test suites run on every PR, gated against known baselines.
+# The BACKEND suite is fully green (0 failed / 0 errors) — that gate is now a
+# hard zero. The frontend still carries documented legacy failures, so its gate
+# is "no NEW failures". Ratchet the frontend numbers DOWN as suites get fixed;
+# never loosen either gate without a PR that explains why.
 name: CI
 
 on:
@@ -31,7 +30,7 @@ jobs:
           cache: pip
           cache-dependency-path: backend/requirements.txt
       - run: pip install -r requirements.txt
-      - name: "pytest (baseline: 40 failed / 0 errors / 400 passed / 445 outcomes)"
+      - name: "pytest (baseline: 0 failed / 0 errors / 440 passed / 445 outcomes)"
         run: |
           python -m pytest tests/ -q --tb=no > pytest.out 2>&1 || true
           tail -3 pytest.out
@@ -42,7 +41,7 @@ jobs:
           FAILED=${FAILED:-0}; ERRORS=${ERRORS:-0}; PASSED=${PASSED:-0}; SKIPPED=${SKIPPED:-0}
           OUTCOMES=$((FAILED + PASSED + SKIPPED))
           echo "passed=$PASSED failed=$FAILED errors=$ERRORS skipped=$SKIPPED outcomes=$OUTCOMES"
-          echo "baseline: failed<=40, errors<=0, passed>=400, outcomes>=445"
+          echo "baseline: failed<=0, errors<=0, passed>=440, outcomes>=445"
           # OUTCOMES is the load-bearing check. A test that stops RUNNING
           # reports nothing — not a failure, not an error, not a skip — so a
           # failure-count gate reads the loss as an improvement.
@@ -59,8 +58,8 @@ jobs:
           #
           # Never lower these to make a build green. If tests are legitimately
           # removed, lower them in that same PR and say why.
-          if [ "$FAILED" -gt 40 ] || [ "$ERRORS" -gt 0 ] || [ "$PASSED" -lt 400 ] || [ "$OUTCOMES" -lt 445 ]; then
-            echo "::error::Test results regressed past the baseline (failed<=40, errors<=0, passed>=400, outcomes>=445)"
+          if [ "$FAILED" -gt 0 ] || [ "$ERRORS" -gt 0 ] || [ "$PASSED" -lt 440 ] || [ "$OUTCOMES" -lt 445 ]; then
+            echo "::error::Test results regressed past the baseline (failed<=0, errors<=0, passed>=440, outcomes>=445)"
             exit 1
           fi
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,7 @@ module's deltas on top of this file.
 
 ## Tech stack
 
-- **Backend**: FastAPI (Python 3.9+), HAPI FHIR JPA v8.8.0-1, PostgreSQL 15 with
+- **Backend**: FastAPI (Python 3.12 — Dockerfiles and CI both pin it), HAPI FHIR JPA v8.8.0-1, PostgreSQL 15 with
   async SQLAlchemy, Redis 7, Pydantic V2, pytest.
 - **Frontend**: React 18, MUI v5, React Router v6, Context API, Vite 7 (build + dev server), Vitest.
 

--- a/backend/api/cds_hooks/CLAUDE.md
+++ b/backend/api/cds_hooks/CLAUDE.md
@@ -37,6 +37,31 @@ flows are identical.
 Providers live in `providers/` (`__init__.py` exports `BaseServiceProvider`,
 `LocalServiceProvider`, `RemoteServiceProvider`, `CQLBackedServiceProvider`).
 
+### Provider failure contract — never raise, never block
+
+`LocalServiceProvider.execute()` and `RemoteServiceProvider.execute()` NEVER
+raise: any failure logs, tracks (remote: consecutive-failure counters in
+`external_services.services`, auto-disable at 5), and returns empty cards.
+CDS is advisory — a dead service must not 500 a clinician-facing response.
+The router keeps a catch-all as a second net; discovery likewise degrades to
+registry-only when HAPI is down. Two provider details that were once bugs:
+the local provider awaits async `execute()`/`should_execute()` (the canonical
+`CDSService` is async — unawaited, every async service silently returned zero
+cards) and honors the `should_execute()` gate; the remote provider opens one
+`httpx.AsyncClient` per call inside `async with` (a per-instance client was
+never closed) and reads auth from the columns production supplies
+(`auth_type` + Fernet-encrypted `credentials_encrypted` → X-API-Key / Bearer /
+X-HMAC-Signature), not the never-passed `auth_config`.
+
+### Request validation (`models.py` `CDSHookRequest`)
+
+- `hookInstance` MUST be a UUID (spec shape; frontend senders use `uuidv4()`).
+- `fhirServer` accepts **http or https**. CDS Hooks 2.0 requires https only
+  "when production data is exchanged" — this platform is synthetic-only and
+  every deployment it targets is http. An unconditional-https validator once
+  422'd every hook call in which the frontend included `fhirServer`
+  (it sends `window.location.origin + '/fhir'`). Do not reintroduce it.
+
 ---
 
 ## The canonical patterns (don't reinvent)
@@ -183,6 +208,8 @@ support libraries, not independently-registered routers.
 | Symptom | Look at |
 |---|---|
 | Service not in `cds-services` discovery | `execute_service` discovery merge — built-in registry vs. HAPI `PlanDefinition` with `service-origin` extension |
+| Hook call 422s before reaching any service | `CDSHookRequest` validation — non-UUID `hookInstance`, or `fhirServer` not an http(s) URL |
+| External service always returns empty cards | Provider degraded a failure — check logs + `external_services.services` failure counters / `auto_disabled` |
 | CQL edit not taking effect after save | ELM cache keyed by Library name — `cql_dev_helper.py` should produce a fresh `Draft*` id; check the upload actually ran |
 | ValueSet code change not reflected | CR expansion cache — confirm `POST /admin/cr/flush-caches` fired (HAPI overlay deployed? `HAPI_ADMIN_TOKEN` set?) |
 | `$apply` returns no cards | `request_orchestration_to_cards` found no `RequestGroup`, or actions lacked title/description |

--- a/backend/api/cds_hooks/cds_hooks_router.py
+++ b/backend/api/cds_hooks/cds_hooks_router.py
@@ -352,6 +352,12 @@ async def discover_services(
             logger.warning(f"Cannot connect to FHIR server for service discovery: {e}")
         except (KeyError, TypeError, ValueError) as e:
             logger.warning(f"Error parsing HAPI service data: {e}")
+        except Exception as e:
+            # HAPIFHIRClient wraps transport failures in generic Exception, so
+            # without this a dead HAPI took down the ENTIRE discovery response —
+            # including the in-process built-in services that need no HAPI at
+            # all. Discovery degrades to registry-only; it never 500s over HAPI.
+            logger.warning(f"Unexpected error discovering HAPI services: {e}")
 
     logger.info(f"Total CDS services discovered: {len(services)}")
     return CDSServicesResponse(services=services)

--- a/backend/api/cds_hooks/models.py
+++ b/backend/api/cds_hooks/models.py
@@ -164,16 +164,25 @@ class CDSHookRequest(BaseModel):
     hook: HookType = Field(..., description="Hook type")
     hookInstance: str = Field(..., description="Unique hook instance ID (UUID)")
     context: Dict[str, Any] = Field(..., description="Hook context")
-    fhirServer: Optional[str] = Field(None, description="FHIR server base URL (must use HTTPS)")
+    fhirServer: Optional[str] = Field(None, description="FHIR server base URL (http or https)")
     fhirAuthorization: Optional[FHIRAuthorization] = Field(None, description="FHIR authorization")
     prefetch: Optional[Dict[str, Any]] = Field(None, description="Prefetched FHIR resources")
-    
+
     @field_validator('fhirServer')
     @classmethod
-    def validate_https(cls, v):
-        """CDS Hooks 2.0 requires HTTPS for fhirServer"""
-        if v and not v.startswith('https://'):
-            raise ValueError('fhirServer must use HTTPS scheme in CDS Hooks 2.0')
+    def validate_fhir_server_scheme(cls, v):
+        """Require an http(s) URL — but do NOT require https.
+
+        CDS Hooks 2.0 makes https conditional: the scheme "MUST be https when
+        production data is exchanged". This platform never exchanges production
+        data (synthetic Synthea only, by charter) and every real deployment of
+        it — localhost dev, the wintehrdev demo box — serves plain http. An
+        unconditional https check here 422'd every hook call in which the
+        frontend included fhirServer (it sends window.location.origin), which
+        silently disabled CDS on exactly the deployments this platform targets.
+        """
+        if v and not (v.startswith('https://') or v.startswith('http://')):
+            raise ValueError('fhirServer must be an http(s) URL')
         return v
 
     @field_validator('hookInstance')

--- a/backend/api/cds_hooks/providers/local_provider.py
+++ b/backend/api/cds_hooks/providers/local_provider.py
@@ -5,6 +5,7 @@ Executes built-in CDS services by dynamically importing Python classes.
 Used for services with service-origin extension = "built-in".
 """
 
+import inspect
 import logging
 import importlib
 from typing import Dict, Any, List, Optional
@@ -71,15 +72,13 @@ class LocalServiceProvider(BaseServiceProvider):
             service_metadata: Optional metadata (not used for local services)
 
         Returns:
-            CDSHookResponse with generated cards
-
-        Raises:
-            ValueError: If python-class extension not found
-            ImportError: If service class cannot be imported
-            Exception: If service execution fails
+            CDSHookResponse with generated cards, or an empty card list on any
+            failure. Never raises — CDS is advisory, and a broken legacy
+            service must not break the hook response (same contract as
+            RemoteServiceProvider).
         """
+        service_id = plan_definition.get("id", "unknown")
         try:
-            service_id = plan_definition.get("id", "unknown")
             logger.info(f"Executing local service: {service_id}")
 
             # Extract Python class from extension
@@ -89,19 +88,37 @@ class LocalServiceProvider(BaseServiceProvider):
             )
 
             if not python_class:
-                raise ValueError(f"No python-class extension found for service {service_id}")
+                logger.error(f"  ❌ No python-class extension found for service {service_id}")
+                return CDSHookResponse(cards=[])
 
             logger.debug(f"  Python class: {python_class}")
 
             # Import and instantiate service
             service_instance = self._get_service_instance(python_class, service_id)
 
-            # Execute service
+            context = hook_request.context
+            prefetch = hook_request.prefetch or {}
+
+            # Honor the canonical CDSService gate: should_execute() decides
+            # whether the card logic runs at all. The legacy path used to skip
+            # it, so gated services fired unconditionally when dispatched here.
+            gate = getattr(service_instance, "should_execute", None)
+            if callable(gate):
+                applicable = gate(context=context, prefetch=prefetch)
+                if inspect.isawaitable(applicable):
+                    applicable = await applicable
+                if not applicable:
+                    logger.info(f"  Service {service_id} should_execute=False — no cards")
+                    return CDSHookResponse(cards=[])
+
+            # Execute service. The canonical CDSService.execute is async
+            # (base_service.py) — the old code never awaited, so any async
+            # service dispatched through this path logged "Unexpected return
+            # type: <class 'coroutine'>" and silently produced zero cards.
             logger.debug(f"  Executing service logic...")
-            result = service_instance.execute(
-                context=hook_request.context,
-                prefetch=hook_request.prefetch or {}
-            )
+            result = service_instance.execute(context=context, prefetch=prefetch)
+            if inspect.isawaitable(result):
+                result = await result
 
             # Handle different return types
             if isinstance(result, dict):
@@ -128,14 +145,12 @@ class LocalServiceProvider(BaseServiceProvider):
             return CDSHookResponse(cards=card_objects)
 
         except ImportError as e:
-            error_msg = f"Failed to import service class: {str(e)}"
-            logger.error(f"  ❌ {error_msg}")
-            raise ImportError(error_msg) from e
+            logger.error(f"  ❌ Failed to import service class for {service_id}: {e}")
+            return CDSHookResponse(cards=[])
 
         except Exception as e:
-            error_msg = f"Failed to execute local service: {str(e)}"
-            logger.error(f"  ❌ {error_msg}", exc_info=True)
-            raise Exception(error_msg) from e
+            logger.error(f"  ❌ Failed to execute local service {service_id}: {e}", exc_info=True)
+            return CDSHookResponse(cards=[])
 
     def _get_service_instance(self, python_class: str, service_id: str):
         """

--- a/backend/api/cds_hooks/providers/remote_provider.py
+++ b/backend/api/cds_hooks/providers/remote_provider.py
@@ -10,6 +10,7 @@ Features:
 - Timeout handling and graceful degradation
 """
 
+import inspect
 import logging
 import httpx
 import hmac
@@ -25,6 +26,10 @@ from ..models import CDSHookRequest, CDSHookResponse, Card
 
 logger = logging.getLogger(__name__)
 
+# One timeout policy for all external calls; a slow external service must
+# never hold a hook response open indefinitely.
+_HTTP_TIMEOUT_SECONDS = 30.0
+
 
 class RemoteServiceProvider(BaseServiceProvider):
     """
@@ -32,17 +37,17 @@ class RemoteServiceProvider(BaseServiceProvider):
 
     Execution flow:
     1. Check if service is auto-disabled
-    2. Retrieve service endpoint from database
+    2. Resolve the service endpoint from metadata
     3. Prepare authentication headers
     4. POST CDS Hooks request to external service
     5. Parse response and return cards
     6. Track failures and auto-disable if threshold exceeded
 
-    Educational notes:
-    - Implements CDS Hooks 1.0 HTTP request/response specification
-    - Handles various authentication mechanisms
-    - Provides graceful degradation on failures
-    - Prevents cascading failures via auto-disable
+    Failure contract: `execute()` NEVER raises. Any failure is tracked
+    (consecutive-failure counters in external_services.services) and degrades
+    to an empty card list — CDS is advisory, and a dead external service must
+    not break the clinician-facing hook response. The router keeps its own
+    catch-all as a second net, but the contract lives here.
     """
 
     def __init__(self, db_session=None):
@@ -55,10 +60,6 @@ class RemoteServiceProvider(BaseServiceProvider):
         super().__init__()
         self.provider_type = "remote"
         self.db = db_session
-        self.http_client = httpx.AsyncClient(
-            timeout=30.0,  # 30 second timeout
-            follow_redirects=True
-        )
         self.failure_threshold = 5  # Auto-disable after 5 consecutive failures
 
     async def should_execute(
@@ -94,14 +95,11 @@ class RemoteServiceProvider(BaseServiceProvider):
             service_metadata: External service DB record with URL and auth
 
         Returns:
-            CDSHookResponse with cards from external service
-
-        Raises:
-            ValueError: If service metadata not provided
-            Exception: If HTTP request fails
+            CDSHookResponse with cards from the external service, or an empty
+            card list on any failure (after tracking it). Never raises.
         """
+        service_id = plan_definition.get("id", "unknown")
         try:
-            service_id = plan_definition.get("id", "unknown")
             logger.info(f"Executing remote service: {service_id}")
 
             if not service_metadata:
@@ -112,38 +110,51 @@ class RemoteServiceProvider(BaseServiceProvider):
                 logger.warning(f"  Service {service_id} is auto-disabled due to consecutive failures")
                 return CDSHookResponse(cards=[])
 
-            # Extract service endpoint
-            service_url = service_metadata.get("service_url")
+            service_url = self._resolve_service_url(plan_definition, service_metadata)
             if not service_url:
                 raise ValueError(f"No service URL found for service {service_id}")
 
             logger.debug(f"  Service URL: {service_url}")
 
-            # Prepare authentication
-            headers = self._prepare_auth_headers(service_metadata)
-
-            # Prepare request body (CDS Hooks specification)
+            # Prepare request body (CDS Hooks specification). fhirAuthorization
+            # is a pydantic model — serialize it, or json encoding blows up the
+            # first time a caller actually supplies one.
             request_body = {
                 "hook": hook_request.hook,
                 "hookInstance": hook_request.hookInstance,
                 "fhirServer": hook_request.fhirServer,
-                "fhirAuthorization": hook_request.fhirAuthorization,
+                "fhirAuthorization": (
+                    hook_request.fhirAuthorization.model_dump()
+                    if hook_request.fhirAuthorization is not None else None
+                ),
                 "context": hook_request.context,
                 "prefetch": hook_request.prefetch or {}
             }
 
+            # Prepare authentication (HMAC signs the body, so body comes first)
+            headers = self._prepare_auth_headers(service_metadata, request_body)
+
             logger.debug(f"  Sending CDS Hooks request...")
 
-            # POST to external service
-            response = await self.http_client.post(
-                service_url,
-                json=request_body,
-                headers=headers
-            )
+            # One client per call, closed deterministically. The previous
+            # long-lived client was created per provider instance and the
+            # router constructs a provider per request without ever calling
+            # close() — leaking a connection pool on every external hook fire.
+            async with httpx.AsyncClient(
+                timeout=_HTTP_TIMEOUT_SECONDS,
+                follow_redirects=True
+            ) as client:
+                response = await client.post(
+                    service_url,
+                    json=request_body,
+                    headers=headers
+                )
 
-            response.raise_for_status()
+            # Explicit status check (rather than raise_for_status) so the
+            # failure path is uniform with every other failure below.
+            if response.status_code >= 400:
+                raise Exception(f"HTTP error from external service: {response.status_code}")
 
-            # Parse response
             response_data = response.json()
 
             logger.info(f"  ✅ Received response from external service")
@@ -170,30 +181,98 @@ class RemoteServiceProvider(BaseServiceProvider):
 
             return CDSHookResponse(cards=card_objects)
 
-        except httpx.HTTPStatusError as e:
-            error_msg = f"HTTP error from external service: {e.response.status_code}"
-            logger.error(f"  ❌ {error_msg}")
-            await self._handle_failure(service_id, error_msg)
-            raise Exception(error_msg) from e
-
-        except httpx.TimeoutException as e:
-            error_msg = f"Timeout calling external service"
-            logger.error(f"  ❌ {error_msg}")
-            await self._handle_failure(service_id, error_msg)
-            raise Exception(error_msg) from e
-
+        except httpx.TimeoutException:
+            return await self._degrade(service_id, "Timeout calling external service")
+        except httpx.RequestError as e:
+            return await self._degrade(service_id, f"Connection error calling external service: {e}")
         except Exception as e:
-            error_msg = f"Failed to execute remote service: {str(e)}"
-            logger.error(f"  ❌ {error_msg}", exc_info=True)
-            await self._handle_failure(service_id, error_msg)
-            raise Exception(error_msg) from e
+            return await self._degrade(service_id, f"Failed to execute remote service: {e}")
 
-    def _prepare_auth_headers(self, service_metadata: Dict[str, Any]) -> Dict[str, str]:
+    async def _degrade(self, service_id: str, error_msg: str) -> CDSHookResponse:
+        """Track the failure, log it, and return an empty (non-blocking) response."""
+        logger.error(f"  ❌ {error_msg}")
+        await self._handle_failure(service_id, error_msg)
+        return CDSHookResponse(cards=[])
+
+    def _resolve_service_url(
+        self,
+        plan_definition: Dict[str, Any],
+        service_metadata: Dict[str, Any]
+    ) -> Optional[str]:
         """
-        Prepare authentication headers based on service auth type
+        Resolve the endpoint to POST to.
+
+        The production SQL row computes it directly
+        (base_url || '/cds-services/' || hook_service_id AS service_url).
+        When only base_url is present, derive the same shape the CDS Hooks
+        spec defines: {baseUrl}/cds-services/{service.id}, taking the service
+        id from the metadata row or the PlanDefinition's hook-service-id
+        extension.
+        """
+        service_url = service_metadata.get("service_url")
+        if service_url:
+            return service_url
+
+        base_url = service_metadata.get("base_url")
+        if not base_url:
+            return None
+
+        hook_service_id = service_metadata.get("hook_service_id")
+        if not hook_service_id:
+            for ext in plan_definition.get("extension", []):
+                if ext.get("url") == "http://wintehr.local/fhir/StructureDefinition/hook-service-id":
+                    hook_service_id = ext.get("valueString")
+                    break
+        if not hook_service_id:
+            return None
+
+        return f"{base_url.rstrip('/')}/cds-services/{hook_service_id}"
+
+    def _decrypt_credentials(self, service_metadata: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Recover the credentials dict from external_services.services.credentials_encrypted.
+
+        The registry (api/external_services/service.py) stores Fernet-encrypted
+        JSON, so that path is tried first. Plain JSON and bare-string secrets
+        are accepted as fallbacks — this is a training platform and fixtures /
+        hand-registered services routinely hold unencrypted values.
+        """
+        raw = service_metadata.get("credentials_encrypted")
+        if not raw:
+            return {}
+
+        try:
+            from api.external_services.service import EncryptionService
+            return EncryptionService().decrypt(raw)
+        except Exception:
+            pass
+
+        try:
+            parsed = json.loads(raw)
+            if isinstance(parsed, dict):
+                return parsed
+        except (ValueError, TypeError):
+            pass
+
+        # Bare string — treat it as the secret itself.
+        return {"secret": raw}
+
+    def _prepare_auth_headers(
+        self,
+        service_metadata: Dict[str, Any],
+        request_body: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, str]:
+        """
+        Prepare authentication headers from the external_services.services row.
+
+        Reads the columns the production query actually supplies (auth_type +
+        credentials_encrypted). The earlier implementation read an "auth_config"
+        key that no caller ever passed, so external-service auth silently never
+        attached credentials.
 
         Args:
-            service_metadata: Service database record with auth configuration
+            service_metadata: Service database record
+            request_body: The outgoing CDS Hooks body (HMAC signs it)
 
         Returns:
             Headers dictionary with authentication
@@ -203,27 +282,38 @@ class RemoteServiceProvider(BaseServiceProvider):
             "Accept": "application/json"
         }
 
-        auth_config = service_metadata.get("auth_config", {})
-        auth_type = auth_config.get("type", "none")
+        auth_type = (service_metadata.get("auth_type") or "none").lower()
+        if auth_type == "none":
+            return headers
+
+        creds = self._decrypt_credentials(service_metadata)
 
         if auth_type == "api_key":
-            # API Key authentication
-            api_key = auth_config.get("api_key")
-            header_name = auth_config.get("header_name", "Authorization")
-            header_value = auth_config.get("header_value_format", "Bearer {api_key}")
-
+            api_key = creds.get("api_key") or creds.get("key") or creds.get("secret")
+            header_name = creds.get("header_name", "X-API-Key")
             if api_key:
-                headers[header_name] = header_value.format(api_key=api_key)
+                headers[header_name] = api_key
+            else:
+                logger.warning("  api_key auth configured but no key found in credentials")
 
         elif auth_type == "oauth2":
-            # OAuth2 Bearer token
-            access_token = auth_config.get("access_token")
-            if access_token:
-                headers["Authorization"] = f"Bearer {access_token}"
+            token = creds.get("access_token") or creds.get("token") or creds.get("secret")
+            if token:
+                headers["Authorization"] = f"Bearer {token}"
+            else:
+                logger.warning("  oauth2 auth configured but no token found in credentials")
 
         elif auth_type == "hmac":
-            # HMAC signature (future implementation)
-            logger.warning("HMAC authentication not yet implemented")
+            secret = creds.get("secret") or creds.get("hmac_secret")
+            if secret and request_body is not None:
+                payload = json.dumps(request_body, sort_keys=True, default=str).encode()
+                signature = hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
+                headers["X-HMAC-Signature"] = signature
+            else:
+                logger.warning("  hmac auth configured but no secret found in credentials")
+
+        else:
+            logger.warning(f"  Unknown auth_type '{auth_type}' — sending unauthenticated")
 
         return headers
 
@@ -264,6 +354,11 @@ class RemoteServiceProvider(BaseServiceProvider):
                 RETURNING s.consecutive_failures, s.auto_disabled
             """), {"err": error_message, "threshold": self.failure_threshold, "sid": service_id})).first()
             await self.db.commit()
+
+            # Mocked sessions in tests hand back awaitables; unwrap so the
+            # logging below never explodes inside an error handler.
+            if inspect.isawaitable(row):
+                row = None
 
             if row is None:
                 logger.warning(f"  Service {service_id} not found in external_services registry")
@@ -307,7 +402,3 @@ class RemoteServiceProvider(BaseServiceProvider):
 
         except Exception as e:
             logger.error(f"  Error resetting failure count: {e}")
-
-    async def close(self):
-        """Close HTTP client connection"""
-        await self.http_client.aclose()

--- a/backend/tests/api/cds_hooks/test_cds_hooks_router.py
+++ b/backend/tests/api/cds_hooks/test_cds_hooks_router.py
@@ -36,7 +36,13 @@ class TestCDSHooksDiscovery:
         sample_plan_definition,
         external_plan_definition
     ):
-        """Test discovery endpoint returns all services"""
+        """Unfiltered discovery merges in-process built-ins with HAPI externals.
+
+        Discovery is a MERGE: built-in services come from the in-process
+        ServiceRegistry (however many are registered), external/visual-builder
+        ones from HAPI PlanDefinitions. So assert set-membership, not exact
+        counts — an exact count couples the test to the registry's size.
+        """
         # Mock HAPI FHIR response
         mock_bundle = {
             "resourceType": "Bundle",
@@ -59,8 +65,14 @@ class TestCDSHooksDiscovery:
             # Verify
             assert response.status_code == 200
             data = response.json()
-            assert "services" in data
-            assert len(data["services"]) == 2
+            ids = [s["id"] for s in data["services"]]
+            # The HAPI external service appears...
+            assert "external-diabetes-management" in ids
+            # ...alongside registry built-ins (the merge actually happened).
+            assert len(ids) > 1
+            # A PlanDefinition marked service-origin=built-in is NOT served
+            # from HAPI — the registry is the sole authority for built-ins.
+            assert "diabetes-screening-reminder" not in ids
 
     def test_discover_services_built_in_only(
         self,
@@ -86,10 +98,15 @@ class TestCDSHooksDiscovery:
             # Execute
             response = client.get("/cds-services?service_origin=built-in")
 
-            # Verify
+            # Verify: built-in filter serves the registry only — HAPI is not
+            # consulted, so the mocked external service must NOT leak in and
+            # the HAPI built-in PlanDefinition must not appear either.
             assert response.status_code == 200
             data = response.json()
-            assert len(data["services"]) == 1
+            ids = [s["id"] for s in data["services"]]
+            assert len(ids) >= 1  # registry built-ins
+            assert "external-diabetes-management" not in ids
+            assert "diabetes-screening-reminder" not in ids
 
     def test_discover_services_external_only(
         self,
@@ -121,7 +138,12 @@ class TestCDSHooksDiscovery:
             assert len(data["services"]) == 1
 
     def test_discover_services_empty_result(self, client):
-        """Test discovery with no services in HAPI"""
+        """No PlanDefinitions in HAPI → the external filter returns nothing.
+
+        (Unfiltered discovery would still return the in-process built-ins —
+        they don't live in HAPI — so the empty-HAPI premise is only observable
+        through the external filter.)
+        """
         # Mock empty HAPI FHIR response
         mock_bundle = {
             "resourceType": "Bundle",
@@ -136,7 +158,7 @@ class TestCDSHooksDiscovery:
             mock_client_class.return_value = mock_client
 
             # Execute
-            response = client.get("/cds-services")
+            response = client.get("/cds-services?service_origin=external")
 
             # Verify
             assert response.status_code == 200
@@ -144,7 +166,12 @@ class TestCDSHooksDiscovery:
             assert data["services"] == []
 
     def test_discover_services_hapi_error(self, client):
-        """Test discovery when HAPI FHIR fails"""
+        """HAPI down → discovery degrades to registry-only, never 500s.
+
+        HAPIFHIRClient wraps transport failures in a generic Exception; the
+        endpoint used to let that propagate, so a dead HAPI took the built-in
+        services down with it even though they need no HAPI at all.
+        """
         # Mock HAPI error
         with patch('services.hapi_fhir_client.HAPIFHIRClient') as mock_client_class:
             mock_client = AsyncMock()
@@ -154,10 +181,12 @@ class TestCDSHooksDiscovery:
             # Execute
             response = client.get("/cds-services")
 
-            # Verify - should return empty services, not error
+            # Verify - built-ins still served; no external ones (HAPI is dead)
             assert response.status_code == 200
             data = response.json()
-            assert data["services"] == []
+            ids = [s["id"] for s in data["services"]]
+            assert len(ids) >= 1  # registry built-ins survive the outage
+            assert "external-diabetes-management" not in ids
 
     def test_discover_services_dedupes_visual_builder_duplicates(self, client):
         """Discovery dedupes by hook-service-id, keeping the latest by lastUpdated.
@@ -247,9 +276,12 @@ class TestCDSHooksExecution:
 
         # Mock LocalServiceProvider
         with patch('services.hapi_fhir_client.HAPIFHIRClient') as mock_hapi, \
-             patch('backend.api.cds_hooks.providers.LocalServiceProvider') as mock_provider_class:
+             patch('api.cds_hooks.providers.LocalServiceProvider') as mock_provider_class:
 
             mock_hapi_client = AsyncMock()
+            # Direct read resolves the PlanDefinition (the fixture id is not
+            # in the in-process registry, so the router takes the HAPI path).
+            mock_hapi_client.read.return_value = sample_plan_definition
             mock_hapi_client.search.return_value = mock_bundle
             mock_hapi.return_value = mock_hapi_client
 
@@ -285,10 +317,11 @@ class TestCDSHooksExecution:
 
         # Mock database query
         with patch('services.hapi_fhir_client.HAPIFHIRClient') as mock_hapi, \
-             patch('backend.api.cds_hooks.providers.RemoteServiceProvider') as mock_provider_class, \
+             patch('api.cds_hooks.providers.RemoteServiceProvider') as mock_provider_class, \
              patch('database.get_db_session'):
 
             mock_hapi_client = AsyncMock()
+            mock_hapi_client.read.return_value = external_plan_definition
             mock_hapi_client.search.return_value = mock_bundle
             mock_hapi.return_value = mock_hapi_client
 
@@ -316,6 +349,10 @@ class TestCDSHooksExecution:
 
         with patch('services.hapi_fhir_client.HAPIFHIRClient') as mock_hapi:
             mock_hapi_client = AsyncMock()
+            # HAPIFHIRClient re-raises 404 as a generic Exception whose text
+            # contains "not found" — mirror that failure shape.
+            mock_hapi_client.read.side_effect = Exception(
+                "Resource PlanDefinition/non-existent-service not found")
             mock_hapi_client.search.return_value = mock_bundle
             mock_hapi.return_value = mock_hapi_client
 
@@ -349,6 +386,7 @@ class TestCDSHooksExecution:
 
         with patch('services.hapi_fhir_client.HAPIFHIRClient') as mock_hapi:
             mock_hapi_client = AsyncMock()
+            mock_hapi_client.read.return_value = plan_def
             mock_hapi_client.search.return_value = mock_bundle
             mock_hapi.return_value = mock_hapi_client
 
@@ -358,8 +396,12 @@ class TestCDSHooksExecution:
                 json=sample_cds_request
             )
 
-            # Verify error handling
-            assert response.status_code == 500
+            # Verify: CDS Hooks is non-blocking by design — a misconfigured
+            # origin degrades to 200 + empty cards (the router's legacy
+            # fallback fails, its catch-all swallows), it must never 500 into
+            # the clinician-facing workflow.
+            assert response.status_code == 200
+            assert response.json()["cards"] == []
 
 
 class TestPlanDefinitionConversion:
@@ -471,10 +513,13 @@ class TestExecutionLogging:
         }
 
         with patch('services.hapi_fhir_client.HAPIFHIRClient') as mock_hapi, \
-             patch('backend.api.cds_hooks.providers.LocalServiceProvider') as mock_provider_class, \
-             patch('backend.api.cds_hooks.hook_persistence.log_hook_execution') as mock_log:
+             patch('api.cds_hooks.providers.LocalServiceProvider') as mock_provider_class, \
+             patch('api.cds_hooks.cds_hooks_router.log_service_execution', new_callable=AsyncMock) as mock_log:
 
             mock_hapi_client = AsyncMock()
+            # Direct read resolves the PlanDefinition (the fixture id is not
+            # in the in-process registry, so the router takes the HAPI path).
+            mock_hapi_client.read.return_value = sample_plan_definition
             mock_hapi_client.search.return_value = mock_bundle
             mock_hapi.return_value = mock_hapi_client
 
@@ -508,10 +553,13 @@ class TestExecutionLogging:
         }
 
         with patch('services.hapi_fhir_client.HAPIFHIRClient') as mock_hapi, \
-             patch('backend.api.cds_hooks.providers.LocalServiceProvider') as mock_provider_class, \
-             patch('backend.api.cds_hooks.hook_persistence.log_hook_execution') as mock_log:
+             patch('api.cds_hooks.providers.LocalServiceProvider') as mock_provider_class, \
+             patch('api.cds_hooks.cds_hooks_router.log_service_execution', new_callable=AsyncMock) as mock_log:
 
             mock_hapi_client = AsyncMock()
+            # Direct read resolves the PlanDefinition (the fixture id is not
+            # in the in-process registry, so the router takes the HAPI path).
+            mock_hapi_client.read.return_value = sample_plan_definition
             mock_hapi_client.search.return_value = mock_bundle
             mock_hapi.return_value = mock_hapi_client
 

--- a/backend/tests/api/cds_hooks/test_failure_tracking.py
+++ b/backend/tests/api/cds_hooks/test_failure_tracking.py
@@ -168,7 +168,7 @@ class TestFailureTracking:
         }
 
         # Mock successful response
-        mock_response = AsyncMock()
+        mock_response = MagicMock()  # httpx.Response API is sync
         mock_response.status_code = 200
         mock_response.json.return_value = {"cards": []}
 
@@ -375,7 +375,7 @@ class TestFailureTypes:
         test_db
     ):
         """Test HTTP error status codes are tracked"""
-        mock_response = AsyncMock()
+        mock_response = MagicMock()  # httpx.Response API is sync
         mock_response.status_code = 500
         mock_response.text = "Internal Server Error"
 
@@ -405,7 +405,7 @@ class TestFailureTypes:
         test_db
     ):
         """Test malformed responses are tracked as failures"""
-        mock_response = AsyncMock()
+        mock_response = MagicMock()  # httpx.Response API is sync
         mock_response.status_code = 200
         mock_response.json.side_effect = ValueError("Invalid JSON")
 

--- a/backend/tests/api/cds_hooks/test_local_provider.py
+++ b/backend/tests/api/cds_hooks/test_local_provider.py
@@ -241,10 +241,13 @@ class TestLocalServiceProvider:
                 return True
 
             async def execute(self, context, prefetch):
+                # source is REQUIRED on a Card per the CDS Hooks spec —
+                # the Card model enforces it.
                 return {
                     "cards": [{
                         "summary": "Dynamic class test",
-                        "indicator": "info"
+                        "indicator": "info",
+                        "source": {"label": "Dynamic Test Service"}
                     }]
                 }
 

--- a/backend/tests/api/cds_hooks/test_remote_provider.py
+++ b/backend/tests/api/cds_hooks/test_remote_provider.py
@@ -36,7 +36,7 @@ class TestRemoteServiceProvider:
         hook_request = CDSHookRequest(**sample_cds_request)
 
         # Mock HTTP response
-        mock_response = AsyncMock()
+        mock_response = MagicMock()  # httpx.Response API is sync
         mock_response.status_code = 200
         mock_response.json.return_value = {
             "cards": [{
@@ -89,7 +89,7 @@ class TestRemoteServiceProvider:
         }
 
         # Mock HTTP response
-        mock_response = AsyncMock()
+        mock_response = MagicMock()  # httpx.Response API is sync
         mock_response.status_code = 200
         mock_response.json.return_value = {"cards": []}
 
@@ -208,7 +208,7 @@ class TestRemoteServiceProvider:
         }
 
         # Mock HTTP success
-        mock_response = AsyncMock()
+        mock_response = MagicMock()  # httpx.Response API is sync
         mock_response.status_code = 200
         mock_response.json.return_value = {"cards": []}
 
@@ -281,7 +281,7 @@ class TestRemoteServiceProvider:
         }
 
         # Mock HTTP response
-        mock_response = AsyncMock()
+        mock_response = MagicMock()  # httpx.Response API is sync
         mock_response.status_code = 200
         mock_response.json.return_value = {"cards": []}
 
@@ -353,7 +353,7 @@ class TestRemoteServiceProvider:
         hook_request = CDSHookRequest(**sample_cds_request)
 
         # Mock malformed response
-        mock_response = AsyncMock()
+        mock_response = MagicMock()  # httpx.Response API is sync
         mock_response.status_code = 200
         mock_response.json.side_effect = ValueError("Invalid JSON")
 
@@ -387,7 +387,7 @@ class TestRemoteServiceProvider:
         hook_request = CDSHookRequest(**sample_cds_request)
 
         # Mock 500 error
-        mock_response = AsyncMock()
+        mock_response = MagicMock()  # httpx.Response API is sync
         mock_response.status_code = 500
         mock_response.text = "Internal Server Error"
 

--- a/backend/tests/api/cds_studio/test_value_set_composer.py
+++ b/backend/tests/api/cds_studio/test_value_set_composer.py
@@ -129,12 +129,18 @@ class TestCreateRequestValidation:
                 codes=[CodeEntry(system="http://x", code="1")],
             )
 
-    def test_rejects_name_with_hyphens(self):
-        with pytest.raises(ValueError):
-            ValueSetCreateRequest(
-                name="diabetes-conditions",  # hyphens not allowed in CQL identifiers
-                codes=[CodeEntry(system="http://x", code="1")],
-            )
+    def test_accepts_name_with_hyphens(self):
+        # Deliberate: CQL valueset declarations take QUOTED identifiers
+        # (`valueset "diabetes-conditions": '...'`), where hyphens — like
+        # spaces — are perfectly legal, and FHIR ValueSet.name is datatype
+        # `string`. The old bare-identifier rule forced PascalCase names that
+        # then mismatched students' naturally-written retrieves. See
+        # _FHIR_NAME_RE in value_set_composer.py.
+        req = ValueSetCreateRequest(
+            name="diabetes-conditions",
+            codes=[CodeEntry(system="http://x", code="1")],
+        )
+        assert req.name == "diabetes-conditions"
 
     def test_accepts_valid_name(self):
         req = ValueSetCreateRequest(

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -153,9 +153,15 @@ def external_plan_definition() -> Dict[str, Any]:
 
 @pytest.fixture
 def sample_cds_request() -> Dict[str, Any]:
-    """Sample CDS Hooks request for testing"""
+    """Sample CDS Hooks request for testing.
+
+    hookInstance is a real UUID — the model enforces the CDS Hooks 2.0 shape.
+    fhirServer is deliberately plain http: this platform's deployments are all
+    http (synthetic data only), and the model accepting it is load-bearing —
+    an unconditional-https validator once 422'd every real hook call.
+    """
     return {
-        "hookInstance": "test-hook-123",
+        "hookInstance": "7c8a1f5e-2d34-4b6a-9e01-3f5b8c7d9a10",
         "fhirServer": "http://localhost:8888/fhir",
         "hook": "patient-view",
         "context": {
@@ -174,7 +180,13 @@ def sample_cds_request() -> Dict[str, Any]:
 
 @pytest.fixture
 def external_service_metadata() -> Dict[str, Any]:
-    """Sample external service metadata for testing"""
+    """Sample external service metadata for testing.
+
+    Mirrors the row the router's SQL actually builds (it computes service_url
+    as base_url || '/cds-services/' || hook_service_id). Tests that want to
+    exercise the provider's base_url-only derivation fallback construct their
+    own dict without service_url.
+    """
     return {
         "id": 1,
         "base_url": "https://example.com/cds",
@@ -182,7 +194,9 @@ def external_service_metadata() -> Dict[str, Any]:
         "credentials_encrypted": "encrypted_api_key_value",
         "auto_disabled": False,
         "consecutive_failures": 0,
-        "last_error_message": None
+        "last_error_message": None,
+        "hook_service_id": "external-diabetes-management",
+        "service_url": "https://example.com/cds/cds-services/external-diabetes-management",
     }
 
 

--- a/frontend/src/services/cdsHooksClient.js
+++ b/frontend/src/services/cdsHooksClient.js
@@ -508,7 +508,9 @@ class CDSHooksClient {
         hook: hookType,
         hookInstance: uuidv4(),
         context,
-        fhirServer: window.location.origin + '/fhir/R4'
+        // The HAPI proxy is mounted at /fhir (not /fhir/R4). http is fine —
+        // this platform's deployments are http and the backend accepts it.
+        fhirServer: window.location.origin + '/fhir'
       };
       
       if (prefetch) {

--- a/frontend/src/services/cdsHooksService.js
+++ b/frontend/src/services/cdsHooksService.js
@@ -3,6 +3,7 @@
  * Handles CRUD operations for custom CDS hooks
  */
 import axios from 'axios';
+import { v4 as uuidv4 } from 'uuid';
 import { getBackendUrl, getBackendApiUrl, getCdsHooksServicesUrl } from '../config/apiConfig';
 
 class CDSHooksService {
@@ -888,7 +889,9 @@ class CDSHooksService {
       // Create test request
       const testRequest = {
         hook: serviceData.hook,
-        hookInstance: `test-${Date.now()}`,
+        // hookInstance must be a real UUID — the backend enforces the CDS Hooks
+        // 2.0 shape and 422s anything else, which used to break this test flow.
+        hookInstance: uuidv4(),
         context: {
           patientId: testContext.patientId || 'test-patient-123',
           userId: testContext.userId || 'test-user-456',


### PR DESCRIPTION
The entire remaining backend failure budget was one cluster: CDS Hooks (39 tests) + 1 composer test. Working through it surfaced **four real product bugs**, not just stale tests.

## Live bugs fixed

**1. The `fhirServer` validator 422'd every http deployment.** The frontend sends `fhirServer: window.location.origin`, and every deployment of this platform — localhost dev, wintehrdev — is plain http. So any hook call that included `fhirServer` was rejected before reaching a service. CDS Hooks 2.0 requires https only *"when production data is exchanged"*; this platform is synthetic-only by charter. Now accepts http(s), rejects other schemes. (`hookInstance` stays strict-UUID — that is the spec shape — and the CDS Studio test flow now sends `uuidv4()` instead of `test-${Date.now()}`, which could never pass.)

**2. `LocalServiceProvider` never awaited async services.** The canonical `CDSService.execute` **is** `async` (`base_service.py`), so any async service dispatched down the legacy path logged `Unexpected return type: <class 'coroutine'>` and silently produced zero cards. It also never called the `should_execute()` gate, so gated services fired unconditionally. Both fixed.

**3. `RemoteServiceProvider` auth was dead code, and its HTTP client leaked.** `_prepare_auth_headers` read an `auth_config` key **no caller ever passes** — production supplies `auth_type` + Fernet-encrypted `credentials_encrypted`. External-service auth silently never attached. Now reads the real columns (api_key → `X-API-Key`, oauth2 → `Bearer`, hmac → `X-HMAC-Signature`). The per-instance httpx client was never closed (the router constructs a provider per request and never called `close()`) — now one client per call in `async with`. Also: serializes `fhirAuthorization` before JSON encoding (crashed if ever supplied), and derives the endpoint from `base_url + /cds-services/ + hook_service_id` when `service_url` is absent (the spec shape).

**4. Discovery 500'd when HAPI was down.** `HAPIFHIRClient` wraps transport failures in generic `Exception`, which discovery didn't catch — a dead HAPI took down the **in-process built-in services that need no HAPI at all**. Now degrades to registry-only.

Both providers now share one contract, recorded in `cds_hooks/CLAUDE.md`: **execute() never raises** — failures log, track (remote: failure counters + auto-disable at 5), and return empty cards. CDS is advisory; a dead service must not 500 a clinician-facing response.

## Frontend

- `cdsHooksClient` sends `fhirServer` as `origin + '/fhir'` — the proxy mount; `/fhir/R4` was wrong.
- CDS Studio test flow sends a real UUID.

## Test updates (matching reality, with reasons in-line)

- Response mocks are `MagicMock` — `httpx.Response` is a **sync** API; `AsyncMock` made `.json()` a coroutine so no assertion ever saw the payload.
- Router tests configure `mock.read` — unconfigured, every execution test iterated a coroutine and never exercised its branch.
- Patch targets fixed: `backend.api...` (package root doesn't exist) and a logging patch aimed at a module *and* function that never existed.
- Discovery assertions are set-membership, not exact counts — discovery **merges** the in-process registry with HAPI, so exact counts coupled tests to registry size.
- Hyphenated ValueSet names accepted per the documented deliberate loosening (CQL quoted identifiers allow them).

## Result

| | failed | errors | passed |
|---|---|---|---|
| session start | 44 | 29 | 371 |
| this PR | **0** | **0** | **440** |

CI backend gate ratcheted to a **hard zero** (failed<=0, errors<=0, passed>=440, outcomes>=445). Frontend suite verified byte-identical failing set vs master; build passes.

Docs: root CLAUDE.md Python 3.9+ → 3.12 (Dockerfiles + CI pin 3.12); cds_hooks CLAUDE.md records the provider failure contract and request-validation rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)