### PR TITLE
refactor(notebooks): simplify the MIMIC import notebook for sharing

### DIFF
--- a/notebooks/01_import_mimic_on_fhir.ipynb
+++ b/notebooks/01_import_mimic_on_fhir.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "d5ec0ddf",
+   "id": "29f14946",
    "metadata": {},
    "source": [
     "# 01 · Import MIMIC-IV-on-FHIR demo → WintEHR\n",
@@ -10,15 +10,15 @@
     "— 100 de-identified patients as ready-made FHIR R4 NDJSON — into a WintEHR HAPI server as\n",
     "idempotent `PUT`-by-id transaction Bundles.\n",
     "\n",
-    "**What it handles for you:** dependency ordering (Organization → … → Observations, so HAPI's\n",
-    "referential integrity never trips), patient subsetting (the full demo is ~929k resources;\n",
-    "default imports the 5 richest patients), a provenance `meta.tag` on every imported resource\n",
-    "(so verification and cleanup can find exactly what this notebook wrote), and structural\n",
-    "validation before anything is sent.\n",
+    "**What it handles for you:** dependency ordering (so HAPI's referential integrity never\n",
+    "trips), patient subsetting (the full demo is ~929k resources; default imports the 5 richest\n",
+    "patients), a provenance `meta.tag` on every imported resource (so verification and cleanup\n",
+    "can find exactly what this notebook wrote), and structural validation before anything is sent.\n",
     "\n",
-    "**Resource types:** Patient, Encounter (hosp/ED/ICU), Condition, Procedure, Medication +\n",
-    "Request/Dispense/Administration/Statement, Specimen, Observation (labs, micro, ED vitals,\n",
-    "ICU flowsheet), Location, Organization.\n",
+    "**Prerequisites**\n",
+    "- Python 3.9+ with `requests` (`pip install requests`)\n",
+    "- The demo dataset downloaded from PhysioNet and unzipped (default: `~/Downloads/`)\n",
+    "- A running WintEHR — set `FHIR_BASE` below\n",
     "\n",
     "_MIMIC dates are de-identified (shifted ~a century forward) but internally consistent —\n",
     "expect encounter years like 2180._"
@@ -27,13 +27,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "1d916a31",
+   "id": "8c151f7f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-26T16:58:08.290908Z",
-     "iopub.status.busy": "2026-07-26T16:58:08.290805Z",
-     "iopub.status.idle": "2026-07-26T16:58:08.341447Z",
-     "shell.execute_reply": "2026-07-26T16:58:08.341196Z"
+     "iopub.execute_input": "2026-07-26T17:55:46.589081Z",
+     "iopub.status.busy": "2026-07-26T17:55:46.588986Z",
+     "iopub.status.idle": "2026-07-26T17:55:46.633785Z",
+     "shell.execute_reply": "2026-07-26T17:55:46.633544Z"
     }
    },
    "outputs": [
@@ -42,8 +42,7 @@
      "output_type": "stream",
      "text": [
       "data dir : /Users/robertbarrett/Downloads/mimic-iv-clinical-database-demo-on-fhir-2.1.0/fhir\n",
-      "target   : http://localhost:8888/fhir\n",
-      "files    : 25 | ICU flowsheet: skipped\n"
+      "target   : http://localhost:8888/fhir\n"
      ]
     }
    ],
@@ -53,13 +52,13 @@
     "import requests\n",
     "\n",
     "# ---- Config: edit these -------------------------------------------------\n",
-    "DATA_DIR   = pathlib.Path.home() / \"Downloads\" / \"mimic-iv-clinical-database-demo-on-fhir-2.1.0\" / \"fhir\"\n",
+    "DATA_DIR = pathlib.Path.home() / \"Downloads\" / \"mimic-iv-clinical-database-demo-on-fhir-2.1.0\" / \"fhir\"\n",
     "\n",
     "# WintEHR FHIR endpoints (pick one):\n",
     "#   local dev stack          : http://localhost:8888/fhir        (HAPI direct)\n",
-    "#   wintehrdev via SSH tunnel: http://localhost:18888/fhir       (ssh -L 18888:localhost:8888 azureuser@wintehrdev...)\n",
+    "#   wintehrdev via SSH tunnel: http://localhost:8888/fhir        (ssh -L 8888:localhost:80 azureuser@wintehrdev...)\n",
     "#   wintehrdev via app proxy : http://wintehrdev.eastus.cloudapp.azure.com/fhir\n",
-    "FHIR_BASE  = \"http://localhost:8888/fhir\"\n",
+    "FHIR_BASE = \"http://localhost:8888/fhir\"\n",
     "\n",
     "LIMIT_PATIENTS = 5      # 5 richest patients ≈ a few 10k resources. None = all 100 (~929k, hours)\n",
     "PATIENT_IDS    = []     # explicit MimicPatient UUIDs override LIMIT_PATIENTS\n",
