### PR TITLE
fix(frontend): stale-service-worker recovery; harden the lint gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,16 +82,32 @@ jobs:
         # duplicate keys) — the backlog was fixed when the gate went hard, so
         # any new error fails the build. The ~1950 warnings are legacy
         # (mostly no-unused-vars); ratchet them separately.
+        #
+        # JSON format + explicit exit-code handling, NOT a grep over a text
+        # formatter: the previous grep counted 0 errors when eslint itself
+        # crashed (exit 2 after `-f compact` left core), silently bypassing
+        # the gate. eslint exit 0/1 = ran (1 means findings); >=2 = eslint
+        # broke and the gate must fail loudly, never pass by default.
         run: |
-          npx eslint src -f compact > eslint.out 2>&1 || true
-          tail -1 eslint.out
-          ERRORS=$(grep -cE ", Error - " eslint.out || true)
-          echo "eslint errors=$ERRORS (hard gate: 0)"
-          if [ "$ERRORS" -gt 0 ]; then
-            grep -E ", Error - " eslint.out | head -20
-            echo "::error::New eslint error-level findings (gate is zero)"
+          set +e
+          npx eslint src --format json --output-file eslint.json
+          STATUS=$?
+          set -e
+          if [ "$STATUS" -ge 2 ]; then
+            echo "::error::eslint itself failed (exit $STATUS) — gate cannot be evaluated"
+            npx eslint src 2>&1 | head -5 || true
             exit 1
           fi
+          node -e "
+            const r = require('./eslint.json');
+            let e = 0, w = 0;
+            for (const f of r) { e += f.errorCount; w += f.warningCount; }
+            console.log('eslint: ' + e + ' errors, ' + w + ' warnings (hard gate: 0 errors)');
+            if (e > 0) {
+              for (const f of r) for (const m of f.messages)
+                if (m.severity === 2) console.log(f.filePath + ':' + m.line + ' [' + m.ruleId + '] ' + m.message);
+              process.exit(1);
+            }"
       - name: "vitest (baseline: 0 failed / 517 total)"
         run: |
           # The suite is fully green: 517 tests, 0 failed. The failed budget

--- a/frontend/public/service-worker.js
+++ b/frontend/public/service-worker.js
@@ -1,0 +1,21 @@
+// Self-destructing service worker at CRA's default SW path.
+//
+// Browsers that installed the pre-Vite service worker keep checking THIS URL
+// for updates. Serving a worker that immediately unregisters itself (instead
+// of the 404 this path returned after the cutover) converges every stranded
+// client: old caches deleted, registration removed, open tabs reloaded onto
+// the live bundle. The current app registers /sw.js; this file exists only
+// to rescue history.
+self.addEventListener('install', () => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil((async () => {
+    const keys = await caches.keys();
+    await Promise.all(keys.map((k) => caches.delete(k)));
+    await self.registration.unregister();
+    const clients = await self.clients.matchAll({ type: 'window' });
+    clients.forEach((client) => client.navigate(client.url));
+  })());
+});

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -3,6 +3,12 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import './patriotic-styles.css';
 import App from './App';
