### PR TITLE
refactor(auth): drop passlib, use bcrypt directly; unblock bcrypt 5

### DIFF
--- a/backend/api/auth/jwt_handler.py
+++ b/backend/api/auth/jwt_handler.py
@@ -4,23 +4,38 @@ JWT token handling utilities
 
 from datetime import datetime, timedelta
 from typing import Optional, Dict, Any
+import bcrypt
 import jwt
-from passlib.context import CryptContext
 
 from .config import JWT_SECRET_KEY, JWT_ALGORITHM, JWT_ACCESS_TOKEN_EXPIRE_DELTA
 
-# Password hashing context
-pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+# Direct bcrypt, not passlib. passlib 1.7.4 (its final release, 2020) reads
+# bcrypt.__about__.__version__, which bcrypt 5.0 removed — failing that probe
+# silently enabled a $2$ workaround bcrypt then rejected, so every login died
+# on any modern bcrypt (see the near-miss recorded in
+# tests/api/auth/test_password_hashing.py). bcrypt's own API is two calls.
+
+
+def _truncate(password: str) -> bytes:
+    # bcrypt only reads the first 72 bytes; 5.x raises on longer input rather
+    # than truncating silently. Truncate explicitly so behavior is identical
+    # to the passlib era and long passphrases keep verifying against their
+    # stored hashes.
+    return password.encode("utf-8")[:72]
 
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
-    """Verify a password against its hash"""
-    return pwd_context.verify(plain_password, hashed_password)
+    """Verify a password against its bcrypt hash"""
+    try:
+        return bcrypt.checkpw(_truncate(plain_password), hashed_password.encode("utf-8"))
+    except ValueError:
+        # Malformed/non-bcrypt stored hash — treat as non-matching, never 500.
+        return False
 
 
 def get_password_hash(password: str) -> str:
-    """Hash a password"""
-    return pwd_context.hash(password)
+    """Hash a password with bcrypt (unique salt per call)"""
+    return bcrypt.hashpw(_truncate(password), bcrypt.gensalt()).decode("utf-8")
 
 
 def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -33,9 +33,10 @@ psutil==5.9.6
 
 # Security
 python-jose[cryptography]==3.5.0
-passlib[bcrypt]==1.7.4
 python-multipart==0.0.32
-bcrypt==4.1.2
+# Used directly (api/auth/jwt_handler.py) — passlib was dropped: unmaintained
+# since 2020 and permanently incompatible with bcrypt >= 5.
+bcrypt==5.0.0
 PyJWT==2.13.0
 
 # Development tools


### PR DESCRIPTION
Second Phase-2 item — removes the dead-end dependency in the auth path.

## Why

passlib 1.7.4 is its **final release** (2020, unmaintained) and permanently incompatible with bcrypt ≥ 5: it probes `bcrypt.__about__.__version__` (removed in 5.0) and, failing that, silently enables a `$2$` workaround bcrypt 5 rejects — every login died with a spurious 72-byte `ValueError`. That near-miss (dependabot #241) is recorded in `tests/api/auth/test_password_hashing.py`, which is exactly the safety net this change runs against.

## What

`CryptContext` → bcrypt's own two-call API in the single call site (`jwt_handler.py`). The 72-byte truncation is now **explicit** (bcrypt 5 raises on longer input rather than truncating), matching passlib-era behavior so long passphrases keep verifying against their stored hashes. Malformed stored hashes verify as `False` instead of raising. `passlib[bcrypt]` removed from requirements; **bcrypt pinned at 5.0.0** — the upgrade #241 attempted, finally safe.

## Verification

- **Cross-era compatibility**: a hash generated by the old stack (passlib 1.7.4 + bcrypt 4.1.2) verifies under the new code — stored demo credentials keep working
- Wrong password → `False`; malformed hash → `False` (never a 500)
- New hashes are standard `$2b$` with unique salts
- Full suite: **440 / 440, 0 errors** from a clean requirements-only venv (passlib genuinely absent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)