### PR TITLE
fix(frontend): surface the silent catches — E2 sweep, slices 1+2

### DIFF
--- a/frontend/src/components/EditableModal.js
+++ b/frontend/src/components/EditableModal.js
@@ -84,7 +84,8 @@ const EditableModal = ({
           setFormData({
             patient_id: patientId,
             encounter_id: encounterId,
-            // observation_type: 'laboratory', // Field is null in current dataset
+            // observation_type: 'laboratory',
+            // Field is null in current dataset
             code: '',
             display: '',
             value: '',

--- a/frontend/src/components/EditableModal.js
+++ b/frontend/src/components/EditableModal.js
@@ -47,7 +47,7 @@ const EditableModal = ({
       const response = await api.get('/api/providers');
       setProviders(response.data);
     } catch (err) {
-      
+      console.warn('Failed to load providers; provider dropdown will be empty:', err);
     }
   };
 

--- a/frontend/src/components/EncounterDetail.js
+++ b/frontend/src/components/EncounterDetail.js
@@ -143,7 +143,7 @@ const EncounterDetail = ({
         provider: providerResponse.data
       });
     } catch (error) {
-      
+      console.error('Failed to load encounter details:', error);
     } finally {
       setLoading(false);
     }

--- a/frontend/src/components/clinical/appointments/AppointmentsTab.js
+++ b/frontend/src/components/clinical/appointments/AppointmentsTab.js
@@ -68,7 +68,7 @@ function AppointmentsTab() {
         setPatientAppointments(result.appointments);
       }
     } catch (error) {
-      
+      console.warn('Failed to load patient appointments:', error);
     }
   };
 
@@ -104,7 +104,7 @@ function AppointmentsTab() {
         await cancelAppointment(appointment.id, 'Cancelled from clinical workspace');
         await loadPatientAppointments(); // Refresh the list
       } catch (error) {
-        
+        console.error('Failed to cancel appointment — it is still scheduled:', error);
       }
     }
   };

--- a/frontend/src/components/clinical/cds/CDSDocumentationPrompts.js
+++ b/frontend/src/components/clinical/cds/CDSDocumentationPrompts.js
@@ -79,6 +79,7 @@ const CDSDocumentationPrompts = ({
 
     } catch (error) {
       // Failed to generate documentation prompts
+      console.warn('Failed to generate documentation prompts:', error);
     }
   }, [cdsAlerts, patientId, encounterId]);
 
@@ -109,6 +110,7 @@ const CDSDocumentationPrompts = ({
 
     } catch (error) {
       // Failed to create note from prompt
+      console.warn('Failed to create note from prompt:', error);
     }
   }, [onCreateNote, publish, patientId, encounterId]);
 

--- a/frontend/src/components/clinical/dashboard/PatientSummaryV4.js
+++ b/frontend/src/components/clinical/dashboard/PatientSummaryV4.js
@@ -96,6 +96,7 @@ const PatientSummaryV4 = ({ patientId, department = 'general' }) => {
               });
             } catch (everythingError) {
               // Both methods failed, but continue anyway
+              console.warn('Both methods failed, but continue anyway:', everythingError);
             }
           }
         }

--- a/frontend/src/components/clinical/documentation/ClinicalCrossReferences.js
+++ b/frontend/src/components/clinical/documentation/ClinicalCrossReferences.js
@@ -103,6 +103,7 @@ const ClinicalCrossReferences = ({
       setRelatedData(related);
     } catch (error) {
       // Error loading cross-references - component will handle gracefully
+      console.warn('Error loading cross-references - component will handle gracefully:', error);
     } finally {
       setLoading(false);
     }

--- a/frontend/src/components/clinical/documentation/DocumentationTab.js
+++ b/frontend/src/components/clinical/documentation/DocumentationTab.js
@@ -102,7 +102,7 @@ const DocumentationTab = () => {
       
       setEncounterNotes(notesFromEncounters);
     } catch (error) {
-      
+      console.warn('Failed to derive notes from encounters:', error);
     }
   };
 

--- a/frontend/src/components/clinical/documentation/ProblemMedicationLinker.js
+++ b/frontend/src/components/clinical/documentation/ProblemMedicationLinker.js
@@ -76,6 +76,7 @@ const ProblemMedicationLinker = ({
       setSummary(summaryData);
     } catch (error) {
       // Error loading clinical documentation data - component will handle gracefully
+      console.warn('Error loading clinical documentation data - component will handle gracefully:', error);
     } finally {
       setLoading(false);
     }
@@ -114,6 +115,7 @@ const ProblemMedicationLinker = ({
 
     } catch (error) {
       // Error creating problem documentation - handled by parent components
+      console.warn('Error creating problem documentation - handled by parent components:', error);
     }
   }, [patientId, encounterId, publish, onCreateDocumentation, loadClinicalData]);
 
@@ -150,6 +152,7 @@ const ProblemMedicationLinker = ({
 
     } catch (error) {
       // Error creating medication documentation - handled by parent components
+      console.warn('Error creating medication documentation - handled by parent components:', error);
     }
   }, [patientId, encounterId, publish, onCreateDocumentation, loadClinicalData]);
 

--- a/frontend/src/components/clinical/inbox/InboxTab.js
+++ b/frontend/src/components/clinical/inbox/InboxTab.js
@@ -52,7 +52,7 @@ const InboxTab = () => {
     try {
       await markInboxItemRead(itemId);
     } catch (error) {
-      
+      console.error('Failed to mark inbox item read:', error);
     }
   };
 
@@ -61,7 +61,7 @@ const InboxTab = () => {
       // For now, just mark as completed since FHIR doesn't support delete
       await markInboxItemRead(itemId);
     } catch (error) {
-      
+      console.error('Failed to complete inbox item:', error);
     }
   };
 

