### PR TITLE
fix(frontend): truthful FHIR rendering — display fallbacks, medicationReference, one definition of active

### DIFF
--- a/frontend/src/components/clinical/dashboard/PatientSummaryV4.js
+++ b/frontend/src/components/clinical/dashboard/PatientSummaryV4.js
@@ -41,6 +41,11 @@ import CDSPresentation from '../cds/CDSPresentation';
 import { usePatientCDSAlerts } from '../../../contexts/CDSHooksContext';
 import { cdsDisplayBehaviorService } from '../../../services/cdsDisplayBehaviorService';
 import { useMedicationResolver } from '../../../core/fhir/hooks/useMedicationResolver';
+import {
+  getCodeableConceptDisplay,
+  isConditionActive,
+  isMedicationActive,
+} from '../../../core/fhir/utils/fhirFieldUtils';
 
 const PatientSummaryV4 = ({ patientId, department = 'general' }) => {
   
@@ -242,25 +247,20 @@ const PatientSummaryV4 = ({ patientId, department = 'general' }) => {
     };
   }, [currentPatient]);
 
-  // Active conditions
+  // Active conditions — same strict definition the Summary tab uses
+  // (isConditionActive). Conditions without a clinicalStatus (e.g. MIMIC
+  // billing diagnoses, where the field is legitimately absent) are not
+  // claimed as active: this card previously said "ACTIVE PROBLEMS 5" while
+  // the Summary tab said 0 for the same patient.
   const activeConditions = useMemo(() => {
-    return conditions
-      .filter(condition => 
-        condition.clinicalStatus?.coding?.[0]?.code === 'active' ||
-        !condition.clinicalStatus
-      )
-      .slice(0, 5);
+    return conditions.filter(isConditionActive).slice(0, 5);
   }, [conditions]);
 
-  // Current medications
+  // Current medications — strict isMedicationActive, matching the Summary
+  // tab. This card previously counted status=completed (and status-absent)
+  // as "current", which misrepresents finished historical orders.
   const currentMedications = useMemo(() => {
-    return medications
-      .filter(med => 
-        med.status === 'active' || 
-        med.status === 'completed' ||
-        !med.status
-      )
-      .slice(0, 5);
+    return medications.filter(isMedicationActive).slice(0, 5);
   }, [medications]);
 
   // Recent vitals