@@ -69,7 +68,45 @@
     "# Every imported resource gets this tag — verification + cleanup key off it.\n",
     "TAG = {\"system\": \"http://wintehr.local/fhir/import\", \"code\": \"mimic-iv-fhir-demo-2.1.0\"}\n",
     "\n",
-    "# ---- Dependency-ordered file list (referential integrity holds at every step)\n",
+    "print(\"data dir :\", DATA_DIR)\n",
+    "print(\"target   :\", FHIR_BASE)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cf0578f4",
+   "metadata": {},
+   "source": [
+    "## 1 · Ingestion order — the dependency graph\n",
+    "HAPI enforces referential integrity on write: a resource whose reference points at\n",
+    "something the server hasn't seen yet is rejected. So files go up in an order where\n",
+    "every reference target already exists — infrastructure first, patients, encounters,\n",
+    "then everything that points at them.\n",
+    "\n",
+    "**One knot can't be untied by ordering alone.** The microbiology trio cross-references\n",
+    "in *both* directions (`Test --hasMember--> Org --hasMember--> Susc`, while `Org`/`Susc`\n",
+    "point back up via `derivedFrom`), so whichever file goes first, something it references\n",
+    "doesn't exist yet. The escape hatch: send a patient's whole micro chain in **one**\n",
+    "transaction Bundle — HAPI resolves references *within* a transaction regardless of order.\n",
+    "Groups listed in `PATIENT_CLOSED` get exactly that treatment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "683c4e92",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-26T17:55:46.635104Z",
+     "iopub.status.busy": "2026-07-26T17:55:46.635024Z",
+     "iopub.status.idle": "2026-07-26T17:55:46.637871Z",
+     "shell.execute_reply": "2026-07-26T17:55:46.637664Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# (group_name, [files]) in ingestion order. Singles are written as plain\n",
+    "# strings and normalized to one-file groups when read.\n",
     "FILES = [\n",
     "    \"MimicOrganization\", \"MimicLocation\",                      # infrastructure\n",
     "    \"MimicMedication\", \"MimicMedicationMix\",                   # Mix ingredients ref Medication\n",
@@ -82,51 +119,49 @@
     "    \"MimicMedicationStatementED\",\n",
     "    \"MimicCondition\", \"MimicConditionED\",\n",
     "    \"MimicProcedure\", \"MimicProcedureED\", \"MimicProcedureICU\",\n",
-    "    # The microbiology trio cross-references BOTH ways (Test --hasMember-->\n",
-    "    # Org --hasMember--> Susc, while Org/Susc --derivedFrom--> back up), so no\n",
-    "    # file order satisfies referential integrity. They are merged into ONE\n",
-    "    # group below and ingested in patient-closed transactions.\n",
     "    (\"Microbiology\", [\"MimicObservationMicroTest\", \"MimicObservationMicroOrg\",\n",
     "                      \"MimicObservationMicroSusc\"]),\n",
     "    \"MimicObservationLabevents\", \"MimicObservationED\", \"MimicObservationVitalSignsED\",\n",
     "]\n",
-    "ICU_FLOWSHEET = [\"MimicObservationChartevents\", \"MimicObservationDatetimeevents\",\n",
-    "                 \"MimicObservationOutputevents\"]\n",
     "if INCLUDE_ICU_FLOWSHEET:\n",
-    "    FILES += ICU_FLOWSHEET\n",
+    "    FILES += [\"MimicObservationChartevents\", \"MimicObservationDatetimeevents\",\n",
+    "              \"MimicObservationOutputevents\"]\n",
+    "\n",
+    "# Groups whose resources cross-reference each other WITHIN a patient — a\n",
+    "# patient's rows must travel in a single transaction (see §1).\n",
+    "PATIENT_CLOSED = {\"Microbiology\"}\n",
     "\n",
     "# Loaded in full regardless of patient selection (shared, tiny):\n",
     "SHARED = {\"MimicOrganization\", \"MimicLocation\", \"MimicMedication\", \"MimicMedicationMix\"}\n",
     "\n",
+    "def as_group(entry):\n",
+    "    return entry if isinstance(entry, tuple) else (entry, [entry])\n",
+    "\n",
     "def read_ndjson(name):\n",
     "    with gzip.open(DATA_DIR / f\"{name}.ndjson.gz\", \"rt\") as f:\n",
     "        for line in f:\n",
-    "            yield json.loads(line)\n",
-    "\n",
-    "print(\"data dir :\", DATA_DIR)\n",
-    "print(\"target   :\", FHIR_BASE)\n",
-    "print(\"files    :\", len(FILES), \"| ICU flowsheet:\", \"included\" if INCLUDE_ICU_FLOWSHEET else \"skipped\")"
+    "            yield json.loads(line)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "35df9d09",
+   "id": "d4282499",
    "metadata": {},
    "source": [
-    "## 1 · Inventory the dataset\n",
+    "## 2 · Inventory the dataset\n",
     "Count resources per file and confirm the server is reachable before doing any work."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "49dc6a38",
+   "execution_count": 3,
+   "id": "09af1ba0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-26T16:58:08.342689Z",
-     "iopub.status.busy": "2026-07-26T16:58:08.342602Z",
-     "iopub.status.idle": "2026-07-26T16:58:10.859134Z",
-     "shell.execute_reply": "2026-07-26T16:58:10.858473Z"
+     "iopub.execute_input": "2026-07-26T17:55:46.638939Z",
+     "iopub.status.busy": "2026-07-26T17:55:46.638874Z",
+     "iopub.status.idle": "2026-07-26T17:55:48.893378Z",
+     "shell.execute_reply": "2026-07-26T17:55:48.893028Z"
     }
    },
    "outputs": [
@@ -144,7 +179,13 @@
       "MimicEncounterICU                           140\n",
       "MimicSpecimen                              1336\n",
       "MimicSpecimenLab                          11122\n",
-      "MimicMedicationRequest                    17552\n",
+      "MimicMedicationRequest                    17552\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "MimicMedicationDispense                   14293\n",
       "MimicMedicationDispenseED                  1082\n"
      ]