--- a/frontend/src/components/clinical/medications/ClinicalSafetyPanel.js
+++ b/frontend/src/components/clinical/medications/ClinicalSafetyPanel.js
@@ -118,6 +118,7 @@ const ClinicalSafetyPanel = ({ patientId, medications = [], onRefresh }) => {
       }
     } catch (error) {
       // Error running safety verification - handle gracefully
+      console.warn('Error running safety verification - handle gracefully:', error);
     } finally {
       setLoading(false);
       // Remove from active requests

--- a/frontend/src/components/clinical/medications/EffectivenessMonitoringPanel.js
+++ b/frontend/src/components/clinical/medications/EffectivenessMonitoringPanel.js
@@ -113,6 +113,7 @@ const EffectivenessMonitoringPanel = ({ patientId, medications = [], onRefresh }
               promptsMap.set(medication.id, prompts);
             } catch (error) {
               // Skip failed medication prompt loading
+              console.warn('Skip failed medication prompt loading:', error);
             }
           })
       );
@@ -129,6 +130,7 @@ const EffectivenessMonitoringPanel = ({ patientId, medications = [], onRefresh }
 
     } catch (error) {
       // Failed to load effectiveness data
+      console.warn('Failed to load effectiveness data:', error);
     } finally {
       setLoading(false);
       // Remove from active requests
@@ -146,6 +148,7 @@ const EffectivenessMonitoringPanel = ({ patientId, medications = [], onRefresh }
       setAssessmentDialogOpen(true);
     } catch (error) {
       // Failed to start assessment
+      console.warn('Failed to start assessment:', error);
     }
   };
 

--- a/frontend/src/components/clinical/medications/MedicationDiscontinuationDialog.js
+++ b/frontend/src/components/clinical/medications/MedicationDiscontinuationDialog.js
@@ -258,6 +258,7 @@ const MedicationDiscontinuationDialog = ({
       onClose();
     } catch (error) {
       // Error discontinuing medication - handle gracefully
+      console.warn('Error discontinuing medication - handle gracefully:', error);
     } finally {
       setLoading(false);
     }

--- a/frontend/src/components/clinical/medications/MedicationEffectivenessDialog.js
+++ b/frontend/src/components/clinical/medications/MedicationEffectivenessDialog.js
@@ -134,6 +134,7 @@ const MedicationEffectivenessDialog = ({
       onClose();
     } catch (error) {
       // Error submitting assessment - handle gracefully
+      console.warn('Error submitting assessment - handle gracefully:', error);
     } finally {
       setLoading(false);
     }

--- a/frontend/src/components/clinical/medications/WorkflowValidationPanel.js
+++ b/frontend/src/components/clinical/medications/WorkflowValidationPanel.js
@@ -113,6 +113,7 @@ const WorkflowValidationPanel = ({ patientId, medications = [], onRefresh }) => 
       }
     } catch (error) {
       // Error running workflow validation - handle gracefully
+      console.warn('Error running workflow validation - handle gracefully:', error);
     } finally {
       setLoading(false);
       // Remove from active requests
@@ -137,6 +138,7 @@ const WorkflowValidationPanel = ({ patientId, medications = [], onRefresh }) => 
       }
     } catch (error) {
       // Error auto-fixing issues - handle gracefully
+      console.warn('Error auto-fixing issues - handle gracefully:', error);
     } finally {
       setAutoFixing(false);
     }

--- a/frontend/src/components/clinical/orders/OrderCatalogSelector.js
+++ b/frontend/src/components/clinical/orders/OrderCatalogSelector.js
@@ -99,7 +99,7 @@ const OrderCatalogSelector = ({ orderType, onSelect, value }) => {
       
       setAvailableFilters(filterData);
     } catch (error) {
-      
+      console.warn('Failed to load order catalog filters:', error);
     }
   };
 

