### PR TITLE
fix(frontend): traverse the whole record — Medication.identifier names, deceased status

### DIFF
--- a/frontend/src/components/clinical/dashboard/PatientSummaryV4.js
+++ b/frontend/src/components/clinical/dashboard/PatientSummaryV4.js
@@ -229,6 +229,11 @@ const PatientSummaryV4 = ({ patientId, department = 'general' }) => {
     const name = patient.name?.[0];
     const fullName = name ? `${name.given?.join(' ') || ''} ${name.family || ''}`.trim() : 'Unknown Patient';
     const age = patient.birthDate ? differenceInYears(new Date(), new Date(patient.birthDate)) : null;
+    // A third of MIMIC demo patients are deceased; the record says so and
+    // the UI must too — showing a deceased patient as indistinguishable
+    // from a living one misstates the record.
+    const deceasedDate = patient.deceasedDateTime || null;
+    const isDeceased = Boolean(patient.deceasedDateTime || patient.deceasedBoolean);
     const phone = patient.telecom?.find(t => t.system === 'phone')?.value;
     const email = patient.telecom?.find(t => t.system === 'email')?.value;
     const address = patient.address?.[0];
@@ -241,6 +246,8 @@ const PatientSummaryV4 = ({ patientId, department = 'general' }) => {
       age,
       gender: patient.gender || 'unknown',
       birthDate: patient.birthDate,
+      isDeceased,
+      deceasedDate,
       phone,
       email,
       address: address ? `${address.line?.join(' ') || ''}, ${address.city || ''}, ${address.state || ''} ${address.postalCode || ''}`.trim() : null
@@ -457,9 +464,22 @@ const PatientSummaryV4 = ({ patientId, department = 'general' }) => {
             </Grid>
             
             <Grid item xs>
-              <Typography variant="h5" sx={{ fontWeight: 600, mb: 0.5 }}>
-                {patientInfo.fullName}
-              </Typography>
+              <Stack direction="row" spacing={1.5} alignItems="center" sx={{ mb: 0.5 }}>
+                <Typography variant="h5" sx={{ fontWeight: 600 }}>
+                  {patientInfo.fullName}
+                </Typography>
+                {patientInfo.isDeceased && (
+                  <Chip
+                    size="small"
+                    color="default"
+                    variant="outlined"
+                    label={patientInfo.deceasedDate
+                      ? `Deceased ${format(new Date(patientInfo.deceasedDate), 'MMM d, yyyy')}`
+                      : 'Deceased'}
+                    sx={{ fontWeight: 600 }}
+                  />
+                )}
+              </Stack>
               <Stack direction="row" spacing={2} flexWrap="wrap">
                 <Typography variant="body2" color="text.secondary">
                   {patientInfo.age ? `${patientInfo.age} years` : 'Age unknown'} • {patientInfo.gender}

--- a/frontend/src/contexts/FHIRResourceContext.js
+++ b/frontend/src/contexts/FHIRResourceContext.js
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useReducer, useCallback, useEffect, useRef } from 'react';
 import { fhirClient } from '../core/fhir/services/fhirClient';
+import { getMedicationResourceDisplay } from '../core/fhir/utils/fhirFieldUtils';
 import { intelligentCache } from '../core/fhir/utils/intelligentCache';
 import { useStableCallback } from '../hooks/ui/useStableReferences';
 import performanceMonitor from '../utils/performanceMonitor';
@@ -814,6 +815,9 @@ export function FHIRResourceProvider({ children }) {
                 return {
                   ...medRequest,
                   _resolvedMedicationCodeableConcept: medication.code,
+                  // Full-resource name (Medication.identifier can carry it
+                  // when code is a bare NDC — true for ALL MIMIC medications)
+                  _resolvedMedicationDisplay: getMedicationResourceDisplay(medication),
                   medicationReference: {
                     ...medRequest.medicationReference,
                     display: medication.code.text || medication.code.coding?.[0]?.display
@@ -1015,6 +1019,9 @@ export function FHIRResourceProvider({ children }) {
                   return {
                     ...medRequest,
                     _resolvedMedicationCodeableConcept: medication.code,
+                    // Full-resource name (Medication.identifier can carry it
+                    // when code is a bare NDC — true for ALL MIMIC medications)
+                    _resolvedMedicationDisplay: getMedicationResourceDisplay(medication),
                     medicationReference: {
                       ...medRequest.medicationReference,
                       display: medication.code.text || medication.code.coding?.[0]?.display
@@ -1313,6 +1320,9 @@ export function FHIRResourceProvider({ children }) {
                   return {
                     ...medRequest,
                     _resolvedMedicationCodeableConcept: medication.code,
+                    // Full-resource name (Medication.identifier can carry it
+                    // when code is a bare NDC — true for ALL MIMIC medications)
+                    _resolvedMedicationDisplay: getMedicationResourceDisplay(medication),
                     medicationReference: {
                       ...medRequest.medicationReference,
                       display: medication.code.text || medication.code.coding?.[0]?.display
@@ -1648,6 +1658,9 @@ export function FHIRResourceProvider({ children }) {
                     return {
                       ...medRequest,
                       _resolvedMedicationCodeableConcept: medication.code,
+                    // Full-resource name (Medication.identifier can carry it
+                    // when code is a bare NDC — true for ALL MIMIC medications)
+                    _resolvedMedicationDisplay: getMedicationResourceDisplay(medication),
                       medicationReference: {
                         ...medRequest.medicationReference,
                         display: medication.code.text || medication.code.coding?.[0]?.display

--- a/frontend/src/core/fhir/hooks/useMedicationResolver.js
+++ b/frontend/src/core/fhir/hooks/useMedicationResolver.js
@@ -8,7 +8,7 @@
  * and memoizes results in a module-level cache shared across consumers.
  */
 import { useState, useEffect, useCallback, useMemo } from 'react';
-import { getCodeableConceptDisplay } from '../utils/fhirFieldUtils';
+import { getCodeableConceptDisplay, getMedicationResourceDisplay } from '../utils/fhirFieldUtils';
 import { fhirClient } from '../services/fhirClient';
 import { useFHIRResource } from '../../../contexts/FHIRResourceContext';
 
@@ -175,7 +175,7 @@ export const useMedicationResolver = (medicationRequests = []) => {
           if (containedCacheKey && medicationCache.has(containedCacheKey)) {
             const medication = medicationCache.get(containedCacheKey);
             if (medication) {
-              const medName = getCodeableConceptDisplay(medication.code, 'Unknown medication');
+              const medName = getMedicationResourceDisplay(medication, 'Unknown medication');
               resolved[req.id] = {
                 name: medName,
                 code: medication.code,
@@ -192,7 +192,7 @@ export const useMedicationResolver = (medicationRequests = []) => {
               const medication = medicationCache.get(medicationId);
 
               if (medication) {
-                const medName = getCodeableConceptDisplay(medication.code, 'Unknown medication');
+                const medName = getMedicationResourceDisplay(medication, 'Unknown medication');
                 resolved[req.id] = {
                   name: medName,
                   code: medication.code,
@@ -239,6 +239,10 @@ export const useMedicationResolver = (medicationRequests = []) => {
     }
 
     // Check for enriched medication data (from _include resolution)
+    if (medicationRequest._resolvedMedicationDisplay) {
+      return medicationRequest._resolvedMedicationDisplay;
+    }
+
     if (medicationRequest._resolvedMedicationCodeableConcept) {
       const enrichedName = getCodeableConceptDisplay(
         medicationRequest._resolvedMedicationCodeableConcept, null);

--- a/frontend/src/core/fhir/utils/__tests__/truthfulDisplay.test.js
+++ b/frontend/src/core/fhir/utils/__tests__/truthfulDisplay.test.js
@@ -7,7 +7,7 @@
  * coding[0].display with no text, and ships Medication resources that are
  * bare NDC codes. "Unknown" when a real code exists is not truthful.
  */
-import { getCodeableConceptDisplay, getMedicationDisplay, isConditionActive, isMedicationActive } from '../fhirFieldUtils';
+import { getCodeableConceptDisplay, getMedicationDisplay, getMedicationResourceDisplay, isConditionActive, isMedicationActive } from '../fhirFieldUtils';
 import { getMedicationName } from '../medicationDisplayUtils';
 
 // Real shapes from mimic-iv-clinical-database-demo-on-fhir-2.1.0
@@ -21,6 +21,17 @@ const mimicConditionCode = {
 const ndcOnlyMedication = {
   id: 'med-ndc',
   code: { coding: [{ code: '51079030020', system: 'http://mimic.mit.edu/fhir/mimic/CodeSystem/mimic-medication-ndc' }] },
+};
+// The REAL full MIMIC shape: the human name lives in identifier[], not code —
+// true for all 1,480 Medications in the demo dataset.
+const mimicMedication = {
+  id: 'med-full',
+  code: { coding: [{ code: '51079030020', system: 'http://mimic.mit.edu/fhir/mimic/CodeSystem/mimic-medication-ndc' }] },
+  identifier: [
+    { system: 'http://mimic.mit.edu/fhir/mimic/identifier/mimic-medication-ndc', value: '51079030020' },
+    { system: 'http://mimic.mit.edu/fhir/mimic/identifier/mimic-medication-formulary-drug-cd', value: 'CATA2' },
+    { system: 'http://mimic.mit.edu/fhir/mimic/identifier/mimic-medication-name', value: 'CloniDINE' },
+  ],
 };
 
 describe('getCodeableConceptDisplay', () => {
@@ -48,6 +59,39 @@ describe('getCodeableConceptDisplay', () => {
   });
 });
 
+describe('getMedicationResourceDisplay — traverse the WHOLE Medication', () => {
+  it('finds the human name in identifier[] when code is a bare NDC (all MIMIC meds)', () => {
+    expect(getMedicationResourceDisplay(mimicMedication)).toBe('CloniDINE');
+  });
+
+  it('prefers code text/display when present', () => {
+    expect(getMedicationResourceDisplay({
+      ...mimicMedication,
+      code: { text: 'Clonidine HCl 0.1mg tablet', coding: mimicMedication.code.coding },
+    })).toBe('Clonidine HCl 0.1mg tablet');
+  });
+
+  it('name-system CODING code beats the identifier (closer to the concept)', () => {
+    expect(getMedicationResourceDisplay({
+      id: 'm', code: { coding: [{ code: 'vancomycin', system: 'http://mimic.mit.edu/fhir/mimic/CodeSystem/mimic-medication-name' }] },
+    })).toBe('vancomycin');
+  });
+
+  it('falls back to the bare code only when no name exists anywhere', () => {
+    expect(getMedicationResourceDisplay(ndcOnlyMedication)).toBe('51079030020');
+  });
+});
+
+describe('name-system codings in CodeableConcepts (MIMIC Dispense shape)', () => {
+  it('prefers the name-system coding over other bare codes', () => {
+    const concept = { coding: [
+      { code: '00409672924', system: 'http://mimic.mit.edu/fhir/mimic/CodeSystem/mimic-medication-ndc' },
+      { code: 'Calcium Gluconate', system: 'http://mimic.mit.edu/fhir/mimic/CodeSystem/mimic-medication-name' },
+    ]};
+    expect(getCodeableConceptDisplay(concept)).toBe('Calcium Gluconate');
+  });
+});
+
 describe('medicationReference resolution (MIMIC MedicationRequest shape)', () => {
   const mimicMedRequest = {
     id: 'mr-1',
@@ -55,13 +99,25 @@ describe('medicationReference resolution (MIMIC MedicationRequest shape)', () =>
     medicationReference: { reference: 'Medication/med-ndc' },
   };
 
-  it('getMedicationName resolves through a lookup map to the NDC code', () => {
+  it('getMedicationName resolves through a lookup map — to the NAME, via identifier', () => {
+    const req = { ...mimicMedRequest, medicationReference: { reference: 'Medication/med-full' } };
+    expect(getMedicationName(req, { 'med-full': mimicMedication })).toBe('CloniDINE');
+  });
+
+  it('getMedicationName resolves through an array lookup', () => {
+    const req = { ...mimicMedRequest, medicationReference: { reference: 'Medication/med-full' } };
+    expect(getMedicationName(req, [mimicMedication])).toBe('CloniDINE');
+  });
+
+  it('degrades to the NDC only when the Medication truly has no name', () => {
     expect(getMedicationName(mimicMedRequest, { 'med-ndc': ndcOnlyMedication }))
       .toBe('51079030020');
   });
 
-  it('getMedicationName resolves through an array lookup', () => {
-    expect(getMedicationName(mimicMedRequest, [ndcOnlyMedication])).toBe('51079030020');
+  it('the fetch-layer display stamp wins (it saw the full resource)', () => {
+    const stamped = { ...mimicMedRequest, _resolvedMedicationDisplay: 'CloniDINE' };
+    expect(getMedicationDisplay(stamped)).toBe('CloniDINE');
+    expect(getMedicationName(stamped)).toBe('CloniDINE');
   });
 
   it('getMedicationDisplay reads the concept the fetch layer stamps from _include', () => {

--- a/frontend/src/core/fhir/utils/fhirFieldUtils.js
+++ b/frontend/src/core/fhir/utils/fhirFieldUtils.js
@@ -147,10 +147,13 @@ export const getCodeableConceptDisplay = (codeableConcept, defaultValue = 'Unkno
 
   // text is optional in FHIR; display is optional per coding. Fall back to
   // the FIRST coding that has a display (not blindly coding[0] — datasets
-  // like MIMIC-on-FHIR put a bare NDC first), then to the first code:
-  // showing the real code is truthful; "Unknown" when a code exists is not.
+  // like MIMIC-on-FHIR put a bare NDC first), then to a coding from a
+  // name-carrying system (e.g. mimic-medication-name, where the CODE is the
+  // human-readable name), then to the first code: showing the real code is
+  // truthful; "Unknown" when a code exists is not.
   return codeableConcept.text ||
          codeableConcept.coding?.find(c => c.display)?.display ||
+         codeableConcept.coding?.find(c => /-name$/.test(c.system || ''))?.code ||
          codeableConcept.coding?.[0]?.code ||
          defaultValue;
 };
@@ -592,6 +595,32 @@ export const getObservationValueDisplay = (observation) => {
  * @param {string} options.defaultValue - Default if no display found
  * @returns {string} - Human-readable medication description
  */
+/**
+ * Display name for a Medication RESOURCE (not a request).
+ *
+ * Traverses everywhere the name can actually live — found the hard way with
+ * MIMIC-on-FHIR, whose 1,480 Medication resources ALL carry the human name
+ * in identifier[] (system …/mimic-medication-name) while code holds only a
+ * bare NDC. Chain: code text/display → name-system coding → name-system
+ * identifier → any code.
+ */
+export const getMedicationResourceDisplay = (medication, defaultValue = 'Unknown medication') => {
+  if (!medication) return defaultValue;
+
+  const concept = medication.code;
+  const fromConcept = concept?.text ||
+                      concept?.coding?.find(c => c.display)?.display ||
+                      concept?.coding?.find(c => /-name$/.test(c.system || ''))?.code;
+  if (fromConcept) return fromConcept;
+
+  const nameIdentifier = medication.identifier?.find(
+    i => /-name$/.test(i.system || '') && i.value
+  );
+  if (nameIdentifier) return nameIdentifier.value;
+
+  return concept?.coding?.[0]?.code || defaultValue;
+};
+
 export const getMedicationDisplay = (medicationRequest, options = {}) => {
   const { includeDosage = false, defaultValue = 'Unknown Medication', medicationLookup = null } = options;
 
@@ -603,6 +632,12 @@ export const getMedicationDisplay = (medicationRequest, options = {}) => {
   // medicationCodeableConcept
   if (medicationRequest.medicationCodeableConcept) {
     display = getCodeableConceptDisplay(medicationRequest.medicationCodeableConcept, defaultValue);
+  }
+  // Name computed by the fetch layer from the FULL _include'd Medication
+  // (covers names stored in Medication.identifier, which the bare concept
+  // stamp below cannot carry)
+  else if (medicationRequest._resolvedMedicationDisplay) {
+    display = medicationRequest._resolvedMedicationDisplay;
   }
   // Concept stamped onto the request by FHIRResourceContext from the
   // _include'd Medication resource
@@ -620,8 +655,8 @@ export const getMedicationDisplay = (medicationRequest, options = {}) => {
       const medication = Array.isArray(medicationLookup)
         ? medicationLookup.find(m => m.id === medId)
         : medicationLookup[medId];
-      if (medication?.code) {
-        display = getCodeableConceptDisplay(medication.code, defaultValue);
+      if (medication) {
+        display = getMedicationResourceDisplay(medication, defaultValue);
       }
     }
   }

--- a/frontend/src/core/fhir/utils/medicationDisplayUtils.js
+++ b/frontend/src/core/fhir/utils/medicationDisplayUtils.js
@@ -3,7 +3,7 @@
  * Shared functions for consistent medication information display across the application
  */
 
-import { getCodeableConceptDisplay } from './fhirFieldUtils';
+import { getCodeableConceptDisplay, getMedicationResourceDisplay } from './fhirFieldUtils';
 
 /**
  * Gets medication name from either R4 (medicationCodeableConcept) or R5 (medication.concept) format
@@ -25,6 +25,11 @@ export const getMedicationName = (medicationRequest, medicationsLookup = null) =
   if (medicationRequest.medicationCodeableConcept) {
     const concept = medicationRequest.medicationCodeableConcept;
     return getCodeableConceptDisplay(concept, 'Unknown medication');
+  }
+
+  // Name computed by the fetch layer from the full _include'd Medication
+  if (medicationRequest._resolvedMedicationDisplay) {
+    return medicationRequest._resolvedMedicationDisplay;
   }
 
   // Check for resolved medication concept (added by FHIRResourceContext from _include)
@@ -55,8 +60,8 @@ export const getMedicationName = (medicationRequest, medicationsLookup = null) =
         medication = medicationsLookup[medicationId];
       }
 
-      if (medication?.code) {
-        return getCodeableConceptDisplay(medication.code, 'Unknown medication');
+      if (medication) {
+        return getMedicationResourceDisplay(medication, 'Unknown medication');
       }
     }
 


### PR DESCRIPTION
Round 2, prompted by the review question *'are we appropriately using everything the resources carry?'* — the answer was no, twice.

## 1. The medication names were there all along

I audited `Medication.code`, found bare NDCs, and wrongly declared that the ceiling. A full-resource audit shows **all 1,480 MIMIC Medications carry the human name in `identifier[]`** (`mimic-medication-name` → `CloniDINE`, `Octreotide Acetate`, …).

- New `getMedicationResourceDisplay`: `code.text/display → name-system coding → name-system identifier → bare code`
- The `_include` stamps in FHIRResourceContext now carry the **computed display** — the concept-only stamp physically couldn't transport identifier-borne names
- Every path (lookup, resolver hook, stamp readers) routes through it
- `getCodeableConceptDisplay` prefers name-system codings over other systems' bare codes (Dispense stores `'Calcium Gluconate'` as a *code*)

Result: **real drug names**, not NDCs, for every MIMIC medication.

## 2. Patient death was never surfaced

31% of MIMIC demo patients carry `deceasedDateTime`; the UI rendered them indistinguishably from living patients. The summary header now shows **Deceased <date>** when the record says so.

## Inventoried, available, not yet displayed (candidates, not defects)

`Patient.maritalStatus` / `communication.language` / us-core race+ethnicity (100% populated), lab `note` (15%), Condition→Encounter period traversal.

## Verification

7 new tests with the literal full MIMIC shapes. Suite **544/544**, eslint **0 errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)