@@ -153,7 +194,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "MimicMedicationAdministration             36131\n",
+      "MimicMedicationAdministration             36131\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "MimicMedicationAdministrationICU          20404\n",
       "MimicMedicationStatementED                 2411\n",
       "MimicCondition                             4506\n",
@@ -188,7 +235,7 @@
    "source": [
     "counts = {}\n",
     "for entry in FILES:\n",
-    "    for name in (entry[1] if isinstance(entry, tuple) else [entry]):\n",
+    "    for name in as_group(entry)[1]:\n",
     "        counts[name] = sum(1 for _ in read_ndjson(name))\n",
     "        print(f\"{name:38s} {counts[name]:8d}\")\n",
     "print(f\"{'TOTAL (selected files)':38s} {sum(counts.values()):8d}\")\n",
@@ -200,25 +247,25 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d01feb1d",
+   "id": "baee2eaa",
    "metadata": {},
    "source": [
-    "## 2 · Select patients\n",
+    "## 3 · Select patients\n",
     "The demo holds 100 patients but resource volume is heavily skewed. Rank patients by how much\n",
-    "clinical data they carry (encounters + meds + labs) and keep the top `LIMIT_PATIENTS` —\n",
-    "or set `PATIENT_IDS` explicitly. Shared resources (Organization/Location/Medication) always load."
+    "clinical data they carry (encounters + meds + labs + conditions) and keep the top\n",
+    "`LIMIT_PATIENTS` — or set `PATIENT_IDS` explicitly. Shared resources always load."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "3663c2bf",
+   "execution_count": 4,
+   "id": "45e62b7f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-26T16:58:10.861558Z",
-     "iopub.status.busy": "2026-07-26T16:58:10.861379Z",
-     "iopub.status.idle": "2026-07-26T16:58:11.596682Z",
-     "shell.execute_reply": "2026-07-26T16:58:11.596410Z"
+     "iopub.execute_input": "2026-07-26T17:55:48.894730Z",
+     "iopub.status.busy": "2026-07-26T17:55:48.894648Z",
+     "iopub.status.idle": "2026-07-26T17:55:49.686251Z",
+     "shell.execute_reply": "2026-07-26T17:55:49.685946Z"
     }
    },
    "outputs": [
@@ -264,24 +311,29 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9821c8ba",
+   "id": "cb7b5499",
    "metadata": {},
    "source": [
-    "## 3 · Load + filter (dependency order)\n",
+    "## 4 · Load + filter (dependency order)\n",
     "Keep a resource if it is shared infrastructure or belongs to a selected patient\n",
-    "(any `Patient/…` reference it carries). Each kept resource gets the provenance tag."
+    "(every `Patient/…` reference it carries is in the selected set). Each kept resource\n",
+    "gets the provenance tag.\n",
+    "\n",
+    "Rows are stored as **atoms** — indivisible units the ingester never splits across\n",
+    "transactions. For a normal file an atom is a single resource; for a `PATIENT_CLOSED`\n",
+    "group an atom is one patient's entire cross-referencing chain."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "d240076f",
+   "execution_count": 5,
+   "id": "a0da3372",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-26T16:58:11.597953Z",
-     "iopub.status.busy": "2026-07-26T16:58:11.597885Z",
-     "iopub.status.idle": "2026-07-26T16:58:14.522213Z",
-     "shell.execute_reply": "2026-07-26T16:58:14.521918Z"
+     "iopub.execute_input": "2026-07-26T17:55:49.687625Z",
+     "iopub.status.busy": "2026-07-26T17:55:49.687537Z",
+     "iopub.status.idle": "2026-07-26T17:55:53.333391Z",
+     "shell.execute_reply": "2026-07-26T17:55:53.333097Z"
     }
    },
    "outputs": [
@@ -343,69 +395,71 @@
     }
    ],
    "source": [
-    "def patient_refs(o, out):\n",
-    "    if isinstance(o, dict):\n",
-    "        for k, v in o.items():\n",
-    "            if k == \"reference\" and isinstance(v, str) and v.startswith(\"Patient/\"):\n",
-    "                out.add(v.split(\"/\", 1)[1])\n",
+    "def iter_refs(obj):\n",
+    "    \"\"\"Yield every reference string ('Type/id') anywhere in a resource.\"\"\"\n",
+    "    if isinstance(obj, dict):\n",
+    "        for k, v in obj.items():\n",
+    "            if k == \"reference\" and isinstance(v, str) and \"/\" in v:\n",
+    "                yield v\n",
     "            else:\n",
-    "                patient_refs(v, out)\n",
-    "    elif isinstance(o, list):\n",
-    "        for v in o:\n",
-    "            patient_refs(v, out)\n",
-    "    return out\n",
+    "                yield from iter_refs(v)\n",
+    "    elif isinstance(obj, list):\n",
+    "        for v in obj:\n",
+    "            yield from iter_refs(v)\n",
     "\n",
     "def tag(r):\n",
     "    r.setdefault(\"meta\", {}).setdefault(\"tag\", []).append(dict(TAG))\n",
     "    return r\n",
     "\n",
-    "batches = []   # (group_name, [resources], patient_closed) in dependency order\n",
+    "batches = []   # (group_name, [atom, ...]); each atom is a list of resources\n",
     "kept = 0\n",
     "for entry in FILES:\n",
-    "    name, parts = entry if isinstance(entry, tuple) else (entry, [entry])\n",
-    "    patient_closed = isinstance(entry, tuple)   # merged groups chunk on patient boundaries\n",
-    "    rows = []\n",
+    "    name, parts = as_group(entry)\n",
+    "    per_patient = defaultdict(list)   # used only for PATIENT_CLOSED groups\n",
+    "    atoms = []\n",
     "    for part in parts:\n",
     "        for r in read_ndjson(part):\n",
     "            if part in SHARED:\n",
-    "                rows.append(tag(r))\n",
+    "                atoms.append([tag(r)])\n",
     "            elif part == \"MimicPatient\":\n",
     "                if r[\"id\"] in sel:\n",
-    "                    rows.append(tag(r))\n",
+    "                    atoms.append([tag(r)])\n",
     "            else:\n",
-    "                refs = patient_refs(r, set())\n",
+    "                refs = {ref.split(\"/\", 1)[1] for ref in iter_refs(r) if ref.startswith(\"Patient/\")}\n",
     "                if refs and refs <= sel:\n",
-    "                    r[\"_pt\"] = next(iter(refs))   # stripped before send\n",
-    "                    rows.append(tag(r))\n",
-    "    if patient_closed:\n",
-    "        rows.sort(key=lambda r: r.get(\"_pt\", \"\"))  # group each patient contiguously\n",
-    "    batches.append((name, rows, patient_closed))\n",
-    "    total = sum(counts[p] for p in parts)\n",
-    "    kept += len(rows)\n",
-    "    print(f\"{name:38s} kept {len(rows):7d} / {total:7d}\")\n",
+    "                    if name in PATIENT_CLOSED:\n",
+    "                        per_patient[min(refs)].append(tag(r))\n",
+    "                    else:\n",
+    "                        atoms.append([tag(r)])\n",
+    "    atoms += list(per_patient.values())\n",
+    "    batches.append((name, atoms))\n",
+    "    n = sum(len(a) for a in atoms)\n",
+    "    kept += n\n",
+    "    print(f\"{name:38s} kept {n:7d} / {sum(counts[p] for p in parts):7d}\")\n",
     "print(f\"{'TOTAL to import':38s} {kept:12d}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "62576e8f",
+   "id": "82dba2c0",
    "metadata": {},
    "source": [
-    "## 4 · Structural validation\n",
-    "No external deps: unique type/id pairs, and every internal reference to a type we import\n",
-    "must resolve within the import set (references we don't import at all are listed, not fatal)."
+    "## 5 · Structural validation\n",
+    "No external deps: type/id pairs must be unique, and every reference to a type we import\n",
+    "must resolve within the import set. Catching this here beats decoding an\n",
+    "`OperationOutcome` mid-upload."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "862b43a6",
+   "execution_count": 6,
+   "id": "076f746a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-26T16:58:14.523434Z",
-     "iopub.status.busy": "2026-07-26T16:58:14.523362Z",
-     "iopub.status.idle": "2026-07-26T16:58:14.904875Z",
-     "shell.execute_reply": "2026-07-26T16:58:14.904566Z"
+     "iopub.execute_input": "2026-07-26T17:55:53.334708Z",
+     "iopub.status.busy": "2026-07-26T17:55:53.334627Z",
+     "iopub.status.idle": "2026-07-26T17:55:53.869714Z",
+     "shell.execute_reply": "2026-07-26T17:55:53.869471Z"
     }
    },
    "outputs": [
@@ -420,34 +474,25 @@
     }
    ],
    "source": [
-    "def all_refs(o, out):\n",
-    "    if isinstance(o, dict):\n",
-    "        for k, v in o.items():\n",
-    "            if k == \"reference\" and isinstance(v, str) and \"/\" in v:\n",
-    "                out.append(v)\n",
-    "            else:\n",
-    "                all_refs(v, out)\n",
-    "    elif isinstance(o, list):\n",
-    "        for v in o:\n",
-    "            all_refs(v, out)\n",
-    "    return out\n",
-    "\n",
     "ids, dupes = set(), 0\n",
-    "imported_types = set()\n",
-    "for name, rows, _pc in batches:\n",
-    "    for r in rows:\n",
-    "        key = f\"{r['resourceType']}/{r['id']}\"\n",
-    "        dupes += key in ids\n",
-    "        ids.add(key)\n",
-    "        imported_types.add(r[\"resourceType\"])\n",
+    "for name, atoms in batches:\n",
+    "    for atom in atoms:\n",
+    "        for r in atom:\n",
+    "            key = f\"{r['resourceType']}/{r['id']}\"\n",
+    "            if key in ids:\n",
+    "                dupes += 1\n",
+    "            ids.add(key)\n",
+    "\n",
+    "local_counts = Counter(key.split(\"/\", 1)[0] for key in ids)\n",
     "\n",
     "unresolved = Counter()\n",
-    "for name, rows, _pc in batches:\n",
-    "    for r in rows:\n",
-    "        for ref in all_refs(r, []):\n",
-    "            rtype = ref.split(\"/\", 1)[0]\n",
-    "            if rtype in imported_types and ref not in ids:\n",
-    "                unresolved[rtype] += 1\n",
+    "for name, atoms in batches:\n",
+    "    for atom in atoms:\n",
+    "        for r in atom:\n",
+    "            for ref in iter_refs(r):\n",
+    "                rtype = ref.split(\"/\", 1)[0]\n",
+    "                if rtype in local_counts and ref not in ids:\n",
+    "                    unresolved[rtype] += 1\n",
     "\n",
     "print(f\"resources   : {len(ids)}   duplicates: {dupes}\")\n",
     "print(f\"unresolved  : {sum(unresolved.values())}   {dict(unresolved) if unresolved else ''}\")\n",
@@ -456,52 +501,49 @@
   },
   {
    "cell_type": "markdown",
-   "id": "895c23dd",
+   "id": "5050c22a",
    "metadata": {},
    "source": [
     "### Why transaction Bundles and not HAPI's `$import`?\n",
     "Fair question — NDJSON is exactly what FHIR bulk import consumes. Trade-offs that led here:\n",
     "\n",
-    "- **`$import` is disabled by default** on stock HAPI (`bulk_import_enabled: false`), and\n",
-    "  WintEHR's deployed HAPI doesn't enable it — flipping it means a config change + HAPI\n",
-    "  restart on a long-running server holding all the data.\n",
+    "- **`$import` is disabled by default** on stock HAPI, and WintEHR's deployed HAPI doesn't\n",
+    "  enable it — flipping it means a config change + HAPI restart on a long-running server.\n",
     "- **`$import` pulls, it doesn't accept uploads**: each `input.url` must be an NDJSON URL the\n",
-    "  *server* can fetch, so these local files would first need staging somewhere\n",
-    "  HAPI-reachable.\n",
+    "  *server* can fetch, so these local files would first need staging somewhere HAPI-reachable.\n",
     "- **No subsetting, no provenance**: bulk import takes whole files — no 5-patient selection,\n",
-    "  and nothing like our `meta.tag`, which is what makes §6 verification exact and §7 cleanup\n",
+    "  and nothing like our `meta.tag`, which is what makes §7 verification exact and §8 cleanup\n",
     "  surgical.\n",
     "- **Error visibility**: transactions fail loudly per-bundle with an `OperationOutcome`\n",
-    "  (that's how the microbiology `hasMember` cycle above was found); bulk import is an async\n",
-    "  job you poll, with failures buried in job diagnostics.\n",
-    "- **It exercises the real write path** — the same `/fhir` proxy the WintEHR app uses.\n",
+    "  (that's how the microbiology `hasMember` cycle was found); bulk import is an async job\n",
+    "  you poll, with failures buried in job diagnostics.\n",
     "\n",
-    "For a **full-scale load** (all 100 patients / ~929k resources, or the non-demo MIMIC-on-FHIR),\n",
-    "`$import` becomes the right tool: enable it in HAPI's config, stage the NDJSON on an\n",
-    "HTTP endpoint the container can reach, and let the server ingest at batch speed."
+    "For a **full-scale load** (all 100 patients, or the non-demo MIMIC-on-FHIR), `$import`\n",
+    "becomes the right tool: enable it in HAPI's config, stage the NDJSON on an HTTP endpoint\n",
+    "the container can reach, and let the server ingest at batch speed."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "4f522e62",
+   "id": "c16e0903",
    "metadata": {},
    "source": [
-    "## 5 · Ingest — transaction Bundles, PUT-by-id\n",
+    "## 6 · Ingest — transaction Bundles, PUT-by-id\n",
     "`PUT ResourceType/id` in a `transaction` Bundle = idempotent upsert: re-running the notebook\n",
-    "overwrites in place, never duplicates. Files go up in dependency order so HAPI's referential\n",
-    "integrity is satisfied at every step."
+    "overwrites in place, never duplicates. Bundles pack whole atoms, so a `PATIENT_CLOSED`\n",
+    "chain always lands in a single transaction."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "448493a7",
+   "execution_count": 7,
+   "id": "99bb02e3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-26T16:58:14.906179Z",
-     "iopub.status.busy": "2026-07-26T16:58:14.906102Z",
-     "iopub.status.idle": "2026-07-26T17:01:39.996027Z",
-     "shell.execute_reply": "2026-07-26T17:01:39.995467Z"
+     "iopub.execute_input": "2026-07-26T17:55:53.871045Z",
+     "iopub.status.busy": "2026-07-26T17:55:53.870969Z",
+     "iopub.status.idle": "2026-07-26T17:59:43.005878Z",
+     "shell.execute_reply": "2026-07-26T17:59:43.005389Z"
     }
    },
    "outputs": [
@@ -530,7 +572,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "MimicMedicationMix                         314 sent   (1826/71206,     5s)\n",
+      "MimicMedicationMix                         314 sent   (1826/71206,     5s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "MimicPatient                                 5 sent   (1831/71206,     5s)\n"
      ]
     },