@@ -585,7 +585,7 @@ const PatientSummaryV4 = ({ patientId, department = 'general' }) => {
                   {activeConditions.slice(0, 3).map((condition, index) => (
                     <Box key={condition.id} sx={{ py: 0.5 }}>
                       <Typography variant="body2" noWrap>
-                        {condition.code?.text || 'Unknown condition'}
+                        {getCodeableConceptDisplay(condition.code, 'Unknown condition')}
                       </Typography>
                       <Typography variant="caption" color="text.secondary">
                         {condition.onsetDateTime ? format(parseISO(condition.onsetDateTime), 'MMM yyyy') : 'Unknown onset'}
@@ -725,7 +725,7 @@ const PatientSummaryV4 = ({ patientId, department = 'general' }) => {
                   {recentVitals.slice(0, 3).map((vital, index) => (
                     <Box key={vital.id} sx={{ py: 0.5 }}>
                       <Typography variant="body2" noWrap>
-                        {vital.code?.text || 'Unknown vital'}
+                        {getCodeableConceptDisplay(vital.code, 'Unknown vital')}
                       </Typography>
                       <Typography variant="caption" color="text.secondary">
                         {vital.valueQuantity?.value || '--'} {vital.valueQuantity?.unit || ''}
@@ -793,7 +793,7 @@ const PatientSummaryV4 = ({ patientId, department = 'general' }) => {
                   {activeAllergies.slice(0, 3).map((allergy, index) => (
                     <Box key={allergy.id} sx={{ py: 0.5 }}>
                       <Typography variant="body2" noWrap>
-                        {allergy.code?.text || 'Unknown allergen'}
+                        {getCodeableConceptDisplay(allergy.code, 'Unknown allergen')}
                       </Typography>
                       <Typography variant="caption" color="text.secondary">
                         {allergy.criticality || 'Unknown'} severity

--- a/frontend/src/components/clinical/workspace/tabs/ChartReviewTabOptimized.js
+++ b/frontend/src/components/clinical/workspace/tabs/ChartReviewTabOptimized.js
@@ -87,6 +87,7 @@ import { navigateToTab, TAB_IDS } from '../../utils/navigationHelper';
 import { useFHIRResource } from '../../../../contexts/FHIRResourceContext';
 import { useClinicalWorkflow } from '../../../../contexts/ClinicalWorkflowContext';
 import { useMedicationResolver } from '../../../../core/fhir/hooks/useMedicationResolver';
+import { getMedicationName } from '../../../../core/fhir/utils/medicationDisplayUtils';
 import { fhirClient } from '../../../../core/fhir/services/fhirClient';
 import ResourceDataGrid from '../../../common/ResourceDataGrid';
 import ConditionDialogEnhanced from '../dialogs/ConditionDialogEnhanced';
@@ -1837,10 +1838,7 @@ const EnhancedConditionCard = ({ condition, onEdit, isAlternate = false }) => {
 
 const EnhancedMedicationCard = ({ medication, onEdit, isAlternate = false, onNavigateToTab, resolvedName }) => {
   const theme = useTheme();
-  const medicationDisplay = resolvedName ||
-                          medication.medicationCodeableConcept?.text ||
-                          medication.medicationCodeableConcept?.coding?.[0]?.display ||
-                          'Unknown medication';
+  const medicationDisplay = resolvedName || getMedicationName(medication);
   const dosage = medication.dosageInstruction?.[0];
   const isActive = ['active', 'on-hold'].includes(medication.status);
   

--- a/frontend/src/core/fhir/hooks/useMedicationResolver.js
+++ b/frontend/src/core/fhir/hooks/useMedicationResolver.js
@@ -8,6 +8,7 @@
  * and memoizes results in a module-level cache shared across consumers.
  */
 import { useState, useEffect, useCallback, useMemo } from 'react';
+import { getCodeableConceptDisplay } from '../utils/fhirFieldUtils';
 import { fhirClient } from '../services/fhirClient';
 import { useFHIRResource } from '../../../contexts/FHIRResourceContext';
 
@@ -162,7 +163,7 @@ export const useMedicationResolver = (medicationRequests = []) => {
           // Handle concept-based medications (inline)
           if (req.medication?.concept) {
             const concept = req.medication.concept;
-            const medName = concept.text || concept.coding?.[0]?.display || 'Unknown medication';
+            const medName = getCodeableConceptDisplay(concept, 'Unknown medication');
             resolved[req.id] = {
               name: medName,
               code: concept
@@ -174,7 +175,7 @@ export const useMedicationResolver = (medicationRequests = []) => {
           if (containedCacheKey && medicationCache.has(containedCacheKey)) {
             const medication = medicationCache.get(containedCacheKey);
             if (medication) {
-              const medName = medication.code?.text || medication.code?.coding?.[0]?.display || 'Unknown medication';
+              const medName = getCodeableConceptDisplay(medication.code, 'Unknown medication');
               resolved[req.id] = {
                 name: medName,
                 code: medication.code,
@@ -191,7 +192,7 @@ export const useMedicationResolver = (medicationRequests = []) => {
               const medication = medicationCache.get(medicationId);
 
               if (medication) {
-                const medName = medication.code?.text || medication.code?.coding?.[0]?.display || 'Unknown medication';
+                const medName = getCodeableConceptDisplay(medication.code, 'Unknown medication');
                 resolved[req.id] = {
                   name: medName,
                   code: medication.code,
@@ -239,8 +240,8 @@ export const useMedicationResolver = (medicationRequests = []) => {
 
     // Check for enriched medication data (from _include resolution)
     if (medicationRequest._resolvedMedicationCodeableConcept) {
-      const enrichedName = medicationRequest._resolvedMedicationCodeableConcept.text ||
-                          medicationRequest._resolvedMedicationCodeableConcept.coding?.[0]?.display;
+      const enrichedName = getCodeableConceptDisplay(
+        medicationRequest._resolvedMedicationCodeableConcept, null);
       if (enrichedName) {
         return enrichedName;
       }
@@ -254,17 +255,10 @@ export const useMedicationResolver = (medicationRequests = []) => {
     // Fallback to medication field (R5 format) or medicationCodeableConcept (R4 format)
     if (medicationRequest.medication?.concept) {
       // FHIR R5 format
-      const concept = medicationRequest.medication.concept;
-      const fallbackName = concept.text ||
-                          concept.coding?.[0]?.display ||
-                          'Unknown medication';
-      return fallbackName;
+      return getCodeableConceptDisplay(medicationRequest.medication.concept, 'Unknown medication');
     } else if (medicationRequest.medicationCodeableConcept) {
       // FHIR R4 format
-      const fallbackName = medicationRequest.medicationCodeableConcept.text ||
-                          medicationRequest.medicationCodeableConcept.coding?.[0]?.display ||
-                          'Unknown medication';
-      return fallbackName;
+      return getCodeableConceptDisplay(medicationRequest.medicationCodeableConcept, 'Unknown medication');
     }
 
     return 'Unknown medication';

--- a/frontend/src/core/fhir/utils/__tests__/truthfulDisplay.test.js
+++ b/frontend/src/core/fhir/utils/__tests__/truthfulDisplay.test.js
@@ -1,0 +1,95 @@
+/**
+ * Truthful-rendering contracts, pinned against real MIMIC-on-FHIR shapes.
+ *
+ * The import stress test showed every display chain ended at
+ * `text || coding[0].display || 'Unknown …'` — but FHIR makes text optional
+ * and display optional per coding. MIMIC puts condition/vital names in
+ * coding[0].display with no text, and ships Medication resources that are
+ * bare NDC codes. "Unknown" when a real code exists is not truthful.
+ */
+import { getCodeableConceptDisplay, getMedicationDisplay, isConditionActive, isMedicationActive } from '../fhirFieldUtils';
+import { getMedicationName } from '../medicationDisplayUtils';
+
+// Real shapes from mimic-iv-clinical-database-demo-on-fhir-2.1.0
+const mimicConditionCode = {
+  coding: [{
+    code: 'V462',
+    system: 'http://mimic.mit.edu/fhir/mimic/CodeSystem/mimic-diagnosis-icd9',
+    display: 'Other dependence on machines, supplemental oxygen',
+  }],
+};
+const ndcOnlyMedication = {
+  id: 'med-ndc',
+  code: { coding: [{ code: '51079030020', system: 'http://mimic.mit.edu/fhir/mimic/CodeSystem/mimic-medication-ndc' }] },
+};
+
+describe('getCodeableConceptDisplay', () => {
+  it('uses coding display when text is absent (MIMIC condition/vital shape)', () => {
+    expect(getCodeableConceptDisplay(mimicConditionCode, 'Unknown condition'))
+      .toBe('Other dependence on machines, supplemental oxygen');
+  });
+
+  it('prefers the first coding WITH a display over a bare-code coding[0]', () => {
+    const concept = { coding: [
+      { code: '51079030020', system: 'ndc' },
+      { code: '313782', system: 'rxnorm', display: 'Acetaminophen 325 MG Oral Tablet' },
+    ]};
+    expect(getCodeableConceptDisplay(concept)).toBe('Acetaminophen 325 MG Oral Tablet');
+  });
+
+  it('falls back to the code itself — a real code is more truthful than "Unknown"', () => {
+    expect(getCodeableConceptDisplay(ndcOnlyMedication.code, 'Unknown medication'))
+      .toBe('51079030020');
+  });
+
+  it('still uses text first when present', () => {
+    expect(getCodeableConceptDisplay({ text: 'Lisinopril 10mg', ...mimicConditionCode }))
+      .toBe('Lisinopril 10mg');
+  });
+});
+
+describe('medicationReference resolution (MIMIC MedicationRequest shape)', () => {
+  const mimicMedRequest = {
+    id: 'mr-1',
+    status: 'completed',
+    medicationReference: { reference: 'Medication/med-ndc' },
+  };
+
+  it('getMedicationName resolves through a lookup map to the NDC code', () => {
+    expect(getMedicationName(mimicMedRequest, { 'med-ndc': ndcOnlyMedication }))
+      .toBe('51079030020');
+  });
+
+  it('getMedicationName resolves through an array lookup', () => {
+    expect(getMedicationName(mimicMedRequest, [ndcOnlyMedication])).toBe('51079030020');
+  });
+
+  it('getMedicationDisplay reads the concept the fetch layer stamps from _include', () => {
+    const stamped = { ...mimicMedRequest, _resolvedMedicationCodeableConcept: ndcOnlyMedication.code };
+    expect(getMedicationDisplay(stamped)).toBe('51079030020');
+  });
+
+  it('getMedicationDisplay resolves via options.medicationLookup', () => {
+    expect(getMedicationDisplay(mimicMedRequest, { medicationLookup: { 'med-ndc': ndcOnlyMedication } }))
+      .toBe('51079030020');
+  });
+});
+
+describe('one definition of active (preview page vs Summary tab)', () => {
+  it('a condition without clinicalStatus is NOT claimed active', () => {
+    // MIMIC billing diagnoses legitimately omit clinicalStatus — the data
+    // asserts no status, so the UI must not count them as active.
+    expect(isConditionActive({ code: mimicConditionCode })).toBe(false);
+  });
+
+  it('a completed medication is NOT current', () => {
+    expect(isMedicationActive({ status: 'completed' })).toBe(false);
+  });
+
+  it('genuinely active resources still count', () => {
+    expect(isConditionActive({
+      clinicalStatus: { coding: [{ code: 'active' }] },
+    })).toBe(true);
+    expect(isMedicationActive({ status: 'active' })).toBe(true);
+  });
+});

--- a/frontend/src/core/fhir/utils/fhirFieldUtils.js
+++ b/frontend/src/core/fhir/utils/fhirFieldUtils.js
@@ -145,8 +145,12 @@ export const getResourceDisplayText = (resource) => {
 export const getCodeableConceptDisplay = (codeableConcept, defaultValue = 'Unknown') => {
   if (!codeableConcept) return defaultValue;
 
+  // text is optional in FHIR; display is optional per coding. Fall back to
+  // the FIRST coding that has a display (not blindly coding[0] — datasets
+  // like MIMIC-on-FHIR put a bare NDC first), then to the first code:
+  // showing the real code is truthful; "Unknown" when a code exists is not.
   return codeableConcept.text ||
-         codeableConcept.coding?.[0]?.display ||
+         codeableConcept.coding?.find(c => c.display)?.display ||
          codeableConcept.coding?.[0]?.code ||
          defaultValue;
 };
@@ -589,7 +593,7 @@ export const getObservationValueDisplay = (observation) => {
  * @returns {string} - Human-readable medication description
  */
 export const getMedicationDisplay = (medicationRequest, options = {}) => {
-  const { includeDosage = false, defaultValue = 'Unknown Medication' } = options;
+  const { includeDosage = false, defaultValue = 'Unknown Medication', medicationLookup = null } = options;
 
   if (!medicationRequest) return defaultValue;
 
@@ -600,9 +604,26 @@ export const getMedicationDisplay = (medicationRequest, options = {}) => {
   if (medicationRequest.medicationCodeableConcept) {
     display = getCodeableConceptDisplay(medicationRequest.medicationCodeableConcept, defaultValue);
   }
-  // medicationReference (need to resolve separately)
-  else if (medicationRequest.medicationReference?.display) {
-    display = medicationRequest.medicationReference.display;
+  // Concept stamped onto the request by FHIRResourceContext from the
+  // _include'd Medication resource
+  else if (medicationRequest._resolvedMedicationCodeableConcept) {
+    display = getCodeableConceptDisplay(medicationRequest._resolvedMedicationCodeableConcept, defaultValue);
+  }
+  // medicationReference: inline display, else resolve through the caller's
+  // lookup (id -> Medication) — MedicationRequest.medicationReference is
+  // first-class R4 and the fetch layer already _includes the targets.
+  else if (medicationRequest.medicationReference) {
+    if (medicationRequest.medicationReference.display) {
+      display = medicationRequest.medicationReference.display;
+    } else if (medicationLookup) {
+      const medId = (medicationRequest.medicationReference.reference || '').replace('Medication/', '');
+      const medication = Array.isArray(medicationLookup)
+        ? medicationLookup.find(m => m.id === medId)
+        : medicationLookup[medId];
+      if (medication?.code) {
+        display = getCodeableConceptDisplay(medication.code, defaultValue);
+      }
+    }
   }
 
   // Optionally include dosage

--- a/frontend/src/core/fhir/utils/medicationDisplayUtils.js
+++ b/frontend/src/core/fhir/utils/medicationDisplayUtils.js
@@ -3,6 +3,8 @@
  * Shared functions for consistent medication information display across the application
  */
 
+import { getCodeableConceptDisplay } from './fhirFieldUtils';
+
 /**
  * Gets medication name from either R4 (medicationCodeableConcept) or R5 (medication.concept) format
  * Also supports resolving medicationReference if a lookup map or array is provided
@@ -16,19 +18,19 @@ export const getMedicationName = (medicationRequest, medicationsLookup = null) =
   // R5 format: medication.concept
   if (medicationRequest.medication?.concept) {
     const concept = medicationRequest.medication.concept;
-    return concept.text || concept.coding?.[0]?.display || 'Unknown medication';
+    return getCodeableConceptDisplay(concept, 'Unknown medication');
   }
 
   // R4 format: medicationCodeableConcept (legacy support)
   if (medicationRequest.medicationCodeableConcept) {
     const concept = medicationRequest.medicationCodeableConcept;
-    return concept.text || concept.coding?.[0]?.display || 'Unknown medication';
+    return getCodeableConceptDisplay(concept, 'Unknown medication');
   }
 
   // Check for resolved medication concept (added by FHIRResourceContext from _include)
   if (medicationRequest._resolvedMedicationCodeableConcept) {
     const concept = medicationRequest._resolvedMedicationCodeableConcept;
-    return concept.text || concept.coding?.[0]?.display || 'Unknown medication';
+    return getCodeableConceptDisplay(concept, 'Unknown medication');
   }
 
   // Reference format - try to resolve from lookup
@@ -54,7 +56,7 @@ export const getMedicationName = (medicationRequest, medicationsLookup = null) =
       }
 
       if (medication?.code) {
-        return medication.code.text || medication.code.coding?.[0]?.display || 'Unknown medication';
+        return getCodeableConceptDisplay(medication.code, 'Unknown medication');
       }
     }
 


### PR DESCRIPTION
Fixes the three frontend oddities reviewed against the MIMIC import, scoped by the principle **do what is right, not what looks good**.

## 1. CodeableConcept resolution (the 'Unknown everything' preview)

Every name chain ended at `text || coding[0].display || 'Unknown …'` — but `text` is **optional** in FHIR and `display` is optional per coding. MIMIC puts names in `coding[0].display` with no `text`, and its Medications lead with a bare-NDC coding. `getCodeableConceptDisplay` is now the canonical chain — **text → first coding *with* a display → first code** — and six ad-hoc copies (medicationDisplayUtils, useMedicationResolver ×4, ChartReview inline, PatientSummaryV4 ×3) route through it. Showing the real code when that's all the data carries is truthful; "Unknown" when a code exists is not.

## 2. `medicationReference` (the 'Unknown medication' Chart Review)

First-class R4; MIMIC uses it for every MedicationRequest, and the fetch layer already `_include`s the targets — the display code just never looked. Now resolves: `_resolvedMedicationCodeableConcept` stamp → `reference.display` → `options.medicationLookup`, all through the canonical chain. **Known ceiling:** the MIMIC demo's 1,480 Medication resources carry *zero* displays — the honest best is the NDC code itself. Real names = NDC→RxNorm enrichment (terminology bucket).

## 3. One definition of active (the empty Summary tab)

Not a Summary-tab bug — the **preview page** was lying twice: status-absent conditions counted as ACTIVE, and `completed` medications counted as CURRENT ("ACTIVE PROBLEMS 5" vs the Summary tab's truthful 0 for the same patient). The preview now uses the same strict `isConditionActive`/`isMedicationActive`. The Summary tab's empty active lists on MIMIC patients are **data-correct**: all 17,552 med requests are completed/stopped historical orders.

## Deliberately not changed (per review)

- **Negative age** on future birthDates — the display reflects the data; correction belongs at the source if ever wanted.
- **'Unknown onset'** — the onset genuinely is unknown.

## Verification

11 tests pin the contracts against literal MIMIC resource shapes (NDC-only Medication, display-only Condition coding, status-absent conditions). Suite **537/537**, eslint **0 errors**, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)