--- a/frontend/src/components/clinical/quality/QualityMeasurePrompts.js
+++ b/frontend/src/components/clinical/quality/QualityMeasurePrompts.js
@@ -95,6 +95,7 @@ const QualityMeasurePrompts = ({
       setQualityStatus(status);
     } catch (error) {
       // Failed to load quality measure prompts
+      console.warn('Failed to load quality measure prompts:', error);
     } finally {
       setLoading(false);
     }
@@ -134,6 +135,7 @@ const QualityMeasurePrompts = ({
       
     } catch (error) {
       // Failed to create quality measure note
+      console.warn('Failed to create quality measure note:', error);
     } finally {
       setCreating(false);
     }

--- a/frontend/src/components/clinical/results/CriticalValueAlert.js
+++ b/frontend/src/components/clinical/results/CriticalValueAlert.js
@@ -238,6 +238,7 @@ const CriticalValueAlert = ({
       onClose();
     } catch (error) {
       // Error handled silently, acknowledgment button returns to normal state
+      console.warn('Error handled silently, acknowledgment button returns to normal state:', error);
     } finally {
       setAcknowledging(false);
     }

--- a/frontend/src/components/clinical/results/FacilityResultManager.js
+++ b/frontend/src/components/clinical/results/FacilityResultManager.js
@@ -153,6 +153,7 @@ const FacilityResultManager = ({
 
     } catch (error) {
       // Error loading lab facilities - component will show empty state
+      console.warn('Error loading lab facilities - component will show empty state:', error);
     } finally {
       setLoading(false);
     }
@@ -199,6 +200,7 @@ const FacilityResultManager = ({
         onResultsUpdate(results);
       } catch (error) {
         // Error filtering by facility - keeping current results
+        console.warn('Error filtering by facility - keeping current results:', error);
       } finally {
         setLoading(false);
       }

--- a/frontend/src/components/clinical/results/LabMonitoringDashboard.js
+++ b/frontend/src/components/clinical/results/LabMonitoringDashboard.js
@@ -89,6 +89,7 @@ const LabMonitoringDashboard = ({ patientId, patientConditions }) => {
       
     } catch (error) {
       // Error handled silently, component shows loading state
+      console.warn('Error handled silently, component shows loading state:', error);
     } finally {
       setLoading(false);
     }
@@ -248,6 +249,7 @@ const LabMonitoringDashboard = ({ patientId, patientConditions }) => {
       
     } catch (error) {
       // Error handled silently, button returns to normal state
+      console.warn('Error handled silently, button returns to normal state:', error);
     }
   };
 

--- a/frontend/src/components/clinical/results/ProviderAccountabilityPanel.js
+++ b/frontend/src/components/clinical/results/ProviderAccountabilityPanel.js
@@ -96,6 +96,7 @@ const ProviderAccountabilityPanel = ({
       setProviderResults(resultCounts);
     } catch (error) {
       // Error loading patient providers - component will show empty state
+      console.warn('Error loading patient providers - component will show empty state:', error);
     } finally {
       setLoading(false);
     }
@@ -129,6 +130,7 @@ const ProviderAccountabilityPanel = ({
         onResultsUpdate(results);
       } catch (error) {
         // Error filtering by provider - keeping current results
+        console.warn('Error filtering by provider - keeping current results:', error);
       } finally {
         setLoading(false);
       }
@@ -152,6 +154,7 @@ const ProviderAccountabilityPanel = ({
       onResultsUpdate(results);
     } catch (error) {
       // Error filtering by provider type - keeping current results
+      console.warn('Error filtering by provider type - keeping current results:', error);
     } finally {
       setLoading(false);
     }

--- a/frontend/src/components/clinical/results/ResultTrendAnalysis.js
+++ b/frontend/src/components/clinical/results/ResultTrendAnalysis.js
@@ -115,6 +115,7 @@ const ResultTrendAnalysis = ({ patientId, initialTestCode = null }) => {
       calculateStatistics(formattedData);
     } catch (error) {
       // Error handled silently, component shows loading state
+      console.warn('Error handled silently, component shows loading state:', error);
     } finally {
       setLoading(false);
     }

--- a/frontend/src/components/clinical/shared/layout/QuickActionsBar.js
+++ b/frontend/src/components/clinical/shared/layout/QuickActionsBar.js
@@ -300,6 +300,7 @@ const QuickActionsBar = ({
         setRecentActions(JSON.parse(saved));
       } catch (e) {
         // Invalid data
+        console.warn('Invalid data:', e);
       }
     }
   }, []);

--- a/frontend/src/components/clinical/timeline/FHIRResourceTimeline.js
+++ b/frontend/src/components/clinical/timeline/FHIRResourceTimeline.js
@@ -341,7 +341,7 @@ const FHIRResourceTimeline = ({ patientId, height = '600px' }) => {
             
             allResources.push(...typedResources);
           } catch (err) {
-            
+            console.warn('Timeline: failed to load one resource type; continuing without it:', err);
           }
         }
 

--- a/frontend/src/components/clinical/workspace/cds/CDSHooksVerifier.js
+++ b/frontend/src/components/clinical/workspace/cds/CDSHooksVerifier.js
@@ -90,7 +90,7 @@ const CDSHooksVerifier = () => {
       const discoveredServices = await cdsHooksClient.discoverServices();
       setServices(discoveredServices);
     } catch (error) {
-      
+      console.warn('CDS service discovery failed:', error);
     }
   };
 
@@ -99,7 +99,7 @@ const CDSHooksVerifier = () => {
       const result = await searchResources('Patient', { _count: 50 });
       setPatients(result.resources || []);
     } catch (error) {
-      
+      console.warn('Failed to load patients for CDS verification:', error);
     }
   };
 
@@ -240,7 +240,7 @@ const CDSHooksVerifier = () => {
         }
       }
     } catch (error) {
-      
+      console.error('CDS verification run failed:', error);
     } finally {
       setLoading(false);
     }

--- a/frontend/src/components/clinical/workspace/cds/SuggestionBuilder.js
+++ b/frontend/src/components/clinical/workspace/cds/SuggestionBuilder.js
@@ -262,6 +262,7 @@ const SuggestionBuilder = ({ suggestions = [], onChange }) => {
                           updateAction(suggestion.id, action.id, { resource: parsed });
                         } catch (err) {
                           // Invalid JSON, don't update
+                          console.warn('Invalid JSON, don\'t update:', err);
                         }
                       }}
                       sx={{

--- a/frontend/src/components/clinical/workspace/components/EnhancedProviderDisplay.js
+++ b/frontend/src/components/clinical/workspace/components/EnhancedProviderDisplay.js
@@ -55,6 +55,7 @@ const EnhancedProviderDisplay = ({ encounter, compact = false, showActions = fal
           setProviderDetails(profile);
         } catch (err) {
           // Failed to load provider profile - will show basic info only
+          console.warn('Failed to load provider profile - will show basic info only:', err);
         } finally {
           setLoadingProfile(false);
         }

--- a/frontend/src/components/clinical/workspace/components/GeographicTimelineFilter.js
+++ b/frontend/src/components/clinical/workspace/components/GeographicTimelineFilter.js
@@ -84,6 +84,7 @@ const GeographicTimelineFilter = ({
       }
     } catch (error) {
       // Error loading nearby providers - geographic filter will be unavailable
+      console.warn('Error loading nearby providers - geographic filter will be unavailable:', error);
     } finally {
       setLoadingNearby(false);
     }

--- a/frontend/src/components/clinical/workspace/components/UniversalSearchBar.js
+++ b/frontend/src/components/clinical/workspace/components/UniversalSearchBar.js
@@ -112,7 +112,7 @@ const UniversalSearchBar = ({
         setSelectedResult(null);
         setSearchQuery('');
       } catch (error) {
-        
+        console.error('Failed to add resource to patient:', error);
       }
     }
   };

--- a/frontend/src/components/clinical/workspace/dialogs/DiagnosticReportDialogEnhanced.js
+++ b/frontend/src/components/clinical/workspace/dialogs/DiagnosticReportDialogEnhanced.js
@@ -144,6 +144,7 @@ const searchDiagnosticReports = async (query) => {
       });
     } catch (error) {
       // Ignore errors from lab catalog
+      console.warn('Ignore errors from lab catalog:', error);
     }
     
     // Add common diagnostic report types if search is empty or general

