### PR TITLE
fix(frontend): resolve medication mixtures — ingredient traversal + mix-identifier parse

### DIFF
--- a/frontend/src/core/fhir/utils/__tests__/truthfulDisplay.test.js
+++ b/frontend/src/core/fhir/utils/__tests__/truthfulDisplay.test.js
@@ -82,6 +82,43 @@ describe('getMedicationResourceDisplay — traverse the WHOLE Medication', () =>
   });
 });
 
+describe('medication mixtures (MIMIC MedicationMix shape — no code at all)', () => {
+  // Literal shape from MimicMedicationMix.ndjson.gz
+  const mixMedication = {
+    id: 'mix-1',
+    status: 'active',
+    identifier: [{
+      system: 'http://mimic.mit.edu/fhir/mimic/identifier/medication-mix',
+      value: 'Sodium Phosphate--NAPH15I--00409739172_0.9% Sodium Chloride--NS250--00338004902',
+    }],
+    ingredient: [
+      { itemReference: { reference: 'Medication/comp-a' } },
+      { itemReference: { reference: 'Medication/comp-b' } },
+    ],
+  };
+  const componentA = {
+    id: 'comp-a',
+    code: { coding: [{ code: '00409739172', system: 'http://mimic.mit.edu/fhir/mimic/CodeSystem/mimic-medication-ndc' }] },
+    identifier: [{ system: 'http://mimic.mit.edu/fhir/mimic/identifier/mimic-medication-name', value: 'Sodium Phosphate' }],
+  };
+  const componentB = {
+    id: 'comp-b',
+    code: { coding: [{ code: '00338004902', system: 'http://mimic.mit.edu/fhir/mimic/CodeSystem/mimic-medication-ndc' }] },
+    identifier: [{ system: 'http://mimic.mit.edu/fhir/mimic/identifier/mimic-medication-name', value: '0.9% Sodium Chloride' }],
+  };
+
+  it('resolves component names through the lookup (ingredient traversal)', () => {
+    expect(getMedicationResourceDisplay(mixMedication, 'Unknown medication',
+      { 'comp-a': componentA, 'comp-b': componentB }))
+      .toBe('Sodium Phosphate + 0.9% Sodium Chloride');
+  });
+
+  it('parses the mix identifier when components are not loadable', () => {
+    expect(getMedicationResourceDisplay(mixMedication))
+      .toBe('Sodium Phosphate + 0.9% Sodium Chloride');
+  });
+});
+
 describe('name-system codings in CodeableConcepts (MIMIC Dispense shape)', () => {
   it('prefers the name-system coding over other bare codes', () => {
     const concept = { coding: [

--- a/frontend/src/core/fhir/utils/fhirFieldUtils.js
+++ b/frontend/src/core/fhir/utils/fhirFieldUtils.js
@@ -604,7 +604,7 @@ export const getObservationValueDisplay = (observation) => {
  * bare NDC. Chain: code text/display → name-system coding → name-system
  * identifier → any code.
  */
-export const getMedicationResourceDisplay = (medication, defaultValue = 'Unknown medication') => {
+export const getMedicationResourceDisplay = (medication, defaultValue = 'Unknown medication', lookup = null) => {
   if (!medication) return defaultValue;
 
   const concept = medication.code;
@@ -617,6 +617,37 @@ export const getMedicationResourceDisplay = (medication, defaultValue = 'Unknown
     i => /-name$/.test(i.system || '') && i.value
   );
   if (nameIdentifier) return nameIdentifier.value;
+
+  // Mixtures (e.g. MIMIC MedicationMix) have NO code at all — the composition
+  // lives in ingredient[].itemReference. Resolve components through the
+  // lookup when the caller has one, joining their names.
+  if (medication.ingredient?.length) {
+    const componentNames = medication.ingredient
+      .map(ing => {
+        const ref = ing.itemReference?.reference || '';
+        const compId = ref.replace('Medication/', '');
+        const component = lookup &&
+          (Array.isArray(lookup) ? lookup.find(m => m.id === compId) : lookup[compId]);
+        // note: components carry their own identifier names — recurse
+        return ing.itemCodeableConcept
+          ? getCodeableConceptDisplay(ing.itemCodeableConcept, null)
+          : (component ? getMedicationResourceDisplay(component, null, lookup) : null);
+      })
+      .filter(Boolean);
+    if (componentNames.length) return componentNames.join(' + ');
+
+    // No lookup can resolve the components, but the mix identifier itself
+    // encodes them: "{name}--{formulary}--{ndc}_{name}--{formulary}--{ndc}".
+    const mixIdentifier = medication.identifier?.find(
+      i => /medication-mix$/.test(i.system || '') && i.value
+    );
+    if (mixIdentifier) {
+      const names = mixIdentifier.value.split('_')
+        .map(part => part.split('--')[0].trim())
+        .filter(Boolean);
+      if (names.length) return names.join(' + ');
+    }
+  }
 
   return concept?.coding?.[0]?.code || defaultValue;
 };
@@ -656,7 +687,7 @@ export const getMedicationDisplay = (medicationRequest, options = {}) => {
         ? medicationLookup.find(m => m.id === medId)
         : medicationLookup[medId];
       if (medication) {
-        display = getMedicationResourceDisplay(medication, defaultValue);
+        display = getMedicationResourceDisplay(medication, defaultValue, medicationLookup);
       }
     }
   }

--- a/frontend/src/core/fhir/utils/medicationDisplayUtils.js
+++ b/frontend/src/core/fhir/utils/medicationDisplayUtils.js
@@ -61,7 +61,7 @@ export const getMedicationName = (medicationRequest, medicationsLookup = null) =
       }
 
       if (medication) {
-        return getMedicationResourceDisplay(medication, 'Unknown medication');
+        return getMedicationResourceDisplay(medication, 'Unknown medication', medicationsLookup);
       }
     }
 


### PR DESCRIPTION
Third traversal layer, found while **live-verifying #277 on wintehrdev**: the first Medication I sampled had no name because it's one of MIMIC's 314 `MedicationMix` resources — **no `code` element at all**. The composition lives in `ingredient[].itemReference` → component Medications, and the mix `identifier` value literally encodes the components (`{name}--{formulary}--{ndc}_{name}--…`).

`getMedicationResourceDisplay` now, after the code/identifier chain:
1. **traverses `ingredient[]`** through the caller's lookup, joining component names — `Sodium Phosphate + 0.9% Sodium Chloride` — recursing so components' identifier-borne names resolve;
2. **parses the medication-mix identifier** when no lookup can supply components (the `_include` pulls only the mix, not its ingredients) — same names, encoded in the value.

Two tests pin both routes with the literal MedicationMix shape. Suite **555/555**, eslint **0 errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)