### PR TITLE
fix(frontend): read-time medication stamping for Pharmacy/Orders; truthful micro susceptibilities

### DIFF
--- a/frontend/src/components/clinical/workspace/tabs/ResultsTabOptimized.js
+++ b/frontend/src/components/clinical/workspace/tabs/ResultsTabOptimized.js
@@ -186,6 +186,26 @@ const detectAbnormalFromReferenceRange = (observation) => {
 
 // Get result status icon and color
 const getResultStatus = (observation) => {
+  // Microbiology susceptibilities (e.g. MIMIC MicroSusc) carry their entire
+  // meaning as a v3-ObservationInterpretation valueCodeableConcept — R/S/I.
+  // Rendering a Resistant organism as "Normal" is the exact opposite of the
+  // record; surface the susceptibility verdict as the status.
+  const suscCoding = observation.valueCodeableConcept?.coding?.find(
+    c => c.system === 'http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation'
+  );
+  if (suscCoding) {
+    switch (suscCoding.code) {
+      case 'R':
+        return { icon: <AbnormalIcon color="error" />, color: 'error', label: 'Resistant', isCritical: false };
+      case 'S':
+        return { icon: <NormalIcon color="success" />, color: 'success', label: 'Susceptible', isCritical: false };
+      case 'I':
+        return { icon: <AbnormalIcon color="warning" />, color: 'warning', label: 'Intermediate', isCritical: false };
+      default:
+        return { icon: <NormalRangeIcon />, color: 'default', label: suscCoding.display || suscCoding.code, isCritical: false };
+    }
+  }
+
   const interpretation = getObservationInterpretation(observation);
 
   // First check explicit interpretation codes
@@ -244,7 +264,14 @@ const getResultStatus = (observation) => {
       : { icon: <LowIcon color="error" />, color: 'error', label: 'Low', isCritical: false };
   }
 
-  return { icon: <NormalRangeIcon />, color: 'default', label: 'Normal', isCritical: false };
+  // No interpretation, no threshold match, no reference-range flag. For a
+  // numeric value that cleared the checks above, "Normal" would be earned —
+  // but for everything else the record asserts nothing, and the UI must not
+  // either.
+  if (observation.valueQuantity?.value !== undefined) {
+    return { icon: <NormalRangeIcon />, color: 'default', label: 'Normal', isCritical: false };
+  }
+  return { icon: <NormalRangeIcon />, color: 'default', label: '—', isCritical: false };
 };
 
 // Get status icon and color for DiagnosticReport rows — reports carry a
@@ -853,7 +880,12 @@ const ResultsTabOptimized = ({
                   '-')) :
                 (item.valueQuantity ?
                   `${item.valueQuantity.value} ${item.valueQuantity.unit || ''}` :
-                  item.valueString || 'Pending');
+                  item.valueString ||
+                  getCodeableConceptDisplay(item.valueCodeableConcept, null) ||
+                  // 'Pending' is only truthful when the record says the
+                  // result is still coming; a final observation with no
+                  // value is simply valueless.
+                  (['registered', 'preliminary'].includes(item.status) ? 'Pending' : '—'));
 
               // Format reference range from low/high values
               const refRange = item.referenceRange?.[0];

--- a/frontend/src/contexts/FHIRResourceContext.js
+++ b/frontend/src/contexts/FHIRResourceContext.js
@@ -575,9 +575,12 @@ export function FHIRResourceProvider({ children }) {
       const currentRelationships = state.relationships[patientId];
       const currentResources = resourceType ? state.resources[resourceType] : state.resources;
       
-      // Use simple comparison for validity check
+      // Use simple comparison for validity check. MedicationRequest results
+      // are name-stamped from the Medication store below, so they must also
+      // invalidate when Medications arrive after the requests did.
       if (cached.relationships === currentRelationships && 
-          cached.resources === currentResources) {
+          cached.resources === currentResources &&
+          (resourceType !== 'MedicationRequest' || cached.medications === state.resources.Medication)) {
         return cached.result;
       }
     }