--- a/frontend/src/components/clinical/workspace/dialogs/EnhancedNoteEditor.js
+++ b/frontend/src/components/clinical/workspace/dialogs/EnhancedNoteEditor.js
@@ -206,6 +206,7 @@ const AutoPopulationPreview = ({ template, patientId, onApply }) => {
       setPreviewData(autoContent);
     } catch (error) {
       // Auto-population preview failed silently
+      console.warn('Auto-population preview failed silently:', error);
     } finally {
       setLoading(false);
     }
@@ -327,6 +328,7 @@ const NoteSharing = ({ note, onShare }) => {
       setShareMessage('');
     } catch (error) {
       // Note sharing failed silently
+      console.warn('Note sharing failed silently:', error);
     } finally {
       setLoading(false);
     }
@@ -587,6 +589,7 @@ const EnhancedNoteEditor = ({
 
     } catch (error) {
       // Note data extraction failed silently
+      console.warn('Note data extraction failed silently:', error);
     }
 
     return {

--- a/frontend/src/components/clinical/workspace/dialogs/ServiceRequestDialogEnhanced.js
+++ b/frontend/src/components/clinical/workspace/dialogs/ServiceRequestDialogEnhanced.js
@@ -150,6 +150,7 @@ const searchServiceRequests = async (query) => {
       });
     } catch (error) {
       // Ignore errors from lab catalog
+      console.warn('Ignore errors from lab catalog:', error);
     }
     
     // Convert to array and filter by query if provided

--- a/frontend/src/components/clinical/workspace/tabs/CDSHooksTab.js
+++ b/frontend/src/components/clinical/workspace/tabs/CDSHooksTab.js
@@ -223,6 +223,7 @@ const CDSHooksTab = ({ patientId }) => {
           }
         } catch (serviceError) {
           // Continue with other services
+          console.warn('Continue with other services:', serviceError);
         }
       }
       
@@ -304,6 +305,7 @@ const CDSHooksTab = ({ patientId }) => {
           }
         } catch (serviceError) {
           // Error executing service - add to results with error status
+          console.warn('Error executing service - add to results with error status:', serviceError);
         }
       }
       

--- a/frontend/src/components/clinical/workspace/tabs/EncountersTab.js
+++ b/frontend/src/components/clinical/workspace/tabs/EncountersTab.js
@@ -283,6 +283,7 @@ const EncountersTab = ({
         });
       } catch (error) {
         // Failed to load encounters
+        console.warn('Failed to load encounters:', error);
       }
     }
   }, [patientId, searchResources, isLoading]);

--- a/frontend/src/components/clinical/workspace/tabs/PharmacyTab.js
+++ b/frontend/src/components/clinical/workspace/tabs/PharmacyTab.js
@@ -361,6 +361,7 @@ const PharmacyTab = ({
         }
       } catch (error) {
         // Handle error silently to prevent console clutter
+        console.warn('Handle error silently to prevent console clutter:', error);
       }
     };
 

--- a/frontend/src/components/clinical/workspace/tabs/ResultsTabOptimized.js
+++ b/frontend/src/components/clinical/workspace/tabs/ResultsTabOptimized.js
@@ -447,6 +447,7 @@ const ResultsTabOptimized = ({
         // Successfully subscribed to patient room
       } catch (error) {
         // Failed to subscribe to patient room
+        console.warn('Failed to subscribe to patient room:', error);
       }
     };
 

--- a/frontend/src/components/clinical/workspace/tabs/SummaryTab.js
+++ b/frontend/src/components/clinical/workspace/tabs/SummaryTab.js
@@ -854,6 +854,7 @@ const SummaryTab = ({ patientId, onNotificationUpdate, onNavigateToTab }) => {
     } catch (error) {
       // Error loading summary stats - stats will not be displayed
       // Log error but don't call fetchPatientBundle to avoid infinite loop
+      console.warn('Error loading summary stats - stats will not be displayed:', error);
     }
   }, [patientId, fhirClient]);
 