@@ -538,14 +586,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "MimicEncounter                              54 sent   (1885/71206,     6s)\n"
+      "MimicEncounter                              54 sent   (1885/71206,     5s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "MimicEncounterED                            48 sent   (1933/71206,     6s)\n",
+      "MimicEncounterED                            48 sent   (1933/71206,     5s)\n",
       "MimicEncounterICU                           14 sent   (1947/71206,     6s)\n"
      ]
     },
@@ -553,35 +601,35 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "MimicSpecimen                              291 sent   (2238/71206,     7s)\n"
+      "MimicSpecimen                              291 sent   (2238/71206,     6s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "MimicSpecimenLab                          3150 sent   (5388/71206,    13s)\n"
+      "MimicSpecimenLab                          3150 sent   (5388/71206,    14s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "MimicMedicationRequest                    3900 sent   (9288/71206,    23s)\n"
+      "MimicMedicationRequest                    3900 sent   (9288/71206,    24s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "MimicMedicationDispense                   3010 sent   (12298/71206,    33s)\n"
+      "MimicMedicationDispense                   3010 sent   (12298/71206,    32s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "MimicMedicationDispenseED                  324 sent   (12622/71206,    33s)\n"
+      "MimicMedicationDispenseED                  324 sent   (12622/71206,    32s)\n"
      ]
     },
     {
@@ -595,79 +643,79 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "MimicMedicationAdministrationICU          3298 sent   (27023/71206,    68s)\n"
+      "MimicMedicationAdministrationICU          3298 sent   (27023/71206,    70s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "MimicMedicationStatementED                 886 sent   (27909/71206,    70s)\n"
+      "MimicMedicationStatementED                 886 sent   (27909/71206,    72s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "MimicCondition                            1105 sent   (29014/71206,    73s)\n"
+      "MimicCondition                            1105 sent   (29014/71206,    75s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "MimicConditionED                           106 sent   (29120/71206,    73s)\n"
+      "MimicConditionED                           106 sent   (29120/71206,    77s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "MimicProcedure                             122 sent   (29242/71206,    73s)\n"
+      "MimicProcedure                             122 sent   (29242/71206,    77s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "MimicProcedureED                           328 sent   (29570/71206,    74s)\n"
+      "MimicProcedureED                           328 sent   (29570/71206,    78s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "MimicProcedureICU                          149 sent   (29719/71206,    75s)\n"
+      "MimicProcedureICU                          149 sent   (29719/71206,    78s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Microbiology                               537 sent   (30256/71206,    76s)\n"
+      "Microbiology                               537 sent   (30256/71206,    80s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "MimicObservationLabevents                38606 sent   (68862/71206,   199s)\n"
+      "MimicObservationLabevents                38606 sent   (68862/71206,   221s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "MimicObservationED                         704 sent   (69566/71206,   201s)\n"
+      "MimicObservationED                         704 sent   (69566/71206,   223s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "MimicObservationVitalSignsED              1640 sent   (71206/71206,   205s)\n",
+      "MimicObservationVitalSignsED              1640 sent   (71206/71206,   229s)\n",
       "\n",
-      "done: 71206 resources in 205s\n"
+      "done: 71206 resources in 229s\n"
      ]
     }
    ],
