### PR TITLE
fix(nginx): exact-match /fhir and /fhir/R4 — POST [base] must not 301

### DIFF
--- a/deploy/nginx-prod.conf.template
+++ b/deploy/nginx-prod.conf.template
@@ -241,6 +241,33 @@ http {
             proxy_connect_timeout 75s;
         }
 
+        # POST [base] is the FHIR-standard transaction submit. nginx's
+        # trailing-slash prefix location 301s the bare /fhir, and HTTP
+        # clients turn a redirected POST into a GET — the transaction is
+        # silently discarded. Exact-match locations proxy the base directly
+        # (the backend has matching explicit /fhir and /fhir/R4 routes).
+        location = /fhir {
+            limit_req zone=api_limit burst=200 nodelay;
+            proxy_pass http://backend;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            client_max_body_size 50M;
+        }
+
+        location = /fhir/R4 {
+            limit_req zone=api_limit burst=200 nodelay;
+            proxy_pass http://backend;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            client_max_body_size 50M;
+        }
+
         # FHIR Server - Standard /fhir/ path (also through FastAPI for SMART validation)
         # Same CORS rationale as /fhir/R4/ above.
         location /fhir/ {


### PR DESCRIPTION
Completes #272's FHIR base-POST fix at the layer that was actually redirecting on wintehrdev: **nginx's trailing-slash prefix location** 301s the bare `/fhir` before the backend's new base route ever sees it — and HTTP clients turn a redirected POST into a GET, silently discarding the transaction.

Exact-match `location = /fhir` / `location = /fhir/R4` blocks proxy the base directly, mirroring the prefix blocks' settings.

**Verified live on wintehrdev** (rendered conf hand-patched identically, nginx restarted): `POST /fhir` → 200 transaction-response, `POST /fhir/R4` → 200, app unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)