@@ -864,7 +865,8 @@ const SummaryTab = ({ patientId, onNotificationUpdate, onNavigateToTab }) => {
   //   if (patientId) {
   //     loadSummaryStats();
   //   }
-  // }, [patientId]); // Only depend on patientId to avoid infinite loop
+  // }, [patientId]);
+  // Only depend on patientId to avoid infinite loop
 
   // Get resources from context - these are already cached and shared
   const conditions = useMemo(() => {
@@ -1064,6 +1066,7 @@ const SummaryTab = ({ patientId, onNotificationUpdate, onNavigateToTab }) => {
       setLastRefresh(new Date());
     } catch (error) {
       // Error loading summary data - in production this would show an error notification to the user
+      console.warn('Error loading summary data - in production this would show an error notification to the:', error);
     } finally {
       setLoading(false);
       setRefreshing(false);

--- a/frontend/src/components/clinical/workspace/tabs/TimelineTabModern.js
+++ b/frontend/src/components/clinical/workspace/tabs/TimelineTabModern.js
@@ -167,7 +167,8 @@ import { useSnackbar } from 'notistack';
 // Import animation libraries
 import { motion, AnimatePresence, useScroll, useTransform, useSpring, useAnimation, useInView } from 'framer-motion';
 import { Chrono } from 'react-chrono';
-// import { ResponsiveCalendar } from '@nivo/calendar'; // Temporarily disabled due to rendering issues
+// import { ResponsiveCalendar } from '@nivo/calendar';
+// Temporarily disabled due to rendering issues
 import { 
   Tooltip as RechartsTooltip,
   ResponsiveContainer,

--- a/frontend/src/components/clinical/workspace/tabs/components/AdministrationDialog.js
+++ b/frontend/src/components/clinical/workspace/tabs/components/AdministrationDialog.js
@@ -234,6 +234,7 @@ const AdministrationDialog = ({
       onClose();
     } catch (error) {
       // Error recording administration - user will need to retry
+      console.warn('Error recording administration - user will need to retry:', error);
     } finally {
       setAdministering(false);
     }
@@ -284,6 +285,7 @@ const AdministrationDialog = ({
       onClose();
     } catch (error) {
       // Error recording missed dose - user will need to retry
+      console.warn('Error recording missed dose - user will need to retry:', error);
     } finally {
       setAdministering(false);
     }

--- a/frontend/src/components/clinical/workspace/tabs/components/AdvancedLabValueFilter.js
+++ b/frontend/src/components/clinical/workspace/tabs/components/AdvancedLabValueFilter.js
@@ -374,6 +374,7 @@ const AdvancedLabValueFilter = ({
         }
       } catch (error) {
         // Failed to load saved filters - will use defaults
+        console.warn('Failed to load saved filters - will use defaults:', error);
       }
     };
     loadSavedFilters();

--- a/frontend/src/components/clinical/workspace/tabs/components/EnhancedDispenseDialog.js
+++ b/frontend/src/components/clinical/workspace/tabs/components/EnhancedDispenseDialog.js
@@ -428,6 +428,7 @@ const EnhancedDispenseDialog = ({
       onClose();
     } catch (error) {
       // Error handled by parent component
+      console.warn('Error handled by parent component:', error);
     } finally {
       setDispensing(false);
     }

--- a/frontend/src/components/fhir-explorer-v4/core/FHIRExplorerApp.jsx
+++ b/frontend/src/components/fhir-explorer-v4/core/FHIRExplorerApp.jsx
@@ -113,11 +113,13 @@ function FHIRExplorerApp() {
                   _count: 10
                 });
               } catch (err) {
+                console.warn('Explorer cache warm-up: one resource type failed:', err);
               }
             }));
           }
         }
       } catch (error) {
+        console.warn('Explorer cache warm-up failed:', error);
       }
     };
 

--- a/frontend/src/components/fhir-explorer-v4/discovery/RelationshipMapper.jsx
+++ b/frontend/src/components/fhir-explorer-v4/discovery/RelationshipMapper.jsx
@@ -326,6 +326,7 @@ function RelationshipMapper({ selectedResource, onResourceSelect, useFHIRData })
       }
     } catch (err) {
       // Error fetching relationship schema - silently handled
+      console.warn('Error fetching relationship schema - silently handled:', err);
     } finally {
       requestsInFlightRef.current.delete('schema');
     }
@@ -352,6 +353,7 @@ function RelationshipMapper({ selectedResource, onResourceSelect, useFHIRData })
       }
     } catch (err) {
       // Error fetching statistics - non-critical, don't show error
+      console.warn('Error fetching statistics - non-critical, don\'t show error:', err);
     } finally {
       requestsInFlightRef.current.delete('statistics');
       if (isMountedRef.current) {

--- a/frontend/src/components/migration/MigrationDashboard.js
+++ b/frontend/src/components/migration/MigrationDashboard.js
@@ -328,7 +328,7 @@ const MigrationDashboard = () => {
       try {
         await getMigrationStatus();
       } catch (error) {
-        
+        console.warn('Failed to load migration status:', error);
       } finally {
         setLoading(false);
       }
@@ -382,7 +382,7 @@ const MigrationDashboard = () => {
     try {
       await getMigrationStatus(selectedResourceType === 'all' ? null : selectedResourceType);
     } catch (error) {
-      
+      console.warn('Failed to refresh migration status:', error);
     } finally {
       setLoading(false);
     }

--- a/frontend/src/components/monitoring/DataIntegrityDashboard.js
+++ b/frontend/src/components/monitoring/DataIntegrityDashboard.js
@@ -365,7 +365,7 @@ const DataIntegrityDashboard = () => {
       setIntegrityResults(results);
       setLastUpdate(new Date());
     } catch (error) {
-      
+      console.error('Data integrity check failed:', error);
     } finally {
       setLoading(false);
     }

--- a/frontend/src/components/search/ResourceSearchAutocomplete.js
+++ b/frontend/src/components/search/ResourceSearchAutocomplete.js
@@ -390,6 +390,7 @@ const ResourceSearchAutocomplete = ({
               if (optionKey && valueKey && optionKey === valueKey) return true;
             } catch (e) {
               // Fall through to other matching strategies
+              console.warn('Fall through to other matching strategies:', e);
             }
           }
           

--- a/frontend/src/contexts/AuthContext.js
+++ b/frontend/src/contexts/AuthContext.js
@@ -74,7 +74,7 @@ export const AuthProvider = ({ children }) => {
     try {
       await api.post('/api/auth/logout');
     } catch (error) {
-      
+      console.warn('Logout request failed; clearing local session anyway:', error);
     } finally {
       localStorage.removeItem('auth_token');
       localStorage.removeItem('auth_user');

--- a/frontend/src/contexts/ClinicalWorkflowContext.js
+++ b/frontend/src/contexts/ClinicalWorkflowContext.js
@@ -609,7 +609,7 @@ export const ClinicalWorkflowProvider = ({ children }) => {
       });
       
     } catch (error) {
-      
+      console.warn('Failed to load clinical context for encounter:', error);
     }
   };
 

--- a/frontend/src/contexts/InboxContext.js
+++ b/frontend/src/contexts/InboxContext.js
@@ -182,7 +182,7 @@ export const InboxProvider = ({ children }) => {
       }));
       setUnreadCount(unreadResult.total || 0);
     } catch (err) {
-      
+      console.warn('Failed to load inbox counts; badge may be stale:', err);
     }
   }, [user]);
 

