### PR TITLE
fix(frontend): recover the two CDS test suites (+38); fix container healthcheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,13 +82,13 @@ jobs:
         # be a hard gate yet. Report the count; the test baseline below is the
         # enforced bar. Ratchet toward a hard gate as the backlog shrinks.
         run: npx eslint src -f compact 2>&1 | tail -1 || true
-      - name: "vitest (baseline: 104 failed / 561 total)"
+      - name: "vitest (baseline: 66 failed / 561 total)"
         run: |
-          # Baseline 104 failed of 561 under Vitest. Vitest collects more than
-          # CRA/jest did because two suites jest could not even collect now run
-          # — cdsHooksClient.parallel (6, all pass) and QueryStudioEnhanced
-          # (19, a known-broken suite tracked for fix/removal). The failure
-          # count rose only because more tests execute.
+          # Baseline 66 failed of 561. The remaining failures are: the
+          # unfinished medication consolidation layer (37, tracked for
+          # finish-or-delete adjudication), QueryStudioEnhanced (18,
+          # known-broken suite tracked for fix/removal), ServiceSelector (6),
+          # UIComposer (3), ErrorBoundary (2).
           #
           # numTotalTests is the counterpart to the backend's OUTCOMES check:
           # it catches tests that stop running, which a failure-count gate
@@ -98,8 +98,8 @@ jobs:
           npx vitest run --reporter=json --outputFile=vitest.json > vitest.out 2>&1 || true
           node -e "
             const r = require('./vitest.json');
-            console.log(r.numTotalTests + ' tests, ' + r.numFailedTests + ' failed, ' + r.numPassedTests + ' passed (baseline: failed<=104, total>=561, passed>=448)');
-            if (r.numFailedTests > 104 || r.numTotalTests < 561 || r.numPassedTests < 448) {
-              console.error('::error::Test results regressed past the baseline (failed<=104, total>=561, passed>=448)');
+            console.log(r.numTotalTests + ' tests, ' + r.numFailedTests + ' failed, ' + r.numPassedTests + ' passed (baseline: failed<=66, total>=561, passed>=495)');
+            if (r.numFailedTests > 66 || r.numTotalTests < 561 || r.numPassedTests < 495) {
+              console.error('::error::Test results regressed past the baseline (failed<=66, total>=561, passed>=495)');
               process.exit(1);
             }"

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -45,8 +45,11 @@ RUN chmod -R 644 /usr/share/nginx/html/* && \
 EXPOSE 80
 
 # Health check
+# 127.0.0.1 explicitly: alpine resolves `localhost` to ::1 first, but nginx
+# here binds IPv4 only — the old probe failed and the container sat
+# "unhealthy" forever while serving fine. /health is the nginx stub route.
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD wget --no-verbose --tries=1 --spider http://localhost || exit 1
+    CMD wget --no-verbose --tries=1 --spider http://127.0.0.1/health || exit 1
 
 # Start nginx
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/src/services/__tests__/cdsHooksClient.test.js
+++ b/frontend/src/services/__tests__/cdsHooksClient.test.js
@@ -5,10 +5,20 @@
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import { cdsHooksClient } from '../cdsHooksClient';
+import { cdsPrefetchResolver } from '../cdsPrefetchResolver';
 import { v4 as uuidv4 } from 'uuid';
 
-// Create mock adapter
-const mock = new MockAdapter(axios);
+// The prefetch resolver reaches for the real FHIR client — in tests that's a
+// live network call that hangs to the 30s axios timeout and blows the 5s test
+// budget. Hooks under test only need it to resolve fast.
+vi.spyOn(cdsPrefetchResolver, 'resolvePrefetchTemplates').mockResolvedValue({});
+vi.spyOn(cdsPrefetchResolver, 'buildCommonPrefetch').mockResolvedValue({});
+
+// Mock the CLIENT'S OWN axios instance. The client builds a private
+// instance via axios.create(), so an adapter on the global `axios` export
+// intercepts nothing — every request passed through and failed, and the
+// client's graceful degradation turned each test into `[]`.
+const mock = new MockAdapter(cdsHooksClient.httpClient);
 
 describe('CDSHooksClient', () => {
   beforeEach(() => {

--- a/frontend/src/services/__tests__/cdsHooksCompliance.test.js
+++ b/frontend/src/services/__tests__/cdsHooksCompliance.test.js
@@ -2,7 +2,10 @@
  * CDS Hooks Compliance Test Suite
  * Tests to ensure our implementation follows CDS Hooks 1.0 specification
  */
-import { CDSHooksClientSpec } from '../cdsHooksClient.spec';
+// Default import: the module default-exports the class (plus a lowercase
+// singleton). The old named import resolved to undefined under real ESM —
+// every test in this suite failed at `new undefined()` in beforeEach.
+import CDSHooksClientSpec from '../cdsHooksClient.spec';
 import { cdsHooksService } from '../cdsHooksService';
 import { validateCDSService } from '../../models/cdsService';
 
@@ -35,9 +38,11 @@ describe('CDS Hooks 1.0 Specification Compliance', () => {
       vi.spyOn(client.client, 'get').mockResolvedValue(mockResponse);
 
       const result = await client.discoverServices();
-      
+
       expect(client.client.get).toHaveBeenCalledWith('/cds-services');
-      expect(result).toEqual(mockResponse.data.services);
+      // The spec's discovery response body IS {"services": [...]} — the
+      // client returns the wire shape.
+      expect(result).toEqual(mockResponse.data);
     });
 
     it('should handle empty service list', async () => {
@@ -45,8 +50,8 @@ describe('CDS Hooks 1.0 Specification Compliance', () => {
       vi.spyOn(client.client, 'get').mockResolvedValue(mockResponse);
 
       const result = await client.discoverServices();
-      
-      expect(result).toEqual([]);
+
+      expect(result).toEqual({ services: [] });
     });
   });
 
@@ -197,7 +202,7 @@ describe('CDS Hooks 1.0 Specification Compliance', () => {
       };
 
       const result = validateCDSService(validService);
-      expect(result.isValid).toBe(true);
+      expect(result.valid).toBe(true);
       expect(result.errors).toHaveLength(0);
     });
 
