### PR TITLE
build(deps): react-router-dom 6.30 → 7.18

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -40,7 +40,7 @@
         "react-grid-layout": "^1.5.2",
         "react-hotkeys-hook": "^4.6.2",
         "react-markdown": "^10.1.0",
-        "react-router-dom": "^6.30.4",
+        "react-router-dom": "^7.18.0",
         "react-syntax-highlighter": "^16.1.1",
         "react-transition-group": "^4.4.5",
         "recharts": "^3.10.1",
@@ -3998,15 +3998,6 @@
       "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
     },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
-      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
@@ -6423,6 +6414,19 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/core-js-compat": {
       "version": "3.44.0",
@@ -11560,35 +11564,41 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
-      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
-      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3",
-        "react-router": "6.30.4"
+        "react-router": "7.18.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/react-syntax-highlighter": {
@@ -12184,6 +12194,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,7 +35,7 @@
     "react-grid-layout": "^1.5.2",
     "react-hotkeys-hook": "^4.6.2",
     "react-markdown": "^10.1.0",
-    "react-router-dom": "^6.30.4",
+    "react-router-dom": "^7.18.0",
     "react-syntax-highlighter": "^16.1.1",
     "react-transition-group": "^4.4.5",
     "recharts": "^3.10.1",

--- a/frontend/src/router/router.js
+++ b/frontend/src/router/router.js
@@ -178,14 +178,7 @@ export const router = createBrowserRouter([
     path: '*',
     element: page(<NotFound />)
   }
-], {
-  // Enable future flags to prevent deprecation warnings
-  future: {
-    v7_startTransition: true,
-    v7_relativeSplatPath: true,
-    v7_fetcherPersist: true,
-    v7_normalizeFormMethod: true,
-    v7_partialHydration: true,
-    v7_skipActionErrorRevalidation: true
-  }
-});
+]);
+// (The v6 `future` block is gone: every v7_* flag it enabled is simply the
+// default behavior in React Router 7, which is why this upgrade was safe —
+// the app had been running v7 semantics on v6 since the flags went on.)


### PR DESCRIPTION
First Phase-2 item. Clears the two advisories that **apply** to this app — the open redirect via backslash in `Link`/`useNavigate` (CVE-2025-68470 bypass) and the `deserializeErrors` constructor injection — both fixed in 7.18.0, with **no fix inside the v6 line**.

## Why it's near-mechanical

`router.js` already had **all six `v7_*` future flags enabled**, so the app has been running v7 semantics on v6 for months. The usage surface is hooks (`useNavigate` ×24, `useParams`, `useLocation`, `useSearchParams`), `Navigate`/`Link`, and `createBrowserRouter`+`RouterProvider` — no loaders, no actions, no fetchers, no `<Form>`. The `future` block is deleted: every flag it set is the v7 default.

## Known and accepted: the RSC advisory

npm audit flags GHSA-qwww-vcr4-c8h2 (RSC-mode CSRF, affects 7.12.0–8.2.0, **no 7.x fix**) against this version — and its suggested "fix" is downgrading to 7.11.0, which would *reintroduce* the open-redirect CVE that actually applies here. The RSC advisory's surface is React Server Components / framework-mode server actions; this app is a client-only SPA with a data-less browser router, so the vulnerable path doesn't exist. If dependabot raises it, dismiss as *vulnerable code not in use*.

## Verification

- **517/517 tests pass** under v7 (both gates are hard zeros now, so this is a strong signal)
- `vite build` clean; no v6 remnants in the lockfile
- react-router core resolves to 7.18.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)