--- a/frontend/src/core/fhir/converters/DocumentReferenceConverter.js
+++ b/frontend/src/core/fhir/converters/DocumentReferenceConverter.js
@@ -555,6 +555,7 @@ export class DocumentReferenceConverter extends AbstractFHIRConverter {
                 };
               } catch (e) {
                 // Not valid base64, use as-is
+                console.warn('Not valid base64, use as-is:', e);
               }
             }
             

--- a/frontend/src/hooks/patient/useChartReviewResources.js
+++ b/frontend/src/hooks/patient/useChartReviewResources.js
@@ -107,6 +107,7 @@ const useChartReviewResources = (patientId, options = {}) => {
           await contextRefs.current.fetchPatientBundle(patientId, false, 'all');
         } catch (bundleError) {
           // Silently fallback to individual resource fetches
+          console.warn('Silently fallback to individual resource fetches:', bundleError);
         }
 
         // Direct search fallback for comprehensive coverage (only when cache is cold)
@@ -167,6 +168,7 @@ const useChartReviewResources = (patientId, options = {}) => {
             resources = searchResults || [];
           } catch (searchError) {
             // Silent fallback
+            console.warn('Silent fallback:', searchError);
           }
         }
         

--- a/frontend/src/hooks/ui/useNotifications.js
+++ b/frontend/src/hooks/ui/useNotifications.js
@@ -71,7 +71,7 @@ export const useNotifications = () => {
         return data;
       }
     } catch (error) {
-      
+      console.warn('Failed to fetch notifications:', error);
     }
   }, [user]);
 

--- a/frontend/src/modules/ui-composer/agents/AgentOrchestrator.js
+++ b/frontend/src/modules/ui-composer/agents/AgentOrchestrator.js
@@ -34,6 +34,7 @@ class AgentOrchestrator {
         listener(event, data);
       } catch (error) {
         // Ignore listener errors
+        console.warn('Ignore listener errors:', error);
       }
     });
   }

--- a/frontend/src/modules/ui-composer/agents/SimpleOrchestrator.js
+++ b/frontend/src/modules/ui-composer/agents/SimpleOrchestrator.js
@@ -103,6 +103,7 @@ class SimpleOrchestrator {
         listener(event, data);
       } catch (error) {
         // Listener error silently handled
+        console.warn('Listener error silently handled:', error);
       }
     });
   }

--- a/frontend/src/modules/ui-composer/components/CostDisplay.js
+++ b/frontend/src/modules/ui-composer/components/CostDisplay.js
@@ -41,6 +41,7 @@ const CostDisplay = ({ sessionId, loading, onCostUpdate }) => {
       }
     } catch (error) {
       // Failed to fetch cost data - error handled silently
+      console.warn('Failed to fetch cost data - error handled silently:', error);
     } finally {
       setFetchingCost(false);
     }

--- a/frontend/src/modules/ui-composer/components/DashboardManager.js
+++ b/frontend/src/modules/ui-composer/components/DashboardManager.js
@@ -81,6 +81,7 @@ const DashboardManager = () => {
       }
     } catch (error) {
       // Error loading saved dashboards
+      console.warn('Error loading saved dashboards:', error);
     }
   }, [setDashboardList]);
   
@@ -90,6 +91,7 @@ const DashboardManager = () => {
       localStorage.setItem('ui-composer-dashboards', JSON.stringify(dashboards));
     } catch (error) {
       // Error saving dashboards
+      console.warn('Error saving dashboards:', error);
     }
   }, []);
   

--- a/frontend/src/modules/ui-composer/components/FeedbackInterface.js
+++ b/frontend/src/modules/ui-composer/components/FeedbackInterface.js
@@ -112,6 +112,7 @@ const FeedbackInterface = () => {
       
     } catch (error) {
       // Error submitting feedback
+      console.warn('Error submitting feedback:', error);
     } finally {
       setSubmitting(false);
     }

--- a/frontend/src/modules/ui-composer/services/ProgressiveLoader.js
+++ b/frontend/src/modules/ui-composer/services/ProgressiveLoader.js
@@ -30,6 +30,7 @@ class ProgressiveLoader {
         listener(event, data);
       } catch (error) {
         // Progressive loader listener error
+        console.warn('Progressive loader listener error:', error);
       }
     });
   }

--- a/frontend/src/modules/ui-composer/utils/componentRegistry.js
+++ b/frontend/src/modules/ui-composer/utils/componentRegistry.js
@@ -207,6 +207,7 @@ class ComponentRegistry {
         listener(event, componentId, data);
       } catch (error) {
         // Ignore listener errors
+        console.warn('Ignore listener errors:', error);
       }
     });
   }