+import { installStaleBundleRecovery } from './utils/staleBundleRecovery';
+
+// Must be installed before the router mounts: the first lazy chunk that 404s
+// against a stale service-worker cache triggers unregister + cache purge +
+// one reload. See src/utils/staleBundleRecovery.js for the failure mode.
+installStaleBundleRecovery();
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(

--- a/frontend/src/utils/__tests__/staleBundleRecovery.test.js
+++ b/frontend/src/utils/__tests__/staleBundleRecovery.test.js
@@ -1,0 +1,89 @@
+/**
+ * Tests for the stale-bundle recovery kill-switch — the fix for browsers
+ * pinned to a pre-deploy service worker whose cached index.html references
+ * chunks that no longer exist (blank lazy tabs, e.g. the Summary tab after
+ * the CRA→Vite cutover).
+ */
+import { isChunkLoadError, recoverFromStaleBundle } from '../staleBundleRecovery';
+
+const makeDeps = (overrides = {}) => {
+  const store = new Map();
+  const registration = { unregister: vi.fn().mockResolvedValue(true) };
+  return {
+    storage: {
+      getItem: (k) => (store.has(k) ? store.get(k) : null),
+      setItem: (k, v) => store.set(k, v),
+    },
+    sw: { getRegistrations: vi.fn().mockResolvedValue([registration]) },
+    cacheStore: {
+      keys: vi.fn().mockResolvedValue(['medgen-emr-old', 'medgen-static-old']),
+      delete: vi.fn().mockResolvedValue(true),
+    },
+    reload: vi.fn(),
+    registration,
+    ...overrides,
+  };
+};
+
+describe('isChunkLoadError', () => {
+  it.each([
+    ['Vite', new TypeError('Failed to fetch dynamically imported module: http://x/static/js/SummaryTab.abc.js')],
+    ['webpack (old bundle)', new Error('Loading chunk 4154 failed.')],
+    ['Firefox', new Error('error loading dynamically imported module')],
+    ['Safari', new Error('Importing a module script failed.')],
+  ])('recognizes %s chunk failures', (_name, err) => {
+    expect(isChunkLoadError(err)).toBe(true);
+  });
+
+  it('ignores unrelated errors', () => {
+    expect(isChunkLoadError(new Error('Network Error'))).toBe(false);
+    expect(isChunkLoadError(new Error("Cannot read properties of undefined (reading 'matches')"))).toBe(false);
+    expect(isChunkLoadError(undefined)).toBe(false);
+  });
+});
+
+describe('recoverFromStaleBundle', () => {
+  it('unregisters workers, purges caches, and reloads once', async () => {
+    const deps = makeDeps();
+
+    const acted = await recoverFromStaleBundle(deps);
+
+    expect(acted).toBe(true);
+    expect(deps.registration.unregister).toHaveBeenCalled();
+    expect(deps.cacheStore.delete).toHaveBeenCalledTimes(2);
+    expect(deps.reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('never loops: the second attempt in a session is a no-op', async () => {
+    const deps = makeDeps();
+
+    await recoverFromStaleBundle(deps);
+    const second = await recoverFromStaleBundle(deps);
+
+    expect(second).toBe(false);
+    expect(deps.reload).toHaveBeenCalledTimes(1); // still just the one reload
+  });
+
+  it('still reloads when cleanup partially fails — a broken purge must not strand the user', async () => {
+    const deps = makeDeps({
+      cacheStore: {
+        keys: vi.fn().mockRejectedValue(new Error('cache API unavailable')),
+        delete: vi.fn(),
+      },
+    });
+
+    const acted = await recoverFromStaleBundle(deps);
+
+    expect(acted).toBe(true);
+    expect(deps.reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('works without a service worker API (older/locked-down browsers)', async () => {
+    const deps = makeDeps({ sw: null, cacheStore: null });
+
+    const acted = await recoverFromStaleBundle(deps);
+
+    expect(acted).toBe(true);
+    expect(deps.reload).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/utils/staleBundleRecovery.js
+++ b/frontend/src/utils/staleBundleRecovery.js
@@ -1,0 +1,71 @@
+/**
+ * Stale-bundle recovery — the service-worker kill-switch.
+ *
+ * Failure mode this ends: a browser whose service worker predates the current
+ * deploy serves a cached index.html whose hashed chunks no longer exist on the
+ * server. Lazy route/tab chunks then 404 and render nothing (observed on
+ * wintehrdev after the CRA→Vite cutover: Chart Review worked from SW cache
+ * while the Summary tab's uncached chunk 404'd as
+ * /static/js/4154.984aa094.chunk.js — a webpack-era filename).
+ *
+ * Strategy: the moment a dynamic import fails, assume the bundle is stale —
+ * unregister every service worker, delete every cache, and reload ONCE.
+ * The sessionStorage guard stops a reload loop when the failure has a
+ * different cause (e.g. the server is actually down).
+ */
+
+const RECOVERY_FLAG = 'wintehr-sw-recovery-attempted';
+
+const CHUNK_FAILURE_PATTERNS = [
+  /failed to fetch dynamically imported module/i, // Vite
+  /error loading dynamically imported module/i,   // Firefox wording
+  /loading chunk [\w-]+ failed/i,                 // webpack (old bundles)
+  /importing a module script failed/i,            // Safari wording
+];
+
+export function isChunkLoadError(reason) {
+  const message = String((reason && (reason.message || reason)) || '');
+  return CHUNK_FAILURE_PATTERNS.some((re) => re.test(message));
+}
+
+export async function recoverFromStaleBundle({ storage, sw, cacheStore, reload }) {
+  if (storage.getItem(RECOVERY_FLAG)) {
+    return false; // already tried this session — don't loop
+  }
+  storage.setItem(RECOVERY_FLAG, String(Date.now()));
+
+  try {
+    if (sw) {
+      const registrations = await sw.getRegistrations();
+      await Promise.all(registrations.map((r) => r.unregister()));
+    }
+    if (cacheStore) {
+      const keys = await cacheStore.keys();
+      await Promise.all(keys.map((k) => cacheStore.delete(k)));
+    }
+  } catch (error) {
+    // Even a partial cleanup is worth the reload — the SW is unregistered
+    // or the caches are gone, either breaks the stale pin.
+    console.warn('[staleBundleRecovery] cleanup incomplete:', error);
+  }
+
+  reload();
+  return true;
+}
+
+/** Wire the kill-switch to the global chunk-failure signals. */
+export function installStaleBundleRecovery({
+  storage = window.sessionStorage,
+  sw = 'serviceWorker' in navigator ? navigator.serviceWorker : null,
+  cacheStore = 'caches' in window ? window.caches : null,
+  reload = () => window.location.reload(),
+} = {}) {
+  const handler = (reason) => {
+    if (isChunkLoadError(reason)) {
+      recoverFromStaleBundle({ storage, sw, cacheStore, reload });
+    }
+  };
+  window.addEventListener('unhandledrejection', (e) => handler(e.reason));
+  // <script>/module-load failures surface as error events, not rejections
+  window.addEventListener('error', (e) => handler(e.error || e.message), true);
+}


### PR DESCRIPTION
Item 1 from the import-stress findings — the blank-tab bug — ended two ways, plus a CI gate bypass found while building it.

## The failure mode (observed live)

A browser whose service worker predates the current deploy serves the old cached `index.html`; its hashed chunks no longer exist, so lazy tabs 404 and render **nothing**. Live fingerprint on wintehrdev: Chart Review worked (chunk in SW cache) while the Summary tab requested `/static/js/4154.984aa094.chunk.js` — a webpack-era filename — and went blank.

## Fix 1: chunk-failure kill-switch

`src/utils/staleBundleRecovery.js`, installed in `index.js` before the router mounts. First failed dynamic import → unregister all service workers, purge all caches, reload **once** (sessionStorage guard prevents loops when the cause is a down server instead). Recognizes Vite, webpack, Firefox, and Safari failure wordings — stranded browsers run *old* bundles, so the webpack pattern matters.

## Fix 2: self-destructing worker at the old CRA URL

`public/service-worker.js` (a 404 since the cutover — but stranded clients still update-check it). Now serves a worker that deletes all caches, unregisters itself, and re-navigates open tabs. Converges every pre-cutover client even if they never trip the kill-switch.

## Fix 3: the lint gate was silently bypassed

`eslint -f compact` now exits 2 (the formatter left eslint core; its transitive provider got pruned from the lockfile in a later change) — and the gate's grep counted **0 errors on the crash output and passed**. Exactly the silent-gate failure mode this repo keeps hunting. The gate now uses `--format json` with explicit exit-code handling: eslint exit ≥2 fails the step loudly; findings are parsed structurally, never grepped.

## Verification

- 9 tests pin the recovery contract (pattern recognition per bundler, single-reload guard, partial-cleanup resilience, browsers without the SW API)
- Suite: **526 / 526**; build ships both `/sw.js` and `/service-worker.js`
- Gate dry-run: `0 errors, 1957 warnings`, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)