@@ -684,54 +732,50 @@
     "        raise RuntimeError(f\"HTTP {resp.status_code}: {resp.text[:800]}\")\n",
     "    return resp.json()\n",
     "\n",
-    "def chunks_of(rows, patient_closed):\n",
-    "    # <= BATCH_SIZE per bundle; patient-closed groups never split a patient\n",
-    "    # (their cross-references must resolve inside one transaction).\n",
-    "    if not patient_closed:\n",
-    "        for i in range(0, len(rows), BATCH_SIZE):\n",
-    "            yield rows[i:i + BATCH_SIZE]\n",
-    "        return\n",
-    "    chunk, cur = [], None\n",
-    "    for r in rows:\n",
-    "        if len(chunk) >= BATCH_SIZE and r.get(\"_pt\") != cur:\n",
-    "            yield chunk; chunk = []\n",
-    "        cur = r.get(\"_pt\")\n",
-    "        chunk.append(r)\n",
+    "def bundles_of(atoms):\n",
+    "    \"\"\"Pack whole atoms into chunks of <= BATCH_SIZE resources (an oversized\n",
+    "    atom becomes its own chunk — never split).\"\"\"\n",
+    "    chunk = []\n",
+    "    for atom in atoms:\n",
+    "        if chunk and len(chunk) + len(atom) > BATCH_SIZE:\n",
+    "            yield chunk\n",
+    "            chunk = []\n",
+    "        chunk += atom\n",
     "    if chunk:\n",
     "        yield chunk\n",
     "\n",
     "t0, sent = time.time(), 0\n",