--- a/frontend/src/pages/PatientList.js
+++ b/frontend/src/pages/PatientList.js
@@ -199,6 +199,7 @@ function PatientList() {
           });
         } catch (e) {
           // Coverage batch fetch failed, continue without insurance data
+          console.warn('Coverage batch fetch failed, continue without insurance data:', e);
         }
       }
 
@@ -291,6 +292,7 @@ function PatientList() {
           });
         } catch (e) {
           // Coverage batch fetch failed, continue without insurance data
+          console.warn('Coverage batch fetch failed, continue without insurance data:', e);
         }
       }
 

--- a/frontend/src/pages/SMARTDemoApp.js
+++ b/frontend/src/pages/SMARTDemoApp.js
@@ -196,6 +196,7 @@ const SMARTDemoApp = () => {
             }
           } catch {
             // Token is opaque, not JWT
+            console.warn('Token is opaque, not JWT');
           }
         }
 

--- a/frontend/src/services/cdsHooksClient.js
+++ b/frontend/src/services/cdsHooksClient.js
@@ -243,6 +243,7 @@ class CDSHooksClient {
             prefetch = await cdsPrefetchResolver.resolvePrefetchTemplates(service, context);
           } catch (error) {
             // Prefetch resolution failed, continuing without prefetch
+            console.warn('Prefetch resolution failed, continuing without prefetch:', error);
           }
         }
 
@@ -309,6 +310,7 @@ class CDSHooksClient {
             prefetch = await cdsPrefetchResolver.resolvePrefetchTemplates(service, context);
           } catch (error) {
             // Prefetch resolution failed, continuing without prefetch
+            console.warn('Prefetch resolution failed, continuing without prefetch:', error);
           }
         } else {
           // Use common prefetch for medication-prescribe if no templates defined

--- a/frontend/src/services/cdsHooksService.js
+++ b/frontend/src/services/cdsHooksService.js
@@ -877,6 +877,7 @@ class CDSHooksService {
         serviceExists = true;
       } catch (e) {
         // Service doesn't exist yet
+        console.warn('Service doesn\'t exist yet:', e);
       }
 
       // Save the service first

--- a/frontend/src/services/clinicalCrossReferenceService.js
+++ b/frontend/src/services/clinicalCrossReferenceService.js
@@ -132,6 +132,7 @@ export class ClinicalCrossReferenceService {
                 });
               } catch (err) {
                 // Document could not be fetched, skip it
+                console.warn('Document could not be fetched, skip it:', err);
               }
             }
           }
@@ -245,6 +246,7 @@ export class ClinicalCrossReferenceService {
                 }
               } catch (err) {
                 // Resource could not be fetched, skip it
+                console.warn('Resource could not be fetched, skip it:', err);
               }
             }
           }

--- a/frontend/src/services/criticalValueDetectionService.js
+++ b/frontend/src/services/criticalValueDetectionService.js
@@ -193,6 +193,7 @@ class CriticalValueDetectionService {
           }
         } catch (error) {
           // Continue searching other values despite individual errors
+          console.warn('Continue searching other values despite individual errors:', error);
         }
       }
     }

--- a/frontend/src/services/emrClient.js
+++ b/frontend/src/services/emrClient.js
@@ -226,6 +226,7 @@ class EMRClient {
         return JSON.parse(localState);
       } catch (e) {
         // Invalid JSON, ignore
+        console.warn('Invalid JSON, ignore:', e);
       }
     }
 

--- a/frontend/src/services/fhirSchemaService.js
+++ b/frontend/src/services/fhirSchemaService.js
@@ -74,6 +74,7 @@ class FHIRSchemaService {
           return response.data;
         } catch (v2Error) {
           // fall through to the original endpoint
+          console.warn('fall through to the original endpoint:', v2Error);
         }
       }
 
@@ -216,6 +217,7 @@ class FHIRSchemaService {
           return response.data;
         } catch (v2Error) {
           // fall through to the v1 endpoint
+          console.warn('fall through to the v1 endpoint:', v2Error);
         }
       }
 

--- a/frontend/src/services/medicationDiscontinuationService.js
+++ b/frontend/src/services/medicationDiscontinuationService.js
@@ -79,6 +79,7 @@ class MedicationDiscontinuationService {
         );
       } catch (error) {
         // Error updating medication lists - continue with rest of process
+        console.warn('Error updating medication lists - continue with rest of process:', error);
       }
 
       // Create follow-up appointments if required

--- a/frontend/src/services/medicationEffectivenessService.js
+++ b/frontend/src/services/medicationEffectivenessService.js
@@ -654,6 +654,7 @@ class MedicationEffectivenessService {
       return await fhirClient.update('CarePlan', updatedPlan);
     } catch (error) {
       // Silently continue if plan update fails
+      console.warn('Silently continue if plan update fails:', error);
     }
   }
 

--- a/frontend/src/services/medicationListManagementService.js
+++ b/frontend/src/services/medicationListManagementService.js
@@ -584,6 +584,7 @@ class MedicationListManagementService {
           callback(update);
         } catch (error) {
           // Skip failed callback
+          console.warn('Skip failed callback:', error);
         }
       });
     }

--- a/frontend/src/services/medicationSearchService.js
+++ b/frontend/src/services/medicationSearchService.js
@@ -214,6 +214,7 @@ class MedicationSearchService {
         backendResults = response.data;
       } catch (error) {
         // Backend medication search unavailable, using local database
+        console.warn('Backend medication search unavailable, using local database:', error);
       }
 
       // Search local database

