### PR TITLE
Module platform Phase 1: pages + nav registry, coherence migration, tab placement

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -29,6 +29,20 @@ backend/api/<key>/                 frontend/src/modules/<key>/
 One module key names both halves. `flowsheets` in a disable list switches
 off the backend routers **and** the frontend tabs.
 
+Manifests may contribute (all optional):
+
+- **`tabs`** — patient-chart workspace tabs. `insertAfter: '<tab-id>'`
+  places a tab where it clinically belongs (Flowsheet sits beside the MAR);
+  omitted or unknown anchors append at the end — a tab never silently
+  disappears over a placement typo.
+- **`pages`** — top-level routed pages: `{ id, path, label, icon, color,
+  description, nav: { section, order }, loader }`. ONE entry yields the
+  route (router/router.js) and the app-shell menu item
+  (components/navigationRegistry.js) — they cannot drift. Omit `nav` for a
+  routed page with no menu presence. Valid `nav.section` keys: `clinical`,
+  `analytics`, `tools`, `admin`; a section with no items is dropped from
+  the nav entirely.
+
 Scaffold a new module with:
 
 ```bash
@@ -112,16 +126,18 @@ A workspace module is not always the right tool. In order of preference:
 | `flowsheets` | Nursing vitals flowsheet (time × vital grid over Observations) | Flowsheet tab | pilot — live |
 | `imaging` | DICOM services + imaging studies (needs a dcm4chee VNA) | Imaging tab (core, for now) | converted from core |
 | `ai-tools` | UI Composer + Clinical Canvas (need LLM API keys) | — | converted from core |
-| `quality-analytics` | Quality measures + analytics reporting | app-level pages | converted from core |
-| `scheduling` | Scheduling | Schedule page | converted from core |
+| `quality-analytics` | Quality measures + analytics reporting | Population Health nav section (Analytics / Quality / Care Gaps pages) | full module (backend + pages) |
+| `scheduling` | Scheduling | Schedule page + nav item | full module (backend + pages) |
 | `questionnaires` | Questionnaires | — | converted from core |
 
-The converted keys are backend-only for now: their routers moved from
-`ROUTERS` into `MODULE_ROUTERS` (a pure list move — all prefixes are
-distinct, so registration order is unaffected), gaining the per-deployment
-disable without touching any frontend code. Their frontend surfaces stay
-in the core registry until module tab *placement* is solved — pulling the
-Imaging tab into a module today would demote it to the end of the strip.
+`scheduling` and `quality-analytics` are fully coherent since Phase 1 of
+the platform roadmap: one key removes their backend routers, routes, and
+nav items together (page components stay in `src/pages/` — Phase 1 moved
+ownership, not files). `imaging` and `ai-tools` remain backend-only keys:
+ai-tools has no dedicated frontend surface, and the Imaging tab stays core
+until a concrete need moves it (tab placement via `insertAfter` now exists,
+so the old end-of-strip objection is gone — it is simply not yet worth the
+churn).
 
 ## Roadmap seams (grown one concrete module at a time)
 
@@ -129,8 +145,6 @@ Deliberately NOT built yet — each gets extracted when its first real
 consumer arrives, never speculatively (two pre-platform "unifying layers"
 died unadopted; see `ARCHITECTURE_DEBT.md` §F2):
 
-- **Page/route/nav registry** — first needed by an inpatient census module
-  (top-level pages outside the patient chart).
 - **Slot registry** (patient-header chips, summary cards) — first needed by
   bed/unit display.
 - **Order-type registry + safety-rule providers** — first needed by an

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -122,10 +122,14 @@ drifted. Tab components are `React.lazy()`-loaded from the registry. Do not
 re-add a parallel tab list anywhere.
 
 Pluggable modules (`src/modules/` — see `docs/MODULES.md`) contribute tabs
-through their manifests; the registry appends them after the core set and
-every selector treats them identically. Disable per build with
-`REACT_APP_DISABLED_MODULES` (keys match the backend's
-`WINTEHR_DISABLED_MODULES`).
+through their manifests (placed via `insertAfter`, else appended) and
+top-level **pages**: one `pages` entry yields the route in
+`router/router.js` AND the app-shell menu item
+(`components/navigationRegistry.js` — LayoutV3's old hardcoded
+`navigationConfig` is now the derived output of core seed + module
+contributions). Disable per build with `REACT_APP_DISABLED_MODULES`
+(keys match the backend's `WINTEHR_DISABLED_MODULES`); disabling removes
+tabs, routes, and nav items together.
 
 ---
 

--- a/frontend/src/components/LayoutV3.js
+++ b/frontend/src/components/LayoutV3.js
@@ -34,13 +34,7 @@ import {
 } from '@mui/material';
 import {
   Menu as MenuIcon,
-  Dashboard as DashboardIcon,
-  People as PeopleIcon,
-  LocalPharmacy as PharmacyIcon,
-  TrendingUp as TrendingUpIcon,
   Api as ApiIcon,
-  Webhook as WebhookIcon,
-  Assessment as AssessmentIcon,
   AccountCircle as AccountCircleIcon,
   Logout as LogoutIcon,
   Security as SecurityIcon,
@@ -49,15 +43,11 @@ import {
   ExpandLess,
   ExpandMore,
   Home as HomeIcon,
-  Timeline as TimelineIcon,
-  MedicalServices as MedicalIcon,
-  Analytics as AnalyticsIcon,
-  CalendarMonth as ScheduleIcon,
   Assignment as EncountersIcon
 } from '@mui/icons-material';
 import { useAuth } from '../contexts/AuthContext';
 import { shellPalette, shellGradient } from '../themes/shellPalette';
-import { categoricalAccents } from '../themes/categoricalAccents';
+import { buildNavigationConfig } from './navigationRegistry';
 import { MedicalThemeContext } from '../App';
 import NotificationBell from './NotificationBell';
 import QuickThemeToggle from './theme/QuickThemeToggle';
@@ -66,45 +56,10 @@ import TransitionWrapper from './transitions/TransitionWrapper';
 
 const drawerWidth = 280;
 
-// Enhanced navigation structure with categories and workflows
-const navigationConfig = {
-  clinical: {
-    title: 'Clinical Workflows',
-    icon: <MedicalIcon />,
-    items: [
-      { text: 'Dashboard', icon: <DashboardIcon />, path: '/dashboard', description: 'Overview & quick actions', iconColor: categoricalAccents.summary },
-      { text: 'Schedule', icon: <ScheduleIcon />, path: '/schedule', description: 'Appointments & scheduling', iconColor: categoricalAccents.schedule },
-      { text: 'Patients', icon: <PeopleIcon />, path: '/patients', description: 'Patient management', iconColor: categoricalAccents.patients },
-      { text: 'Encounters', icon: <EncountersIcon />, path: '/encounters', description: 'Visit management', iconColor: categoricalAccents.encounters },
-      { text: 'Pharmacy', icon: <PharmacyIcon />, path: '/pharmacy', description: 'Pharmacy workflow & dispensing', iconColor: categoricalAccents.pharmacy }
-    ]
-  },
-  analytics: {
-    title: 'Population Health',
-    icon: <AnalyticsIcon />,
-    items: [
-      { text: 'Population Analytics', icon: <TrendingUpIcon />, path: '/analytics', description: 'Health trends & metrics', iconColor: categoricalAccents.analytics },
-      { text: 'Quality Measures', icon: <AssessmentIcon />, path: '/quality', description: 'Performance tracking', iconColor: categoricalAccents.quality },
-      { text: 'Care Gaps', icon: <TimelineIcon />, path: '/care-gaps', description: 'Preventive care tracking', iconColor: categoricalAccents.careGaps }
-    ]
-  },
-  tools: {
-    title: 'Developer Tools',
-    icon: <ApiIcon />,
-    items: [
-      { text: 'FHIR Explorer', icon: <ApiIcon />, path: '/fhir-explorer', description: 'FHIR resource exploration & queries', iconColor: categoricalAccents.fhirExplorer },
-      { text: 'CDS Studio', icon: <WebhookIcon />, path: '/cds-studio', description: 'Clinical decision support studio', iconColor: categoricalAccents.cdsStudio }
-    ]
-  },
-  admin: {
-    title: 'Administration',
-    icon: <SecurityIcon />,
-    items: [
-      { text: 'Audit Trail', icon: <SecurityIcon />, path: '/audit-trail', description: 'Security & compliance', iconColor: categoricalAccents.audit },
-      { text: 'System Settings', icon: <SettingsIcon />, path: '/settings', description: 'Configuration', iconColor: categoricalAccents.settings }
-    ]
-  }
-};
+// Navigation structure derives from navigationRegistry: core seed + pages
+// contributed by enabled modules (docs/MODULES.md). Do not hardcode nav
+// items here — module items and their routes come from ONE manifest entry.
+const navigationConfig = buildNavigationConfig();
 
 const NavigationSection = ({ section, sectionKey, isOpen, onToggle, selectedPath, onNavigate }) => {
   return (

--- a/frontend/src/components/clinical/workspace/clinicalTabRegistry.js
+++ b/frontend/src/components/clinical/workspace/clinicalTabRegistry.js
@@ -159,14 +159,31 @@ const CORE_TABS = [
 
 /**
  * Core tabs + tabs contributed by enabled modules (src/modules/ —
- * docs/MODULES.md). Module tabs append after the core set and are ordinary
- * registry entries from here on: every selector, the keyboard map, and the
- * coverage tests treat them identically. Disabling a module (via
- * REACT_APP_DISABLED_MODULES) removes its registrations — its lazy chunks
- * are still emitted by the build but are never fetched, since nothing
- * references them at runtime.
+ * docs/MODULES.md). A module tab may carry `insertAfter: '<tab-id>'` to sit
+ * where it clinically belongs in the strip (e.g. Flowsheet beside the MAR);
+ * without it — or if the named tab is absent — the tab appends at the end,
+ * never silently disappears. From here on module tabs are ordinary registry
+ * entries: every selector, the keyboard map, and the coverage tests treat
+ * them identically. Disabling a module (via REACT_APP_DISABLED_MODULES)
+ * removes its registrations — its lazy chunks are still emitted by the
+ * build but are never fetched, since nothing references them at runtime.
  */
-export const CLINICAL_TABS = [...CORE_TABS, ...getModuleTabs()];
+function mergeModuleTabs(coreTabs, moduleTabs) {
+  const merged = [...coreTabs];
+  for (const tab of moduleTabs) {
+    const anchor = tab.insertAfter
+      ? merged.findIndex((t) => t.id === tab.insertAfter)
+      : -1;
+    if (anchor >= 0) {
+      merged.splice(anchor + 1, 0, tab);
+    } else {
+      merged.push(tab);
+    }
+  }
+  return merged;
+}
+
+export const CLINICAL_TABS = mergeModuleTabs(CORE_TABS, getModuleTabs());
 
 // ---------------------------------------------------------------------
 // Derived selectors — each consumer takes only what it needs.

--- a/frontend/src/components/navigationRegistry.js
+++ b/frontend/src/components/navigationRegistry.js
@@ -1,0 +1,122 @@
+/**
+ * App-shell navigation registry — core seed + module page contributions
+ * (docs/MODULES.md, module platform Phase 1).
+ *
+ * Extracted from LayoutV3's hardcoded `navigationConfig`, which had the
+ * same disease the workspace tab strip had before #150: the nav item list
+ * and the route table had to agree BY HAND (a nav item is only real if
+ * someone also registered its path in router/router.js). Both now derive
+ * from one source: the core seed below plus `pages` contributed by module
+ * manifests (`src/modules/`). Disabling a module removes its nav items and
+ * its routes together — no more dead menu links to disabled features.
+ *
+ * Section keys are the API module pages target (`nav.section`); items sort
+ * by `order` within a section (core items are pre-spaced by tens so module
+ * items can slot between). A section with no items is dropped from the nav
+ * entirely — "Population Health" only exists while the quality-analytics
+ * module is enabled.
+ */
+
+import React from 'react';
+import {
+  Dashboard as DashboardIcon,
+  People as PeopleIcon,
+  LocalPharmacy as PharmacyIcon,
+  Api as ApiIcon,
+  Webhook as WebhookIcon,
+  Security as SecurityIcon,
+  Settings as SettingsIcon,
+  MedicalServices as MedicalIcon,
+  Analytics as AnalyticsIcon,
+  Assignment as EncountersIcon,
+} from '@mui/icons-material';
+
+import { categoricalAccents } from '../themes/categoricalAccents';
+import { getModulePages } from '../modules';
+
+/**
+ * Core sections and items. `order` is explicit and spaced by tens; module
+ * contributions interleave by their own `nav.order`. Schedule and the whole
+ * Population Health item set are NOT here — they belong to the `scheduling`
+ * and `quality-analytics` modules (frontend halves of the backend module
+ * keys), contributed via manifests like any other module page.
+ */
+const CORE_NAV_SECTIONS = {
+  clinical: {
+    title: 'Clinical Workflows',
+    icon: <MedicalIcon />,
+    items: [
+      { order: 10, text: 'Dashboard', icon: <DashboardIcon />, path: '/dashboard', description: 'Overview & quick actions', iconColor: categoricalAccents.summary },
+      { order: 30, text: 'Patients', icon: <PeopleIcon />, path: '/patients', description: 'Patient management', iconColor: categoricalAccents.patients },
+      { order: 40, text: 'Encounters', icon: <EncountersIcon />, path: '/encounters', description: 'Visit management', iconColor: categoricalAccents.encounters },
+      { order: 50, text: 'Pharmacy', icon: <PharmacyIcon />, path: '/pharmacy', description: 'Pharmacy workflow & dispensing', iconColor: categoricalAccents.pharmacy },
+    ],
+  },
+  analytics: {
+    title: 'Population Health',
+    icon: <AnalyticsIcon />,
+    items: [],
+  },
+  tools: {
+    title: 'Developer Tools',
+    icon: <ApiIcon />,
+    items: [
+      { order: 10, text: 'FHIR Explorer', icon: <ApiIcon />, path: '/fhir-explorer', description: 'FHIR resource exploration & queries', iconColor: categoricalAccents.fhirExplorer },
+      { order: 20, text: 'CDS Studio', icon: <WebhookIcon />, path: '/cds-studio', description: 'Clinical decision support studio', iconColor: categoricalAccents.cdsStudio },
+    ],
+  },
+  admin: {
+    title: 'Administration',
+    icon: <SecurityIcon />,
+    items: [
+      { order: 10, text: 'Audit Trail', icon: <SecurityIcon />, path: '/audit-trail', description: 'Security & compliance', iconColor: categoricalAccents.audit },
+      { order: 20, text: 'System Settings', icon: <SettingsIcon />, path: '/settings', description: 'Configuration', iconColor: categoricalAccents.settings },
+    ],
+  },
+};
+
+/** Section keys module pages may target. Exported for the drift tests. */
+export const NAV_SECTION_KEYS = Object.keys(CORE_NAV_SECTIONS);
+
+/**
+ * Build the nav config LayoutV3 renders: core seed merged with enabled
+ * modules' page contributions, sorted, empty sections dropped.
+ */
+export function buildNavigationConfig() {
+  const sections = {};
+  for (const [key, section] of Object.entries(CORE_NAV_SECTIONS)) {
+    sections[key] = { ...section, items: [...section.items] };
+  }
+
+  for (const pageEntry of getModulePages()) {
+    const nav = pageEntry.nav;
+    if (!nav) continue; // a routed page with no menu presence is legal
+    const section = sections[nav.section];
+    if (!section) {
+      // A typo'd section key must be loud, not a silently missing menu item
+      // (same philosophy as the backend's unknown-disable-key warning).
+      console.error(
+        `navigationRegistry: module page '${pageEntry.id}' targets unknown ` +
+        `nav section '${nav.section}' (known: ${NAV_SECTION_KEYS.join(', ')})`,
+      );
+      continue;
+    }
+    const Icon = pageEntry.icon;
+    section.items.push({
+      order: nav.order ?? 1000,
+      text: pageEntry.label,
+      icon: <Icon />,
+      path: pageEntry.path,
+      description: pageEntry.description,
+      iconColor: pageEntry.color,
+    });
+  }
+
+  const config = {};
+  for (const [key, section] of Object.entries(sections)) {
+    if (section.items.length === 0) continue;
+    section.items.sort((a, b) => (a.order - b.order) || a.path.localeCompare(b.path));
+    config[key] = section;
+  }
+  return config;
+}

--- a/frontend/src/modules/__tests__/moduleLoader.test.js
+++ b/frontend/src/modules/__tests__/moduleLoader.test.js
@@ -69,3 +69,88 @@ describe('flowsheets module', () => {
     expect(mod.default).toBeTruthy();
   });
 });
+
+// ---------------------------------------------------------------------
+// Pages contract (module platform Phase 1)
+// ---------------------------------------------------------------------
+
+import { getModulePages } from '../index';
+import { buildNavigationConfig, NAV_SECTION_KEYS } from '../../components/navigationRegistry';
+
+describe('module pages', () => {
+  it('every page entry carries the full field set', () => {
+    for (const p of getModulePages()) {
+      expect(p.id).toBeTruthy();
+      expect(p.path).toMatch(/^\//);
+      expect(p.label).toBeTruthy();
+      expect(p.icon).toBeTruthy();
+      expect(p.color).toBeTruthy();
+      expect(typeof p.loader).toBe('function');
+      if (p.nav) {
+        expect(NAV_SECTION_KEYS).toContain(p.nav.section);
+        expect(typeof p.nav.order).toBe('number');
+      }
+    }
+  });
+
+  it('page paths are unique across modules', () => {
+    const paths = getModulePages().map((p) => p.path);
+    expect(new Set(paths).size).toBe(paths.length);
+  });
+
+  it('page colors come from categoricalAccents (one hue system)', () => {
+    const accentValues = Object.values(categoricalAccents);
+    for (const p of getModulePages()) {
+      expect(accentValues).toContain(p.color);
+    }
+  });
+
+  it('the coherence migration is in place: scheduling and quality-analytics own their pages', () => {
+    const byModule = Object.fromEntries(
+      ENABLED_MODULES.map((m) => [m.id, (m.pages || []).map((p) => p.path)]),
+    );
+    expect(byModule['scheduling']).toEqual(['/schedule']);
+    expect(byModule['quality-analytics']).toEqual(['/analytics', '/quality', '/care-gaps']);
+  });
+});
+
+describe('navigation registry', () => {
+  it('module pages land in their target sections, ordered', () => {
+    const config = buildNavigationConfig();
+    const clinicalPaths = config.clinical.items.map((i) => i.path);
+    // Schedule slots between Dashboard (10) and Patients (30) via order 20.
+    expect(clinicalPaths).toEqual(
+      ['/dashboard', '/schedule', '/patients', '/encounters', '/pharmacy'],
+    );
+    // Population Health exists ONLY because quality-analytics contributes it.
+    expect(config.analytics.items.map((i) => i.path)).toEqual(
+      ['/analytics', '/quality', '/care-gaps'],
+    );
+  });
+
+  it('a section with no items is dropped, not rendered empty', () => {
+    // The analytics section seed is empty by design; if the module system
+    // were broken the section would either vanish (fine) or show empty
+    // (a bug). With modules enabled it must be present and populated.
+    const config = buildNavigationConfig();
+    for (const section of Object.values(config)) {
+      expect(section.items.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('tab placement', () => {
+  it('flowsheet sits directly after the MAR, not at the end of the strip', () => {
+    const ids = CLINICAL_TABS.map((t) => t.id);
+    expect(ids.indexOf('flowsheet')).toBe(ids.indexOf('administration') + 1);
+  });
+
+  it('a tab with an unknown insertAfter would append, never vanish', () => {
+    // Contract check via the registry length: every module tab is present
+    // exactly once regardless of placement.
+    const ids = CLINICAL_TABS.map((t) => t.id);
+    for (const tab of getModuleTabs()) {
+      expect(ids.filter((id) => id === tab.id)).toHaveLength(1);
+    }
+  });
+});

--- a/frontend/src/modules/flowsheets/index.js
+++ b/frontend/src/modules/flowsheets/index.js
@@ -21,6 +21,9 @@ const flowsheetsModule = {
       icon: FlowsheetIcon,
       color: categoricalAccents.flowsheet,
       description: 'Vitals flowsheet — time grid of nursing observations',
+      // Nursing surfaces sit together: Flowsheet lands beside the MAR
+      // instead of at the end of the strip (Phase 1 tab placement).
+      insertAfter: 'administration',
       loader: () => import(/* webpackChunkName: "module-flowsheets" */ './FlowsheetTab'),
     },
   ],

--- a/frontend/src/modules/index.js
+++ b/frontend/src/modules/index.js
@@ -28,9 +28,13 @@
  */
 
 import flowsheets from './flowsheets';
+import scheduling from './scheduling';
+import qualityAnalytics from './quality-analytics';
 
 const ALL_MODULES = [
   flowsheets,
+  scheduling,
+  qualityAnalytics,
 ];
 
 const disabledKeys = new Set(
@@ -50,3 +54,13 @@ export const DISABLED_MODULE_KEYS = ALL_MODULES
 
 /** Workspace tab entries contributed by enabled modules, in module order. */
 export const getModuleTabs = () => ENABLED_MODULES.flatMap((m) => m.tabs || []);
+
+/**
+ * Top-level page entries contributed by enabled modules, in module order.
+ * Each entry: { id, path, label, icon, color, description?, nav?, loader }.
+ * `nav: { section, order }` places the page in the app-shell menu
+ * (navigationRegistry); omit `nav` for a routed page with no menu item.
+ * Consumed by router/router.js (routes) and navigationRegistry (menu) —
+ * one entry drives both, so they cannot drift.
+ */
+export const getModulePages = () => ENABLED_MODULES.flatMap((m) => m.pages || []);

--- a/frontend/src/modules/quality-analytics/index.js
+++ b/frontend/src/modules/quality-analytics/index.js
@@ -1,0 +1,56 @@
+/**
+ * Quality & Analytics module manifest — the frontend half of the backend
+ * `quality-analytics` module key (docs/MODULES.md).
+ *
+ * Contributes the entire "Population Health" nav section's items; with
+ * this module disabled the section disappears from the app shell along
+ * with its routes and backend routers — one key, one honest switch
+ * (module platform Phase 1 coherence migration).
+ *
+ * Page components stay in src/pages/ — Phase 1 moves ownership, not files.
+ */
+
+import {
+  TrendingUp as AnalyticsIcon,
+  Assessment as QualityIcon,
+  Timeline as CareGapsIcon,
+} from '@mui/icons-material';
+import { categoricalAccents } from '../../themes/categoricalAccents';
+
+const qualityAnalyticsModule = {
+  id: 'quality-analytics',
+  pages: [
+    {
+      id: 'analytics',
+      path: '/analytics',
+      label: 'Population Analytics',
+      icon: AnalyticsIcon,
+      color: categoricalAccents.analytics,
+      description: 'Health trends & metrics',
+      nav: { section: 'analytics', order: 10 },
+      loader: () => import(/* webpackChunkName: "module-qa-analytics" */ '../../pages/Analytics'),
+    },
+    {
+      id: 'quality',
+      path: '/quality',
+      label: 'Quality Measures',
+      icon: QualityIcon,
+      color: categoricalAccents.quality,
+      description: 'Performance tracking',
+      nav: { section: 'analytics', order: 20 },
+      loader: () => import(/* webpackChunkName: "module-qa-quality" */ '../../pages/QualityMeasuresPage'),
+    },
+    {
+      id: 'care-gaps',
+      path: '/care-gaps',
+      label: 'Care Gaps',
+      icon: CareGapsIcon,
+      color: categoricalAccents.careGaps,
+      description: 'Preventive care tracking',
+      nav: { section: 'analytics', order: 30 },
+      loader: () => import(/* webpackChunkName: "module-qa-caregaps" */ '../../pages/CareGapsPage'),
+    },
+  ],
+};
+
+export default qualityAnalyticsModule;

--- a/frontend/src/modules/scheduling/index.js
+++ b/frontend/src/modules/scheduling/index.js
@@ -1,0 +1,34 @@
+/**
+ * Scheduling module manifest — the frontend half of the backend
+ * `scheduling` module key (docs/MODULES.md).
+ *
+ * Created in module platform Phase 1 to make the disable key coherent
+ * end-to-end: `scheduling` in the disable lists now removes the backend
+ * routers AND this page AND its nav item together (previously disabling
+ * the backend left a dead "Schedule" menu link).
+ *
+ * The page component stays in src/pages/ for now — Phase 1 moves
+ * ownership, not files; relocation is optional later and would only churn
+ * imports.
+ */
+
+import { CalendarMonth as ScheduleIcon } from '@mui/icons-material';
+import { categoricalAccents } from '../../themes/categoricalAccents';
+
+const schedulingModule = {
+  id: 'scheduling',
+  pages: [
+    {
+      id: 'schedule',
+      path: '/schedule',
+      label: 'Schedule',
+      icon: ScheduleIcon,
+      color: categoricalAccents.schedule,
+      description: 'Appointments & scheduling',
+      nav: { section: 'clinical', order: 20 },
+      loader: () => import(/* webpackChunkName: "module-scheduling" */ '../../pages/Schedule'),
+    },
+  ],
+};
+
+export default schedulingModule;

--- a/frontend/src/router/router.js
+++ b/frontend/src/router/router.js
@@ -1,5 +1,7 @@
 import React, { Suspense, lazy } from 'react';
 import { createBrowserRouter, Navigate } from 'react-router-dom';
+
+import { getModulePages } from '../modules';
 import { Box, CircularProgress } from '@mui/material';
 import ProtectedRoute from '../components/ProtectedRoute';
 import LayoutV3 from '../components/LayoutV3';
@@ -13,18 +15,14 @@ import PatientList from '../pages/PatientList';
 const PatientDashboardV2Page = lazy(() => import('../pages/PatientDashboardV2Page'));
 const ClinicalWorkspaceWrapper = lazy(() => import('../components/clinical/ClinicalWorkspaceWrapper'));
 const Dashboard = lazy(() => import('../pages/Dashboard'));
-const Analytics = lazy(() => import('../pages/Analytics'));
 const FHIRExplorerApp = lazy(() => import('../components/fhir-explorer-v4/core/FHIRExplorerApp'));
 const QueryStudioEnhanced = lazy(() => import('../components/fhir-explorer-v4/query-building/QueryStudioEnhanced'));
 const Settings = lazy(() => import('../pages/Settings'));
-const Schedule = lazy(() => import('../pages/Schedule'));
 const NotFound = lazy(() => import('../pages/NotFound'));
 const MedicationReconciliationPage = lazy(() => import('../pages/MedicationReconciliationPage'));
 const CDSStudioPage = lazy(() => import('../modules/cds-studio').then(m => ({ default: m.CDSStudioPage })));
 const CDSPresentationModeTester = lazy(() => import('../components/clinical/cds/CDSPresentationModeTester'));
 const EncountersPage = lazy(() => import('../pages/EncountersPage'));
-const QualityMeasuresPage = lazy(() => import('../pages/QualityMeasuresPage'));
-const CareGapsPage = lazy(() => import('../pages/CareGapsPage'));
 const AuditTrailPage = lazy(() => import('../pages/AuditTrailPage'));
 const PharmacyPage = lazy(() => import('../pages/PharmacyPage'));
 const InventoryManagementPage = lazy(() => import('../pages/InventoryManagementPage'));
@@ -48,8 +46,19 @@ const page = (element, { layout = true, protect = true } = {}) => {
   return node;
 };
 
+// Top-level pages contributed by enabled modules (docs/MODULES.md). One
+// manifest entry yields this route AND the nav item (navigationRegistry) —
+// they cannot drift, and disabling the module removes both. Includes the
+// migrated frontend halves of the scheduling and quality-analytics module
+// keys (/schedule, /analytics, /quality, /care-gaps).
+const modulePageRoutes = getModulePages().map((entry) => {
+  const ModulePage = lazy(entry.loader);
+  return { path: entry.path, element: page(<ModulePage />) };
+});
+
 // Create router with future flags enabled
 export const router = createBrowserRouter([
+  ...modulePageRoutes,
   {
     path: '/login',
     element: <Login />
@@ -109,18 +118,6 @@ export const router = createBrowserRouter([
     element: page(<InventoryManagementPage />)
   },
   {
-    path: '/analytics',
-    element: page(<Analytics />)
-  },
-  {
-    path: '/quality',
-    element: page(<QualityMeasuresPage />)
-  },
-  {
-    path: '/care-gaps',
-    element: page(<CareGapsPage />)
-  },
-  {
     // No LayoutV3 (the explorer owns its shell) and no extra AppProviders —
     // App.js already wraps the whole RouterProvider in AppProviders, so the
     // previous nested copy double-mounted every context for this route.
@@ -147,10 +144,6 @@ export const router = createBrowserRouter([
   {
     path: '/cds-presentation-test',
     element: page(<CDSPresentationModeTester />)
-  },
-  {
-    path: '/schedule',
-    element: page(<Schedule />)
   },
   {
     path: '/audit-trail',


### PR DESCRIPTION
Phase 1 of the modularity roadmap (see docs/MODULES.md).

- **Pages**: module manifests contribute top-level pages; one entry drives the route AND the nav item (LayoutV3's hardcoded navigationConfig is now derived from a core seed + module contributions via components/navigationRegistry.js).
- **Coherence migration**: scheduling (/schedule) and quality-analytics (/analytics, /quality, /care-gaps — the whole Population Health section) get frontend manifests, so their existing disable keys now remove backend routers + routes + menu items together instead of leaving dead nav links.
- **Tab placement**: `insertAfter` on module tabs; Flowsheet now sits beside the MAR.
- 8 new drift tests; disable-flag behavior proven by flag-set test run (exactly the presence tests fail, contracts stay green).

Suites: frontend 610 passed · lint 0 errors · build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)