### PR TITLE
build(deps): brace-expansion 1.1.13 → 1.1.16 (in-range)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4307,9 +4307,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Clears the last *fixable* dependabot alert (GHSA-3jxr, exponential-time expansion — patched at 1.1.16 in the 1.x line).

`minimatch@3` under `eslint-plugin-import` accepts `^1.1.7`; the vulnerable 1.1.13 was a stale resolution, so a targeted `npm update brace-expansion` suffices — **lockfile-only, 3 lines**. No override: a blanket brace-expansion override was tried earlier in the session and makes npm re-attribute the no-fix advisory across the whole dev tree.

517/517 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)