@@ -597,17 +600,44 @@ export function FHIRResourceProvider({ children }) {
 
     if (resourceType) {
       const resourceIds = relationships[resourceType] || [];
-      const resources = resourceIds.map(id => {
+      let resources = resourceIds.map(id => {
         const resource = state.resources[resourceType]?.[id];
         return resource;
       }).filter(Boolean);
-      
-      
+
+      // Read-time medication-name stamping: MedicationRequests that arrived
+      // via a fetch path that did NOT resolve _include (Pharmacy/Orders load
+      // them through plain searches) get their display resolved here from
+      // whatever Medication resources the store holds. This is the one
+      // chokepoint every consumer reads through — without it, each tab needs
+      // its own resolver wiring and the misses render "Medication (reference)".
+      if (resourceType === 'MedicationRequest') {
+        const medicationStore = state.resources.Medication;
+        if (medicationStore) {
+          resources = resources.map(req => {
+            if (req._resolvedMedicationDisplay ||
+                req.medicationCodeableConcept ||
+                !req.medicationReference?.reference) {
+              return req;
+            }
+            const medId = req.medicationReference.reference.replace('Medication/', '');
+            const medication = medicationStore[medId];
+            if (!medication) return req;
+            return {
+              ...req,
+              _resolvedMedicationDisplay: getMedicationResourceDisplay(medication),
+              _resolvedMedicationCodeableConcept: medication.code,
+            };
+          });
+        }
+      }
+
       // Cache the result
       getPatientResourcesMemo.current.set(memoKey, {
         result: resources,
         relationships: state.relationships[patientId],
-        resources: state.resources[resourceType]
+        resources: state.resources[resourceType],
+        medications: state.resources.Medication
       });
       
       return resources;

--- a/frontend/src/contexts/FHIRResourceContext.js
+++ b/frontend/src/contexts/FHIRResourceContext.js
@@ -750,7 +750,19 @@ export function FHIRResourceProvider({ children }) {
         
         // Standardize the response
         const result = standardizeResponse(rawResult);
-      
+
+      // fhirClient.search maps EVERY bundle entry into `resources` — with
+      // _include that mixes the included resources (e.g. Medication, whose
+      // status is 'active') into the main list. Storing that mix under the
+      // searched type made Chart Review show 30 Medication resources as
+      // "Active / Unknown medication" prescription rows for MIMIC patients
+      // ("All Medications 130" = 100 requests + 30 includes). Keep only the
+      // searched type here; the include-processing block below files the
+      // rest under their own resourceType.
+      if (result.resources?.length) {
+        result.resources = result.resources.filter(r => r?.resourceType === resourceType);
+      }
+
       if (result.resources && result.resources.length > 0) {
         setResources(resourceType, result.resources);
         
@@ -810,17 +822,17 @@ export function FHIRResourceProvider({ children }) {
             if (medRequest.medicationReference && !medRequest.medicationCodeableConcept) {
               const refId = medRequest.medicationReference.reference?.replace('Medication/', '');
               const medication = medicationLookup[refId];
-              if (medication?.code) {
-                // Add resolved medication name as medicationCodeableConcept for display
+              // No .code guard: mixture Medications have no code element at
+              // all — the resource-aware display still resolves them.
+              if (medication) {
+                const resolvedDisplay = getMedicationResourceDisplay(medication);
                 return {
                   ...medRequest,
                   _resolvedMedicationCodeableConcept: medication.code,
-                  // Full-resource name (Medication.identifier can carry it
-                  // when code is a bare NDC — true for ALL MIMIC medications)
-                  _resolvedMedicationDisplay: getMedicationResourceDisplay(medication),
+                  _resolvedMedicationDisplay: resolvedDisplay,
                   medicationReference: {
                     ...medRequest.medicationReference,
-                    display: medication.code.text || medication.code.coding?.[0]?.display
+                    display: resolvedDisplay
                   }
                 };
               }
@@ -1015,16 +1027,15 @@ export function FHIRResourceProvider({ children }) {
               if (medRequest.medicationReference && !medRequest.medicationCodeableConcept) {
                 const refId = medRequest.medicationReference.reference?.replace('Medication/', '');
                 const medication = medicationLookup[refId];
-                if (medication?.code) {
+                if (medication) {
+                  const resolvedDisplay = getMedicationResourceDisplay(medication);
                   return {
                     ...medRequest,
                     _resolvedMedicationCodeableConcept: medication.code,
-                    // Full-resource name (Medication.identifier can carry it
-                    // when code is a bare NDC — true for ALL MIMIC medications)
-                    _resolvedMedicationDisplay: getMedicationResourceDisplay(medication),
+                    _resolvedMedicationDisplay: resolvedDisplay,
                     medicationReference: {
                       ...medRequest.medicationReference,
-                      display: medication.code.text || medication.code.coding?.[0]?.display
+                      display: resolvedDisplay
                     }
                   };
                 }
@@ -1316,16 +1327,15 @@ export function FHIRResourceProvider({ children }) {
               if (medRequest.medicationReference && !medRequest.medicationCodeableConcept) {
                 const refId = medRequest.medicationReference.reference?.replace('Medication/', '');
                 const medication = medicationLookup[refId];
-                if (medication?.code) {
+                if (medication) {
+                  const resolvedDisplay = getMedicationResourceDisplay(medication);
                   return {
                     ...medRequest,
                     _resolvedMedicationCodeableConcept: medication.code,
-                    // Full-resource name (Medication.identifier can carry it
-                    // when code is a bare NDC — true for ALL MIMIC medications)
-                    _resolvedMedicationDisplay: getMedicationResourceDisplay(medication),
+                    _resolvedMedicationDisplay: resolvedDisplay,
                     medicationReference: {
                       ...medRequest.medicationReference,
-                      display: medication.code.text || medication.code.coding?.[0]?.display
+                      display: resolvedDisplay
                     }
                   };
                 }
@@ -1654,16 +1664,15 @@ export function FHIRResourceProvider({ children }) {
                 if (medRequest.medicationReference && !medRequest.medicationCodeableConcept) {
                   const refId = medRequest.medicationReference.reference?.replace('Medication/', '');
                   const medication = medicationLookup[refId];
-                  if (medication?.code) {
+                  if (medication) {
+                    const resolvedDisplay = getMedicationResourceDisplay(medication);
                     return {
                       ...medRequest,
                       _resolvedMedicationCodeableConcept: medication.code,
-                    // Full-resource name (Medication.identifier can carry it
-                    // when code is a bare NDC — true for ALL MIMIC medications)
-                    _resolvedMedicationDisplay: getMedicationResourceDisplay(medication),
+                      _resolvedMedicationDisplay: resolvedDisplay,
                       medicationReference: {
                         ...medRequest.medicationReference,
-                        display: medication.code.text || medication.code.coding?.[0]?.display
+                        display: resolvedDisplay
                       }
                     };
                   }


### PR DESCRIPTION
Two more consumers of the same truths, from live review on wintehrdev.

## 1. Pharmacy & Orders: 'Medication (reference)' / 'Unknown medication'

Their ~15 `getMedicationName()` call sites pass no lookup, and their MedicationRequests arrive via fetch paths that never stamped names. Instead of wiring a resolver through every subcomponent, stamping now happens at the **one chokepoint every consumer reads through**: `getPatientResources()` resolves `_resolvedMedicationDisplay` from the store's Medication resources at read time (`searchResources` already auto-`_include`s them). Memo invalidation extended so results recompute when Medications arrive after the requests.

## 2. Results tab: susceptibilities shown as 'Pending / Normal'

The reviewed rows (TOBRAMYCIN, MEROPENEM, …) are **microbiology susceptibility observations** — real labs, correctly listed. But all 1,036 MIMIC MicroSusc observations carry their meaning as a **v3-ObservationInterpretation `valueCodeableConcept`** — the sampled one is literally **R = Resistant**, rendered as *Normal*. The most clinically dangerous rendering lie found so far.

- Value chain now includes `valueCodeableConcept` → *Resistant* / *Susceptible*
- Status chip surfaces the verdict: **R = Resistant (red)**, S = Susceptible (green), I = Intermediate (amber)
- 'Pending' renders only when `observation.status` says so (registered/preliminary); a final valueless observation shows —
- Non-numeric results with no interpretation no longer claim 'Normal' — the record asserts nothing, so neither does the chip

Suite **555/555**, eslint **0 errors**, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)