-    "for name, rows, patient_closed in batches:\n",
-    "    if not rows:\n",
+    "for name, atoms in batches:\n",
+    "    n = sum(len(a) for a in atoms)\n",
+    "    if not n:\n",
     "        continue\n",
-    "    for chunk in chunks_of(rows, patient_closed):\n",
-    "        for r in chunk:\n",
-    "            r.pop(\"_pt\", None)   # internal bookkeeping, not FHIR\n",
+    "    for chunk in bundles_of(atoms):\n",
     "        put_bundle(chunk)\n",
     "        sent += len(chunk)\n",
-    "    print(f\"{name:38s} {len(rows):7d} sent   ({sent}/{kept}, {time.time()-t0:5.0f}s)\")\n",
+    "    print(f\"{name:38s} {n:7d} sent   ({sent}/{kept}, {time.time()-t0:5.0f}s)\")\n",
     "print(f\"\\ndone: {sent} resources in {time.time()-t0:.0f}s\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "3405a5a5",
+   "id": "50def2e2",
    "metadata": {},
    "source": [
-    "## 6 · Verify\n",
-    "Count what the server now holds under this import's tag, and spot-check one patient's record."
+    "## 7 · Verify\n",
+    "Count what the server now holds under this import's tag, and spot-check the richest\n",
+    "patient with the same reads the WintEHR UI makes."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "1fb91808",
+   "execution_count": 8,
+   "id": "42ed53d5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-26T17:01:39.998577Z",
-     "iopub.status.busy": "2026-07-26T17:01:39.998396Z",
-     "iopub.status.idle": "2026-07-26T17:01:43.639507Z",
-     "shell.execute_reply": "2026-07-26T17:01:43.638796Z"
+     "iopub.execute_input": "2026-07-26T17:59:43.007543Z",
+     "iopub.status.busy": "2026-07-26T17:59:43.007425Z",
+     "iopub.status.idle": "2026-07-26T17:59:46.402951Z",
+     "shell.execute_reply": "2026-07-26T17:59:46.402668Z"
     }
    },
    "outputs": [
@@ -824,15 +868,13 @@
     "tag_param = f\"{TAG['system']}|{TAG['code']}\"\n",
     "print(f\"{'type':24s} {'imported':>9s} {'on server':>10s}\")\n",
     "mismatch = False\n",
-    "for rtype in sorted(imported_types):\n",
-    "    local = sum(1 for _ in ids if _.startswith(rtype + \"/\"))\n",
+    "for rtype, local in sorted(local_counts.items()):\n",
     "    r = requests.get(f\"{FHIR_BASE}/{rtype}\", params={\"_tag\": tag_param, \"_summary\": \"count\"}, timeout=60)\n",
     "    server = r.json().get(\"total\", \"?\")\n",
     "    flag = \"\" if server == local else \"  <-- MISMATCH\"\n",
-    "    mismatch |= bool(flag)\n",
+    "    mismatch = mismatch or bool(flag)\n",
     "    print(f\"{rtype:24s} {local:9d} {server:>10} {flag}\")\n",
     "\n",
-    "# Spot-check the richest patient with the same reads the WintEHR UI makes\n",
     "pid = selected[0]\n",
     "fam = by_id[pid][\"name\"][0][\"family\"]\n",
     "pt  = requests.get(f\"{FHIR_BASE}/Patient/{pid}\", timeout=30)\n",
@@ -851,24 +893,25 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e1272de6",
+   "id": "3addd3f1",
    "metadata": {},
    "source": [
-    "## 7 · (Optional) remove this import\n",
-    "Deletes exactly the resources this notebook tagged, in **reverse** dependency order (children\n",
-    "before the Patients/Medications they reference). Guarded — flip `DO_CLEANUP` deliberately."
+    "## 8 · (Optional) remove this import\n",
+    "Deletes exactly the resources this notebook tagged, in **reverse** dependency order\n",
+    "(children before the Patients/Medications they reference). Guarded — flip `DO_CLEANUP`\n",
+    "deliberately."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "40fd829d",
+   "execution_count": 9,
+   "id": "2e512fd3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-26T17:01:43.642052Z",
-     "iopub.status.busy": "2026-07-26T17:01:43.641839Z",
-     "iopub.status.idle": "2026-07-26T17:01:43.645912Z",
-     "shell.execute_reply": "2026-07-26T17:01:43.645541Z"
+     "iopub.execute_input": "2026-07-26T17:59:46.404261Z",
+     "iopub.status.busy": "2026-07-26T17:59:46.404182Z",
+     "iopub.status.idle": "2026-07-26T17:59:46.407364Z",
+     "shell.execute_reply": "2026-07-26T17:59:46.406819Z"
     }
    },
    "outputs": [
@@ -885,7 +928,8 @@
     "\n",
     "if DO_CLEANUP:\n",
     "    deleted = 0\n",
-    "    for name, rows, _pc in reversed(batches):\n",
+    "    for name, atoms in reversed(batches):\n",
+    "        rows = [r for atom in atoms for r in atom]\n",
     "        for i in range(0, len(rows), BATCH_SIZE):\n",
     "            chunk = rows[i:i + BATCH_SIZE]\n",
     "            bundle = {\"resourceType\": \"Bundle\", \"type\": \"transaction\", \"entry\": [\n",


### PR DESCRIPTION
Review-driven simplification pass. **Behavior verified identical** — re-executed end-to-end against wintehrdev: same 71,206 resources, all per-type server counts match, zero errors; committed with the fresh run's outputs.

## What changed

- **Config cell is now just knobs.** The dependency-ordered file list moved into its own section (*§1 · Ingestion order — the dependency graph*) with the referential-integrity story told in prose. That list is half the lesson; it was hiding inside "config."
- **No more `isinstance`-as-semantics.** An explicit `PATIENT_CLOSED` set names the groups whose per-patient chains must ship in a single transaction; the tuple shape is now only a shape.
- **The `_pt` smuggling is gone** (mutate resource → sort → pop before send). Rows are now **atoms** — indivisible units the ingester never splits across bundles: one resource for normal files, one patient's entire cross-referencing microbiology chain for patient-closed groups. `bundles_of()` packs whole atoms up to `BATCH_SIZE`.
- **One `iter_refs()` generator** replaces two near-identical recursive walkers; both the patient filter and structural validation use it.
- Legibility: explicit duplicate counting, one `Counter`-by-type reused by validation and verification, unused import dropped, a 3-line Prerequisites note in the title cell, continuous section numbering (1–8).

Per review discussion, the "what you'll see in the UI" section was deliberately left out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)