--- a/frontend/src/services/medicationWorkflowValidator.js
+++ b/frontend/src/services/medicationWorkflowValidator.js
@@ -113,6 +113,7 @@ class MedicationWorkflowValidator {
               }
             } catch (error) {
               // Monitoring plan check failed - continue with validation
+              console.warn('Monitoring plan check failed - continue with validation:', error);
             }
           }
 
@@ -351,6 +352,7 @@ class MedicationWorkflowValidator {
       }
     } catch (error) {
       // Refill workflow validation failed - continue
+      console.warn('Refill workflow validation failed - continue:', error);
     }
   }
 
@@ -471,6 +473,7 @@ class MedicationWorkflowValidator {
       }
     } catch (error) {
       // Medication list validation failed - continue
+      console.warn('Medication list validation failed - continue:', error);
     }
 
     // Check status transition validity

--- a/frontend/src/services/prescriptionRefillService.js
+++ b/frontend/src/services/prescriptionRefillService.js
@@ -95,6 +95,7 @@ class PrescriptionRefillService {
         enriched.medicationReference = originalPrescription?.medicationReference;
       } catch (error) {
         // Enrichment is best-effort; the Task summary still renders
+        console.warn('Enrichment is best-effort; the Task summary still renders:', error);
       }
     }
 
@@ -103,6 +104,7 @@ class PrescriptionRefillService {
         enriched.patient = await fhirClient.read('Patient', refill.patient_id);
       } catch (error) {
         // Enrichment is best-effort
+        console.warn('Enrichment is best-effort:', error);
       }
     }
 

--- a/frontend/src/services/prescriptionStatusService.js
+++ b/frontend/src/services/prescriptionStatusService.js
@@ -449,6 +449,7 @@ class PrescriptionStatusService {
           callback(status);
         } catch (error) {
           // Skip failed callback
+          console.warn('Skip failed callback:', error);
         }
       });
     }

--- a/frontend/src/services/providerAccountabilityService.js
+++ b/frontend/src/services/providerAccountabilityService.js
@@ -185,6 +185,7 @@ class ProviderAccountabilityService {
         }
       } catch (error) {
         // Ordering provider not available
+        console.warn('Ordering provider not available:', error);
       }
     }
 
@@ -474,6 +475,7 @@ class ProviderAccountabilityService {
       await fhirClient.create('Task', task);
     } catch (error) {
       // Accountability task creation failed - will retry
+      console.warn('Accountability task creation failed - will retry:', error);
     }
   }
 

--- a/frontend/src/services/resultDocumentationService.js
+++ b/frontend/src/services/resultDocumentationService.js
@@ -67,6 +67,7 @@ export class ResultDocumentationService {
         notes.push(note);
       } catch (error) {
         // Continue with other results
+        console.warn('Continue with other results:', error);
       }
     }
 

--- a/frontend/src/services/searchService.js
+++ b/frontend/src/services/searchService.js
@@ -238,6 +238,7 @@ class SearchService {
 
         } catch (error) {
           // Catalog search failed for resource type
+          console.warn('Catalog search failed for resource type:', error);
         }
       }
 
@@ -575,6 +576,7 @@ class SearchService {
           }
         } catch (error) {
           // Fallback catalog search failed
+          console.warn('Fallback catalog search failed:', error);
         }
       }
 

--- a/frontend/src/services/websocket.js
+++ b/frontend/src/services/websocket.js
@@ -126,6 +126,7 @@ class WebSocketService {
         this.handleMessage(data);
       } catch (error) {
         // Failed to parse message
+        console.warn('Failed to parse message:', error);
       }
     };
 
@@ -380,6 +381,7 @@ class WebSocketService {
           callback(data);
         } catch (error) {
           // Error in listener
+          console.warn('Error in listener:', error);
         }
       });
     }
@@ -548,6 +550,7 @@ class WebSocketService {
         callback(state, data);
       } catch (error) {
         // Error in connection listener
+        console.warn('Error in connection listener:', error);
       }
     });
   }

--- a/frontend/src/test/createTestModalHook.js
+++ b/frontend/src/test/createTestModalHook.js
@@ -21,6 +21,7 @@ export async function createTestModalHook() {
       }
     } catch (e) {
       // Hook doesn't exist, create it
+      console.warn('Hook doesn\'t exist, create it:', e);
     }
     
     // Create the hook


### PR DESCRIPTION
The E2 backlog measured: **344 silent catch sites** in three tiers. This PR takes the first two.

## Slice 1 — 22 truly-empty catch bodies (commit 1)

No log, no state, no feedback. The worst were **user-initiated actions that silently no-op'd**: marking inbox items read, completing them, cancelling an appointment (user confirms the cancellation; the appointment quietly stays scheduled), adding a search result to a patient. Those log at `error` level with the consequence stated; degradable background loads log at `warn`.

## Slice 2 — 91 comment-only catches (commit 2)

These documented *why* they swallow ('Failed to generate documentation prompts') but surfaced nothing at runtime — a comment is invisible in a teaching session's console. Each now logs `console.warn` **using its own comment text as the message**: intent stays documented and the failure becomes observable. Comments kept.

**4 sites stay deliberately silent**, and are now a reviewed decision rather than an accident: session/localStorage micro-writes (CDSPresentation ×3, CDSHooksTab ×1) where quota errors would spam every render for a genuinely ignorable operation.

## Deferred — tier 3

~227 catches that return fallbacks without logging. Each needs individual judgment (is the fallback the design, or a mask?) — tracked, not rushed.

## Verification

- eslint: **0 errors** (hard gate)
- `vite build` clean
- **517/517 tests** — the zero gate held through 113 instrumented sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)