@@ -210,9 +215,9 @@ describe('CDS Hooks 1.0 Specification Compliance', () => {
       };
 
       const result = validateCDSService(invalidService);
-      expect(result.isValid).toBe(false);
-      expect(result.errors).toContain('hook is required');
-      expect(result.errors).toContain('description is required');
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('Hook type is required');
+      expect(result.errors).toContain('Service description is required');
     });
 
     it('should validate hook type', () => {
@@ -224,8 +229,8 @@ describe('CDS Hooks 1.0 Specification Compliance', () => {
       };
 
       const result = validateCDSService(invalidHook);
-      expect(result.isValid).toBe(false);
-      expect(result.errors).toContain('Invalid hook type: invalid-hook-type');
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.startsWith('Invalid hook type'))).toBe(true);
     });
 
     it('should validate prefetch templates', () => {
@@ -241,7 +246,10 @@ describe('CDS Hooks 1.0 Specification Compliance', () => {
       };
 
       const result = validateCDSService(service);
-      expect(result.warnings).toContain('Prefetch template "invalid" may be invalid');
+      // A template with no {{context}} token and no FHIR-query shape is an
+      // ERROR in the model (there is no warnings channel here).
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes("Prefetch template 'invalid'"))).toBe(true);
     });
   });
 
@@ -325,8 +333,8 @@ describe('CDS Hooks 1.0 Specification Compliance', () => {
       };
 
       const validation = cdsHooksService.validateServiceData(service);
-      expect(validation.warnings).toContain(
-        expect.stringContaining('Summary is quite long')
+      expect(validation.warnings).toEqual(
+        expect.arrayContaining([expect.stringContaining('Summary is quite long')])
       );
     });
   });


### PR DESCRIPTION
Pre-deploy sweep. Three infrastructure defects made 38 CDS tests fail without testing anything.

## 1. cdsHooksCompliance (23 → 0 failures)

`import { CDSHooksClientSpec }` — but the module **default**-exports the class. Under real ESM the named import is `undefined`, so all 23 tests died at `new undefined()` in `beforeEach`. With that fixed, 7 tests needed aligning to real contracts:

- the spec client returns the discovery **wire shape** `{services: [...]}` (that IS the CDS Hooks response body);
- `validateCDSService` returns `{valid, errors}` with its actual message strings — the tests asserted an aspirational `isValid`/`warnings` API that never existed;
- `toContain(expect.stringContaining(...))` never worked — asymmetric matchers need `arrayContaining`.

## 2. cdsHooksClient (15 → 0 failures)

The suite mocked the **global** axios export; the client builds its own instance via `axios.create()`. The adapter intercepted nothing → every request hit the real network → the client's graceful degradation turned each test into `[]`. The adapter now targets `cdsHooksClient.httpClient`. One test also stubs the prefetch resolver, which otherwise reaches the real FHIR client and hangs past the test timeout. **This suite covers the live CDS dispatch path**, so it's real coverage recovered ahead of the wintehrdev deploy.

## 3. Frontend container healthcheck

Probed `http://localhost` — alpine resolves that to `::1`, nginx binds IPv4 only, so `emr-frontend` sat **unhealthy forever while serving fine** (long-standing cosmetic issue on wintehrdev). Now probes `http://127.0.0.1/health`, the nginx stub route that already existed.

## Result

Frontend suite **104 failed → 66** (passed 457 → 495), byte-stable across runs; CI gate ratcheted to failed≤66 / total≥561 / passed≥495.

Remaining 66, all accounted for: unfinished medication consolidation layer (37 — **dead code** behind an off-by-default flag with zero real callers; the old services still serve production; tracked for a finish-or-delete adjudication), QueryStudioEnhanced (18, known-broken), ServiceSelector (6), UIComposer (3), ErrorBoundary (2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)